### PR TITLE
Display stdin more intuitively top-down instead of bottom-up

### DIFF
--- a/crates/television-channels/src/channels/stdin.rs
+++ b/crates/television-channels/src/channels/stdin.rs
@@ -19,7 +19,9 @@ impl Channel {
     pub fn new() -> Self {
         let mut lines = Vec::new();
         for line in std::io::stdin().lock().lines().map_while(Result::ok) {
-            lines.push(preprocess_line(&line));
+            if !line.trim().is_empty() {
+                lines.push(preprocess_line(&line));
+            }
         }
         let matcher = Matcher::new(Config::default().n_threads(NUM_THREADS));
         let injector = matcher.injector();

--- a/crates/television-channels/src/channels/stdin.rs
+++ b/crates/television-channels/src/channels/stdin.rs
@@ -25,7 +25,7 @@ impl Channel {
         }
         let matcher = Matcher::new(Config::default().n_threads(NUM_THREADS));
         let injector = matcher.injector();
-        for line in &lines {
+        for line in lines.iter().rev() {
             let () = injector.push(line.clone(), |e, cols| {
                 cols[0] = e.clone().into();
             });


### PR DESCRIPTION
Split into two commits:
- Display stdin top-down instead of bottom-up. This makes using television for browsing shell history more intuitive.
- Makes a change to skip empty or whitespace-only lines from showing up. I am not entirely sure this is a good idea especially that it `trim()`s the lines, which may not be what the user wants for very specific use cases. Feel free to skip this commit of course.