### PR TITLE
perf: optimize entry ranges

### DIFF
--- a/benches/results_list_benchmark.rs
+++ b/benches/results_list_benchmark.rs
@@ -3,6 +3,7 @@ use devicons::FileIcon;
 use ratatui::layout::Alignment;
 use ratatui::prelude::{Line, Style};
 use ratatui::widgets::{Block, BorderType, Borders, ListDirection, Padding};
+use television_channels::entry::merge_ranges;
 use television_channels::entry::{Entry, PreviewType};
 use television_screen::colors::BORDER_COLOR;
 use television_screen::results::build_results_list;
@@ -15,7 +16,12 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/LICENSE".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
             value_match_ranges: None,
             icon: Some(FileIcon {
                 icon: '\u{f016}',
@@ -27,7 +33,12 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/README.md".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
             value_match_ranges: None,
             icon: Some(FileIcon {
                 icon: '\u{f48a}',
@@ -39,7 +50,12 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/stdlib/re.pyi".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
             value_match_ranges: None,
             icon: Some(FileIcon {
                 icon: '\u{e606}',
@@ -51,7 +67,12 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/stdlib/io.pyi".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
             value_match_ranges: None,
             icon: Some(FileIcon {
                 icon: '\u{e606}',
@@ -63,7 +84,12 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/stdlib/gc.pyi".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
             value_match_ranges: None,
             icon: Some(FileIcon {
                 icon: '\u{e606}',
@@ -75,7 +101,12 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/stdlib/uu.pyi".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
             value_match_ranges: None,
             icon: Some(FileIcon {
                 icon: '\u{e606}',
@@ -87,7 +118,12 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/stdlib/nt.pyi".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
             value_match_ranges: None,
             icon: Some(FileIcon {
                 icon: '\u{e606}',
@@ -99,7 +135,12 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/stdlib/dis.pyi".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
             value_match_ranges: None,
             icon: Some(FileIcon {
                 icon: '\u{e606}',
@@ -111,7 +152,12 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/stdlib/imp.pyi".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
             value_match_ranges: None,
             icon: Some(FileIcon {
                 icon: '\u{e606}',
@@ -123,7 +169,12 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/stdlib/bdb.pyi".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
             value_match_ranges: None,
             icon: Some(FileIcon {
                 icon: '\u{e606}',
@@ -135,7 +186,12 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/stdlib/abc.pyi".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
             value_match_ranges: None,
             icon: Some(FileIcon {
                 icon: '\u{e606}',
@@ -147,7 +203,12 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/stdlib/cgi.pyi".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
             value_match_ranges: None,
             icon: Some(FileIcon {
                 icon: '\u{e606}',
@@ -159,7 +220,12 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/stdlib/bz2.pyi".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
             value_match_ranges: None,
             icon: Some(FileIcon {
                 icon: '\u{e606}',
@@ -171,7 +237,12 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/stdlib/grp.pyi".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
             value_match_ranges: None,
             icon: Some(FileIcon {
                 icon: '\u{e606}',
@@ -183,7 +254,12 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/stdlib/ast.pyi".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
             value_match_ranges: None,
             icon: Some(FileIcon {
                 icon: '\u{e606}',
@@ -195,7 +271,12 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/stdlib/csv.pyi".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
             value_match_ranges: None,
             icon: Some(FileIcon {
                 icon: '\u{e606}',
@@ -207,7 +288,12 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/stdlib/pdb.pyi".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
             value_match_ranges: None,
             icon: Some(FileIcon {
                 icon: '\u{e606}',
@@ -219,7 +305,12 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/stdlib/pwd.pyi".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
             value_match_ranges: None,
             icon: Some(FileIcon {
                 icon: '\u{e606}',
@@ -231,7 +322,12 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/stdlib/ssl.pyi".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
             value_match_ranges: None,
             icon: Some(FileIcon {
                 icon: '\u{e606}',
@@ -243,7 +339,12 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/stdlib/tty.pyi".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
             value_match_ranges: None,
             icon: Some(FileIcon {
                 icon: '\u{e606}',
@@ -255,7 +356,12 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/stdlib/nis.pyi".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
             value_match_ranges: None,
             icon: Some(FileIcon {
                 icon: '\u{e606}',
@@ -267,7 +373,12 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/stdlib/pty.pyi".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
             value_match_ranges: None,
             icon: Some(FileIcon {
                 icon: '\u{e606}',
@@ -279,7 +390,12 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/stdlib/cmd.pyi".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
             value_match_ranges: None,
             icon: Some(FileIcon {
                 icon: '\u{e606}',
@@ -291,7 +407,12 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/tests/utils.py".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
             value_match_ranges: None,
             icon: Some(FileIcon {
                 icon: '\u{e606}',
@@ -303,7 +424,12 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/pyproject.toml".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
             value_match_ranges: None,
             icon: Some(FileIcon {
                 icon: '\u{e6b2}',
@@ -315,7 +441,12 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/MAINTAINERS.md".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
             value_match_ranges: None,
             icon: Some(FileIcon {
                 icon: '\u{f48a}',
@@ -327,7 +458,12 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/stdlib/enum.pyi".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
             value_match_ranges: None,
             icon: Some(FileIcon {
                 icon: '\u{e606}',
@@ -339,7 +475,12 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/stdlib/hmac.pyi".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
             value_match_ranges: None,
             icon: Some(FileIcon {
                 icon: '\u{e606}',
@@ -351,7 +492,12 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/stdlib/uuid.pyi".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
             value_match_ranges: None,
             icon: Some(FileIcon {
                 icon: '\u{e606}',
@@ -363,7 +509,12 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/stdlib/glob.pyi".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
             value_match_ranges: None,
             icon: Some(FileIcon {
                 icon: '\u{e606}',
@@ -375,7 +526,12 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/stdlib/_ast.pyi".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
             value_match_ranges: None,
             icon: Some(FileIcon {
                 icon: '\u{e606}',
@@ -387,7 +543,12 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/stdlib/_csv.pyi".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
             value_match_ranges: None,
             icon: Some(FileIcon {
                 icon: '\u{e606}',
@@ -399,7 +560,12 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/stdlib/code.pyi".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
             value_match_ranges: None,
             icon: Some(FileIcon {
                 icon: '\u{e606}',
@@ -411,7 +577,12 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/stdlib/spwd.pyi".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
             value_match_ranges: None,
             icon: Some(FileIcon {
                 icon: '\u{e606}',
@@ -423,7 +594,12 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/stdlib/_msi.pyi".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
             value_match_ranges: None,
             icon: Some(FileIcon {
                 icon: '\u{e606}',
@@ -435,14 +611,20 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         Entry {
             name: "typeshed/stdlib/time.pyi".to_string(),
             value: None,
-            name_match_ranges: Some(vec![(0, 1), (1, 2), (2, 3), (3, 4)]),
-            value_match_ranges: None,
+
             icon: Some(FileIcon {
                 icon: '\u{e606}',
                 color: "#ffbc03",
             }),
             line_number: None,
             preview_type: PreviewType::Files,
+            name_match_ranges: Some(merge_ranges(&vec![
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 4),
+            ])),
+            value_match_ranges: None,
         },
     ];
 

--- a/crates/television-screen/src/results.rs
+++ b/crates/television-screen/src/results.rs
@@ -56,7 +56,7 @@ where
         // entry name
         let (entry_name, name_match_ranges) = make_matched_string_printable(
             &entry.name,
-            entry.minimal_name_match_ranges().as_deref(),
+            entry.name_match_ranges.as_deref(),
         );
         let mut last_match_end = 0;
         for (start, end) in name_match_ranges


### PR DESCRIPTION
## BEFORE (main branch)

```
results_list            time:   [12.175 µs 12.195 µs 12.217 µs]
                        change: [-1.7157% -0.9562% -0.4063%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 28 outliers among 100 measurements (28.00%)
  5 (5.00%) low severe
  14 (14.00%) low mild
  4 (4.00%) high mild
  5 (5.00%) high severe
```

## AFTER (this branch)
```
results_list            time:   [11.671 µs 11.772 µs 11.923 µs]
                        change: [-3.9850% -3.5914% -3.1779%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 28 outliers among 100 measurements (28.00%)
  22 (22.00%) low severe
  6 (6.00%) high severe
```