### PR TITLE
fix(windows): use cmd on windows instead of sh

### DIFF
--- a/crates/television-channels/src/channels/cable.rs
+++ b/crates/television-channels/src/channels/cable.rs
@@ -5,6 +5,7 @@ use television_fuzzy::{
     matcher::{config::Config, injector::Injector},
     Matcher,
 };
+use television_utils::command::shell_command;
 
 #[allow(dead_code)]
 pub struct Channel {
@@ -57,8 +58,7 @@ impl Channel {
 
 #[allow(clippy::unused_async)]
 async fn load_candidates(command: String, injector: Injector<String>) {
-    let output = std::process::Command::new("sh")
-        .arg("-c")
+    let output = shell_command()
         .arg(command)
         .output()
         .expect("failed to execute process");

--- a/crates/television-previewers/src/previewers/command.rs
+++ b/crates/television-previewers/src/previewers/command.rs
@@ -8,6 +8,7 @@ use std::collections::HashSet;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
 use television_channels::entry::{Entry, PreviewCommand};
+use television_utils::command::shell_command;
 use tracing::debug;
 
 #[allow(dead_code)]
@@ -151,8 +152,7 @@ pub fn try_preview(
     let command = format_command(command, entry);
     debug!("Formatted preview command: {:?}", command);
 
-    let output = std::process::Command::new("sh")
-        .arg("-c")
+    let output = shell_command()
         .arg(&command)
         .output()
         .expect("failed to execute process");

--- a/crates/television-utils/src/command.rs
+++ b/crates/television-utils/src/command.rs
@@ -1,0 +1,19 @@
+use std::process::Command;
+
+#[cfg(not(windows))]
+pub fn shell_command() -> Command {
+    let mut cmd = Command::new("sh");
+
+    cmd.arg("-c");
+
+    cmd
+}
+
+#[cfg(windows)]
+pub fn shell_command() -> Command {
+    let mut cmd = Command::new("cmd");
+
+    cmd.arg("/c");
+
+    cmd
+}

--- a/crates/television-utils/src/lib.rs
+++ b/crates/television-utils/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cache;
+pub mod command;
 pub mod files;
 pub mod indices;
 pub mod stdin;


### PR DESCRIPTION
use `cmd` to execute command on windows, otherwise the following error occurs.

```
name = "television"
operating_system = "Windows 10.0.26100 (Windows 11 CoreCountrySpecific) [64-bit]"
crate_version = "0.6.0"
explanation = '''
Panic occurred in file 'D:\env\rust\.cargo\registry\src\rsproxy.cn-0dccff568467c15b\television-previewers-0.0.8\src\previewers\command.rs' at line 158
'''
cause = 'failed to execute process: Error { kind: NotFound, message: "program not found" }'
method = "Panic"
backtrace = """
   0:     0x7ff6488deb0b - onig_get_start_by_callout_args
   1:     0x7ff6488df9f0 - onig_get_start_by_callout_args
   2:     0x7ff6489eea33 - onig_get_start_by_callout_args
   3:     0x7ff6489f1317 - onig_get_start_by_callout_args
   4:     0x7ff648d70710 - onig_get_start_by_callout_args
   5:     0x7ff648bbf9ab - onig_get_start_by_callout_args
   6:     0x7ff648bbf846 - onig_get_start_by_callout_args
   7:     0x7ff648bbd7af - onig_get_start_by_callout_args
   8:     0x7ff648bbf436 - onig_get_start_by_callout_args
   9:     0x7ff648e69b64 - onig_unicode_define_user_property
  10:     0x7ff648e69fa0 - onig_unicode_define_user_property
  11:     0x7ff648c6c3b6 - onig_get_start_by_callout_args
  12:     0x7ff648c8831f - onig_get_start_by_callout_args
  13:     0x7ff648c871ed - onig_get_start_by_callout_args
  14:     0x7ff648c6e6b1 - onig_get_start_by_callout_args
  15:     0x7ff648ca9c98 - onig_get_start_by_callout_args
  16:     0x7ff648ca890c - onig_get_start_by_callout_args
  17:     0x7ff648cb96ec - onig_get_start_by_callout_args
  18:     0x7ff648ca82d1 - onig_get_start_by_callout_args
  19:     0x7ff648c9c351 - onig_get_start_by_callout_args
  20:     0x7ff648c9a452 - onig_get_start_by_callout_args
  21:     0x7ff648ca29c9 - onig_get_start_by_callout_args
  22:     0x7ff648cb4d17 - onig_get_start_by_callout_args
  23:     0x7ff648caba81 - onig_get_start_by_callout_args
  24:     0x7ff648bcbc6d - onig_get_start_by_callout_args
  25:     0x7fffc809e8d7 - BaseThreadInitThunk
  26:     0x7fffc8cbfbcc - RtlUserThreadStart
"""
```