### PR TITLE
add cache for icon colors

### DIFF
--- a/crates/television/television.rs
+++ b/crates/television/television.rs
@@ -47,6 +47,7 @@ pub struct Television {
     /// are rendered correctly even when resizing the terminal while still
     /// benefiting from a cache mechanism.
     pub meta_paragraph_cache: HashMap<(String, u16, u16), Paragraph<'static>>,
+    pub icon_color_cache: HashMap<String, Color>,
     pub(crate) spinner: Spinner,
     pub(crate) spinner_state: SpinnerState,
 }
@@ -81,6 +82,7 @@ impl Television {
             preview_pane_height: 0,
             current_preview_total_lines: 0,
             meta_paragraph_cache: HashMap::new(),
+            icon_color_cache: HashMap::new(),
             spinner,
             spinner_state: SpinnerState::from(&spinner),
         }

--- a/crates/television/ui/remote_control.rs
+++ b/crates/television/ui/remote_control.rs
@@ -65,6 +65,7 @@ impl Television {
                     .result_name_fg(mode_color(self.mode)),
             ),
             self.config.ui.use_nerd_font_icons,
+            &mut self.icon_color_cache,
         );
 
         f.render_stateful_widget(


### PR DESCRIPTION
this PR introduces a tv-level cache for icon colors to avoid calls to `Color::from_str` during the calls to `build_results_list`

the rationale behind this choice is that the number of icon colors is rather small and we should benefit from caching