### PR TITLE
chore: use named constant for colors

### DIFF
--- a/crates/television/ui/help.rs
+++ b/crates/television/ui/help.rs
@@ -1,18 +1,18 @@
+use super::layout::HelpBarLayout;
 use crate::television::Television;
 use crate::ui::logo::build_logo_paragraph;
 use crate::ui::mode::mode_color;
+use crate::ui::BORDER_COLOR;
 use ratatui::layout::Rect;
 use ratatui::prelude::{Color, Style};
 use ratatui::widgets::{Block, BorderType, Borders, Padding};
 use ratatui::Frame;
 
-use super::layout::HelpBarLayout;
-
 pub fn draw_logo_block(f: &mut Frame, area: Rect, color: Color) {
     let logo_block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .border_style(Style::default().fg(Color::Blue))
+        .border_style(Style::default().fg(BORDER_COLOR))
         .style(Style::default().fg(color))
         .padding(Padding::horizontal(1));
 
@@ -39,7 +39,7 @@ impl Television {
         let metadata_block = Block::default()
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
-            .border_style(Style::default().fg(Color::Blue))
+            .border_style(Style::default().fg(BORDER_COLOR))
             .padding(Padding::horizontal(1))
             .style(Style::default());
 
@@ -56,7 +56,7 @@ impl Television {
         let keymaps_block = Block::default()
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
-            .border_style(Style::default().fg(Color::Blue))
+            .border_style(Style::default().fg(BORDER_COLOR))
             .style(Style::default())
             .padding(Padding::horizontal(1));
 

--- a/crates/television/ui/results.rs
+++ b/crates/television/ui/results.rs
@@ -23,6 +23,8 @@ const DEFAULT_RESULT_PREVIEW_FG: Color = Color::Rgb(150, 150, 150);
 const DEFAULT_RESULT_LINE_NUMBER_FG: Color = Color::Yellow;
 const DEFAULT_RESULT_SELECTED_BG: Color = Color::Rgb(50, 50, 50);
 
+const DEFAULT_RESULTS_LIST_MATCH_FOREGROUND_COLOR: Color = Color::Red;
+
 pub struct ResultsListColors {
     pub result_name_fg: Color,
     pub result_preview_fg: Color,
@@ -118,7 +120,8 @@ where
             // the current match
             spans.push(Span::styled(
                 slice_at_char_boundaries(&entry_name, start, end).to_string(),
-                Style::default().fg(Color::Red),
+                Style::default()
+                    .fg(DEFAULT_RESULTS_LIST_MATCH_FOREGROUND_COLOR),
             ));
             last_match_end = end;
         }
@@ -160,7 +163,8 @@ where
                 ));
                 spans.push(Span::styled(
                     slice_at_char_boundaries(&preview, start, end).to_string(),
-                    Style::default().fg(Color::Red),
+                    Style::default()
+                        .fg(DEFAULT_RESULTS_LIST_MATCH_FOREGROUND_COLOR),
                 ));
                 last_match_end = end;
             }


### PR DESCRIPTION
this PR replaces straight colors by named constants, which should facilitate any subsequent move to refactor the theming capabilities of `tv`