### PR TITLE
remove unnecessary clone() calls

### DIFF
--- a/crates/television-channels/src/channels/alias.rs
+++ b/crates/television-channels/src/channels/alias.rs
@@ -85,7 +85,7 @@ impl OnAir for Channel {
 
                 let mut entry =
                     Entry::new(item.inner.name.clone(), PreviewType::EnvVar)
-                        .with_value(item.inner.value.clone())
+                        .with_value(item.inner.value)
                         .with_icon(self.file_icon);
 
                 if should_add_name_indices {
@@ -111,7 +111,7 @@ impl OnAir for Channel {
     fn get_result(&self, index: u32) -> Option<Entry> {
         self.matcher.get_result(index).map(|item| {
             Entry::new(item.inner.name.clone(), PreviewType::EnvVar)
-                .with_value(item.inner.value.clone())
+                .with_value(item.inner.value)
                 .with_icon(self.file_icon)
         })
     }

--- a/crates/television-channels/src/channels/env.rs
+++ b/crates/television-channels/src/channels/env.rs
@@ -65,7 +65,7 @@ impl OnAir for Channel {
 
                 let mut entry =
                     Entry::new(item.inner.name.clone(), PreviewType::EnvVar)
-                        .with_value(item.inner.value.clone())
+                        .with_value(item.inner.value)
                         .with_icon(self.file_icon);
 
                 if should_add_name_indices {
@@ -91,7 +91,7 @@ impl OnAir for Channel {
     fn get_result(&self, index: u32) -> Option<Entry> {
         self.matcher.get_result(index).map(|item| {
             Entry::new(item.inner.name.clone(), PreviewType::EnvVar)
-                .with_value(item.inner.value.clone())
+                .with_value(item.inner.value)
                 .with_icon(self.file_icon)
         })
     }

--- a/crates/television-channels/src/channels/git_repos.rs
+++ b/crates/television-channels/src/channels/git_repos.rs
@@ -50,7 +50,7 @@ impl OnAir for Channel {
             .into_iter()
             .map(|item| {
                 let path = item.matched_string;
-                Entry::new(path.clone(), PreviewType::Directory)
+                Entry::new(path, PreviewType::Directory)
                     .with_name_match_ranges(item.match_indices)
                     .with_icon(self.icon)
             })
@@ -60,8 +60,7 @@ impl OnAir for Channel {
     fn get_result(&self, index: u32) -> Option<Entry> {
         self.matcher.get_result(index).map(|item| {
             let path = item.matched_string;
-            Entry::new(path.clone(), PreviewType::Directory)
-                .with_icon(self.icon)
+            Entry::new(path, PreviewType::Directory).with_icon(self.icon)
         })
     }
 

--- a/crates/television-channels/src/channels/remote_control.rs
+++ b/crates/television-channels/src/channels/remote_control.rs
@@ -57,7 +57,7 @@ impl OnAir for RemoteControl {
             .into_iter()
             .map(|item| {
                 let path = item.matched_string;
-                Entry::new(path.clone(), PreviewType::Basic)
+                Entry::new(path, PreviewType::Basic)
                     .with_name_match_ranges(item.match_indices)
                     .with_icon(TV_ICON)
             })
@@ -67,7 +67,7 @@ impl OnAir for RemoteControl {
     fn get_result(&self, index: u32) -> Option<Entry> {
         self.matcher.get_result(index).map(|item| {
             let path = item.matched_string;
-            Entry::new(path.clone(), PreviewType::Basic).with_icon(TV_ICON)
+            Entry::new(path, PreviewType::Basic).with_icon(TV_ICON)
         })
     }
 

--- a/crates/television-channels/src/channels/text.rs
+++ b/crates/television-channels/src/channels/text.rs
@@ -168,7 +168,7 @@ impl OnAir for Channel {
                 let line = item.matched_string;
                 let display_path =
                     item.inner.path.to_string_lossy().to_string();
-                Entry::new(display_path.clone(), PreviewType::Files)
+                Entry::new(display_path, PreviewType::Files)
                     .with_value(line)
                     .with_value_match_ranges(item.match_indices)
                     .with_icon(FileIcon::from(item.inner.path.as_path()))
@@ -180,7 +180,7 @@ impl OnAir for Channel {
     fn get_result(&self, index: u32) -> Option<Entry> {
         self.matcher.get_result(index).map(|item| {
             let display_path = item.inner.path.to_string_lossy().to_string();
-            Entry::new(display_path.clone(), PreviewType::Files)
+            Entry::new(display_path, PreviewType::Files)
                 .with_icon(FileIcon::from(item.inner.path.as_path()))
                 .with_line_number(item.inner.line_number)
         })

--- a/crates/television-previewers/src/previewers/cache.rs
+++ b/crates/television-previewers/src/previewers/cache.rs
@@ -134,7 +134,7 @@ impl PreviewCache {
     /// If the key is already in the cache, the preview will be updated.
     pub fn insert(&mut self, key: String, preview: Arc<Preview>) {
         debug!("Inserting preview into cache: {}", key);
-        self.entries.insert(key.clone(), preview.clone());
+        self.entries.insert(key.clone(), preview);
         if let Some(oldest_key) = self.ring_set.push(key) {
             debug!("Cache full, removing oldest entry: {}", oldest_key);
             self.entries.remove(&oldest_key);

--- a/crates/television-previewers/src/previewers/directory.rs
+++ b/crates/television-previewers/src/previewers/directory.rs
@@ -40,7 +40,7 @@ impl DirectoryPreviewer {
         let cache = self.cache.clone();
         tokio::spawn(async move {
             let preview = Arc::new(build_tree_preview(&entry_c));
-            cache.lock().insert(entry_c.name.clone(), preview.clone());
+            cache.lock().insert(entry_c.name.clone(), preview);
         });
         preview
     }

--- a/crates/television-previewers/src/previewers/files.rs
+++ b/crates/television-previewers/src/previewers/files.rs
@@ -86,7 +86,7 @@ impl FilePreviewer {
 
         // do we have a preview in cache for that entry?
         if let Some(preview) = self.cache.lock().get(&entry.name) {
-            return preview.clone();
+            return preview;
         }
         debug!("No preview in cache for {:?}", entry.name);
 
@@ -99,7 +99,7 @@ impl FilePreviewer {
             let entry_c = entry.clone();
             let syntax_set = self.syntax_set.clone();
             let syntax_theme = self.syntax_theme.clone();
-            let path = path_buf.clone();
+            let path = path_buf;
             let concurrent_tasks = self.concurrent_preview_tasks.clone();
             let last_previewed = self.last_previewed.clone();
             tokio::spawn(async move {
@@ -161,7 +161,7 @@ pub fn try_preview(
         if get_file_size(&path).map_or(false, |s| s > MAX_FILE_SIZE) {
             debug!("File too large: {:?}", entry.name);
             let preview = meta::file_too_large(&entry.name);
-            cache.lock().insert(entry.name.clone(), preview.clone());
+            cache.lock().insert(entry.name.clone(), preview);
         }
 
         if matches!(FileType::from(&path), FileType::Text) {
@@ -184,13 +184,13 @@ pub fn try_preview(
                 Err(e) => {
                     warn!("Error opening file: {:?}", e);
                     let p = meta::not_supported(&entry.name);
-                    cache.lock().insert(entry.name.clone(), p.clone());
+                    cache.lock().insert(entry.name.clone(), p);
                 }
             }
         } else {
             debug!("File isn't text-based: {:?}", entry.name);
             let preview = meta::not_supported(&entry.name);
-            cache.lock().insert(entry.name.clone(), preview.clone());
+            cache.lock().insert(entry.name.clone(), preview);
         }
         concurrent_tasks.fetch_sub(1, Ordering::Relaxed);
     });

--- a/crates/television/app.rs
+++ b/crates/television/app.rs
@@ -140,7 +140,7 @@ impl App {
         )?;
         debug!("{:?}", keymap);
         let television =
-            Arc::new(Mutex::new(Television::new(channel, config.clone())));
+            Arc::new(Mutex::new(Television::new(channel, config)));
 
         Ok(Self {
             keymap,

--- a/crates/television/config.rs
+++ b/crates/television/config.rs
@@ -46,7 +46,7 @@ pub struct Config {
 
 lazy_static! {
     pub static ref PROJECT_NAME: String = String::from("television");
-    pub static ref PROJECT_NAME_UPPER: String = PROJECT_NAME.to_uppercase().to_string();
+    pub static ref PROJECT_NAME_UPPER: String = PROJECT_NAME.to_uppercase();
     pub static ref DATA_FOLDER: Option<PathBuf> =
         // if `TELEVISION_DATA` is set, use that as the data directory
         env::var_os(format!("{}_DATA", PROJECT_NAME_UPPER.clone())).map(PathBuf::from).or_else(|| {

--- a/crates/television/config/previewers.rs
+++ b/crates/television/config/previewers.rs
@@ -18,7 +18,7 @@ pub struct PreviewersConfig {
 impl From<PreviewersConfig> for PreviewerConfig {
     fn from(val: PreviewersConfig) -> Self {
         PreviewerConfig::default()
-            .file(previewers::FilePreviewerConfig::new(val.file.theme.clone()))
+            .file(previewers::FilePreviewerConfig::new(val.file.theme))
     }
 }
 

--- a/crates/television/television.rs
+++ b/crates/television/television.rs
@@ -222,7 +222,7 @@ impl Television {
         &mut self,
         tx: UnboundedSender<Action>,
     ) -> Result<()> {
-        self.action_tx = Some(tx.clone());
+        self.action_tx = Some(tx);
         Ok(())
     }
 


### PR DESCRIPTION
this PR removes a bunch of redundant calls to `.clone()` 

the list was obtained by running 

```
cargo clippy -- -W clippy::redundant_clone
``` 

on the source and removing the associated calls

- I ran `cargo test` to ensure tests are still OK
- I ran `cargo build --release` to rebuild the app and used it without any issue 