### PR TITLE
perf(ui): improve merging of continuous name match ranges

### DIFF
--- a/crates/television-channels/src/entry.rs
+++ b/crates/television-channels/src/entry.rs
@@ -66,22 +66,21 @@ impl Entry {
         self
     }
     #[allow(clippy::needless_return)]
-    pub fn minimal_name_match_ranges(self) -> Option<Vec<(u32, u32)>> {
+    pub fn minimal_name_match_ranges(&self) -> Option<Vec<(u32, u32)>> {
         // This method takes the existing `name_match_ranges`
         // and merges contiguous ranges into the minimal equivalent
         //   set of ranges. If no ranges exist, it returns `None`.
-        if let Some(name_match_ranges) = self.name_match_ranges {
-            let minimal_name_match_ranges: Vec<(u32, u32)> = name_match_ranges
-                .into_iter()
-                .fold(Vec::new(), |mut acc, x| {
+        if let Some(name_match_ranges) = &self.name_match_ranges {
+            let minimal_name_match_ranges: Vec<(u32, u32)> =
+                name_match_ranges.iter().fold(Vec::new(), |mut acc, x| {
                     if let Some(last) = acc.last_mut() {
                         if last.1 == x.0 {
-                            last.1 = x.1
+                            last.1 = x.1;
                         } else {
-                            acc.push(x);
+                            acc.push(*x);
                         }
                     } else {
-                        acc.push(x);
+                        acc.push(*x);
                     }
                     return acc;
                 });

--- a/crates/television-screen/src/results.rs
+++ b/crates/television-screen/src/results.rs
@@ -56,7 +56,7 @@ where
         // entry name
         let (entry_name, name_match_ranges) = make_matched_string_printable(
             &entry.name,
-            entry.name_match_ranges.as_deref(),
+            entry.minimal_name_match_ranges().as_deref(),
         );
         let mut last_match_end = 0;
         for (start, end) in name_match_ranges


### PR DESCRIPTION
### main
```
results_list            time:   [17.800 µs 17.836 µs 17.869 µs]
                        change: [-0.7235% -0.4176% -0.1185%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
```

### this branch
```
results_list            time:   [12.780 µs 12.789 µs 12.798 µs]
                        change: [-28.381% -28.218% -28.059%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe
```