### PR TITLE
chore: add link to nucleo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 ## About
 `Television` is a blazingly fast general purpose fuzzy finder TUI.
 
-It is inspired by the neovim [telescope](https://github.com/nvim-telescope/telescope.nvim) plugin and is designed to be fast, efficient, simple to use and easily extensible. It is built on top of [tokio](https://github.com/tokio-rs/tokio), [ratatui](https://github.com/ratatui/ratatui) and the *nucleo* matcher used by the [helix](https://github.com/helix-editor/helix) editor.
+It is inspired by the neovim [telescope](https://github.com/nvim-telescope/telescope.nvim) plugin and is designed to be fast, efficient, simple to use and easily extensible. It is built on top of [tokio](https://github.com/tokio-rs/tokio), [ratatui](https://github.com/ratatui/ratatui) and the [nucleo](https://github.com/helix-editor/nucleo) matcher used by the [helix](https://github.com/helix-editor/helix) editor.
 
 
 ## Installation


### PR DESCRIPTION
adding link to `nucleo` on Github to facilitate navigation for readers