### PR TITLE
perf: remove unnecessary clone()

### DIFF
--- a/crates/television-channels/src/channels/stdin.rs
+++ b/crates/television-channels/src/channels/stdin.rs
@@ -21,7 +21,7 @@ impl Channel {
         let matcher = Matcher::new(Config::default());
         let injector = matcher.injector();
 
-        spawn(move || stream_from_stdin(injector.clone()));
+        spawn(move || stream_from_stdin(injector));
 
         Self {
             matcher,


### PR DESCRIPTION
this is another change proposed by `cargo clippy -- -W clippy::redundant_clone`