### PR TITLE
feat(themes): add support for ui themes

### DIFF
--- a/.config/config.toml
+++ b/.config/config.toml
@@ -99,3 +99,28 @@ select_entry = "enter"
 toggle_send_to_channel = "ctrl-s"
 # Toggle the help bar
 toggle_help = "ctrl-g"
+
+
+# Theme settings
+# ----------------------------------------------------------------------------
+# The theme to use for the UI
+[theme]
+background = "#282c34"
+foreground = "#abb2bf"
+black = "#5c6370"
+red = "#e06c75"
+green = "#98c379"
+yellow = "#e5c07b"
+blue = "#61afef"
+magenta = "#c678dd"
+cyan = "#56b6c2"
+white = "#abb2bf"
+bright_black = "#5c6370"
+bright_red = "#e06c75"
+bright_green = "#98c379"
+bright_yellow = "#e5c07b"
+bright_blue = "#61afef"
+bright_magenta = "#c678dd"
+bright_cyan = "#56b6c2"
+bright_white = "#abb2bf"
+

--- a/.config/config.toml
+++ b/.config/config.toml
@@ -1,3 +1,17 @@
+# CONFIGURATION FILE LOCATION ON YOUR SYSTEM:
+# -------------------------------------------
+# Defaults:
+# ---------
+#  Linux:   `$HOME/.config/television/config.toml`
+#  macOS:   `$HOME/Library/Application Support/television/config.toml`
+#  Windows: `%APPDATA%\television\config.toml`
+#
+# XDG dirs:
+# ---------
+# You may use XDG_CONFIG_HOME if set on your system.
+# In that case, television will expect the configuration file to be in:
+# `$XDG_CONFIG_HOME/television/config.toml`
+#
 [ui]
 # Whether to use nerd font icons in the UI
 # This option requires a font patched with Nerd Font in order to properly
@@ -27,6 +41,9 @@ show_help_bar = false
 # Where to place the input bar in the UI (top or bottom)
 input_bar_position = "bottom"
 # The theme to use for the UI
+# A list of builtin themes can be found in the `themes` directory of the television
+# repository. You may also create your own theme by creating a new file in a `themes`
+# directory in your configuration directory (see the `config.toml` location above).
 theme = "gruvbox-dark"
 
 # Previewers settings
@@ -35,6 +52,7 @@ theme = "gruvbox-dark"
 # The theme to use for syntax highlighting
 # A list of available themes can be found in the https://github.com/sharkdp/bat
 # repository which uses the same syntax highlighting engine as television
+# You may add your own themes by following the instructions in the bat repository
 theme = "gruvbox-dark"
 
 # Keybindings

--- a/.config/config.toml
+++ b/.config/config.toml
@@ -1,5 +1,3 @@
-# Ui settings
-# ----------------------------------------------------------------------------
 [ui]
 # Whether to use nerd font icons in the UI
 # This option requires a font patched with Nerd Font in order to properly
@@ -28,6 +26,8 @@ ui_scale = 100
 show_help_bar = false
 # Where to place the input bar in the UI (top or bottom)
 input_bar_position = "bottom"
+# The theme to use for the UI
+theme = "gruvbox-dark"
 
 # Previewers settings
 # ----------------------------------------------------------------------------
@@ -35,7 +35,7 @@ input_bar_position = "bottom"
 # The theme to use for syntax highlighting
 # A list of available themes can be found in the https://github.com/sharkdp/bat
 # repository which uses the same syntax highlighting engine as television
-theme = "Visual Studio Dark+"
+theme = "gruvbox-dark"
 
 # Keybindings
 # ----------------------------------------------------------------------------
@@ -99,28 +99,3 @@ select_entry = "enter"
 toggle_send_to_channel = "ctrl-s"
 # Toggle the help bar
 toggle_help = "ctrl-g"
-
-
-# Theme settings
-# ----------------------------------------------------------------------------
-# The theme to use for the UI
-[theme]
-background = "#282c34"
-foreground = "#abb2bf"
-black = "#5c6370"
-red = "#e06c75"
-green = "#98c379"
-yellow = "#e5c07b"
-blue = "#61afef"
-magenta = "#c678dd"
-cyan = "#56b6c2"
-white = "#abb2bf"
-bright_black = "#5c6370"
-bright_red = "#e06c75"
-bright_green = "#98c379"
-bright_yellow = "#e5c07b"
-bright_blue = "#61afef"
-bright_magenta = "#c678dd"
-bright_cyan = "#56b6c2"
-bright_white = "#abb2bf"
-

--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ It is inspired by the neovim [telescope](https://github.com/nvim-telescope/teles
 ## Usage
 ```bash
 tv [channel] #[default: files] [possible values: env, files, git-repos, text, alias]
+
+# piping into tv
+ls -1a | tv
+
+# piping into tv with a custom preview command
+ls -1a | tv --preview-command 'cat {}'
 ```
 By default, `television` will launch with the `files` channel on.
 | <img width="2213" alt="Screenshot 2024-11-10 at 15 04 20" src="https://github.com/user-attachments/assets/a0fd70a9-ea26-452a-b235-cbce8aeed67f"> |
@@ -182,6 +188,32 @@ This would add two new cable channels to `television` available using the remote
 
 </details>
 
+## Configuration
+Default (may be overriden) locations where `television` expect the configuration files to be located for each platform:
+
+|Platform|Value|
+|--------|:-----:|
+|Linux|`$HOME/.config/television/config.toml`|
+|macOS|`$HOME/Library/Application Support/com.television/config.toml`|
+|Windows|`{FOLDERID_LocalAppData}\television\config`|
+
+Or, if you'd rather use the XDG Base Directory Specification, tv will look for the configuration file in
+`$XDG_CONFIG_HOME/television/config.toml` if the env variable is set.
+
+**Default configuration: [config.toml](./.config/config.toml)**
+
+## Themes
+Builtin themes are available in the [themes](./themes) directory. Feel free to contribute your own themes!
+
+You may provide your own themes by adding files to a `themes` directory in your configuration folder and then
+referring to them by file name through the configuration file.
+```
+config_location/
+├── themes/
+│   └── my_theme.toml
+└── config.toml
+```
+
 ## Design (high-level)
 #### Channels
 **Television**'s design is primarily based on the concept of **Channels**.
@@ -208,35 +240,6 @@ contents of a file, the value of an environment variable, etc. Because entries r
 represent different types of data, **Television** allows for channels to declare the type of previewer that should be
 used. Television comes with a set of built-in previewers that can be used out of the box and will grow over time.
 
-## Recipes
-Here are some examples of how you can use `television` to make your life easier, more productive and fun. You may want to add some of these examples as aliases to your shell configuration file so that you can easily access them.
-
-**NOTE**: *most of the following examples are meant for macOS. Most of the commands should work on Linux as well, but you may need to adjust them slightly.*
-
-#### CDing into git repo
-```bash
-cd `tv git-repos`
-```
-#### Opening file in default editor
-```bash
-open `tv`
-```
-##### VSCode:
-```bash
-code --goto `tv`
-```
-##### Vim
-```bash
-vim `tv`
-```
-at a specific line using the text channel
-```bash
-tv text | xargs -oI {} sh -c 'vim "$(echo {} | cut -d ":" -f 1)" +$(echo {} | cut -d ":" -f 2)'
-```
-#### Inspecting the current directory
-```bash
-ls -1a | tv
-```
 
 ## Terminal Emulators Compatibility
 Here is a list of terminal emulators that have currently been tested with `television` and their compatibility status.
@@ -259,38 +262,6 @@ Here is a list of terminal emulators that have currently been tested with `telev
 
 
 
-
-## Configuration
-You may wish to customize the behavior of `television` by providing your own configuration file. The configuration file
-is a simple TOML file that allows you to customize the behavior of `television` in a number of ways.
-
-Here are default locations where `television` expect the configuration files to be located for each platform:
-
-|Platform|Value|
-|--------|:-----:|
-|Linux|`$HOME/.config/television/config.toml`|
-|macOS|`$HOME/Library/Application Support/com.television/config.toml`|
-|Windows|`{FOLDERID_LocalAppData}\television\config`|
-
-**NOTE**: on either platform, `XDG_CONFIG_HOME` will always take precedence over default locations if set, in which case
-television will expect the configuration file to be in `$XDG_CONFIG_HOME/television/config.toml`.
-
-You may also override these default paths by setting the `TELEVISION_CONFIG` environment variable to the path of your desired configuration **folder**.
-
-<details>
-
-<summary>
-    Using a custom configuration file location:
-</summary>
-
-```bash
-export TELEVISION_CONFIG=$HOME/.config/television
-touch $TELEVISION_CONFIG/config.toml
-```
-</details>
-
-#### Default Configuration
-The default configuration file can be found in the repository's [./.config/config.toml](./.config/config.toml).
 
 ## Contributions
 

--- a/benches/results_list_benchmark.rs
+++ b/benches/results_list_benchmark.rs
@@ -2,9 +2,10 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use devicons::FileIcon;
 use ratatui::layout::Alignment;
 use ratatui::prelude::{Line, Style};
+use ratatui::style::Color;
 use ratatui::widgets::{Block, BorderType, Borders, ListDirection, Padding};
 use television_channels::entry::{Entry, PreviewType};
-use television_screen::colors::BORDER_COLOR;
+use television_screen::colors::ResultsColorscheme;
 use television_screen::results::build_results_list;
 pub fn results_list_benchmark(c: &mut Criterion) {
     let mut icon_color_cache = std::collections::HashMap::default();
@@ -446,6 +447,15 @@ pub fn results_list_benchmark(c: &mut Criterion) {
         },
     ];
 
+    let colorscheme = ResultsColorscheme {
+        result_name_fg: Color::Indexed(222),
+        result_preview_fg: Color::Indexed(222),
+        result_line_number_fg: Color::Indexed(222),
+        result_selected_bg: Color::Indexed(222),
+        match_foreground_color: Color::Indexed(222),
+        pointer_fg: Color::Indexed(222),
+    };
+
     c.bench_function("results_list", |b| {
         b.iter(|| {
             build_results_list(
@@ -455,14 +465,14 @@ pub fn results_list_benchmark(c: &mut Criterion) {
                     )
                     .borders(Borders::ALL)
                     .border_type(BorderType::Rounded)
-                    .border_style(Style::default().fg(BORDER_COLOR))
+                    .border_style(Style::default().fg(Color::Blue))
                     .style(Style::default())
                     .padding(Padding::right(1)),
                 &entries,
                 ListDirection::BottomToTop,
-                None,
                 false,
                 &mut icon_color_cache,
+                &colorscheme,
             );
         })
     });

--- a/crates/television-screen/src/colors.rs
+++ b/crates/television-screen/src/colors.rs
@@ -1,5 +1,48 @@
 use ratatui::style::Color;
 
+pub struct Colorscheme {
+    pub general: GeneralColorscheme,
+    pub help: HelpColorscheme,
+    pub results: ResultsColorscheme,
+    pub preview: PreviewColorscheme,
+    pub input: InputColorscheme,
+}
+
+pub struct GeneralColorscheme {
+    pub border_fg: Color,
+    pub background: Color,
+}
+
+pub struct HelpColorscheme {
+    pub action_fg: Color,
+    pub metadata_field_name_fg: Color,
+    pub metadata_field_value_fg: Color,
+}
+
+pub struct ResultsColorscheme {
+    pub result_name_fg: Color,
+    pub result_preview_fg: Color,
+    pub result_line_number_fg: Color,
+    pub result_selected_bg: Color,
+    pub match_foreground_color: Color,
+}
+
+pub struct PreviewColorscheme {
+    pub title_fg: Color,
+    pub highlight_bg: Color,
+    pub content_fg: Color,
+    pub gutter_fg: Color,
+    pub gutter_selected_fg: Color,
+}
+
+pub struct InputColorscheme {
+    pub input_fg: Color,
+    pub results_count_fg: Color,
+}
+
+pub const METADATA_FIELD_NAME_COLOR: Color = Color::DarkGray;
+pub const METADATA_FIELD_VALUE_COLOR: Color = Color::Gray;
+
 pub const BORDER_COLOR: Color = Color::Blue;
 pub const ACTION_COLOR: Color = Color::DarkGray;
 // Styles
@@ -21,26 +64,21 @@ pub const DEFAULT_RESULT_SELECTED_BG: Color = Color::Rgb(50, 50, 50);
 
 pub const DEFAULT_RESULTS_LIST_MATCH_FOREGROUND_COLOR: Color = Color::Red;
 
-pub struct ResultsListColors {
-    pub result_name_fg: Color,
-    pub result_preview_fg: Color,
-    pub result_line_number_fg: Color,
-    pub result_selected_bg: Color,
-}
-
-impl Default for ResultsListColors {
+impl Default for ResultsColorscheme {
     fn default() -> Self {
         Self {
             result_name_fg: DEFAULT_RESULT_NAME_FG,
             result_preview_fg: DEFAULT_RESULT_PREVIEW_FG,
             result_line_number_fg: DEFAULT_RESULT_LINE_NUMBER_FG,
             result_selected_bg: DEFAULT_RESULT_SELECTED_BG,
+            match_foreground_color:
+                DEFAULT_RESULTS_LIST_MATCH_FOREGROUND_COLOR,
         }
     }
 }
 
 #[allow(dead_code)]
-impl ResultsListColors {
+impl ResultsColorscheme {
     pub fn result_name_fg(mut self, color: Color) -> Self {
         self.result_name_fg = color;
         self

--- a/crates/television-screen/src/colors.rs
+++ b/crates/television-screen/src/colors.rs
@@ -1,24 +1,28 @@
 use ratatui::style::Color;
 
+#[derive(Debug, Clone)]
 pub struct Colorscheme {
     pub general: GeneralColorscheme,
     pub help: HelpColorscheme,
     pub results: ResultsColorscheme,
     pub preview: PreviewColorscheme,
     pub input: InputColorscheme,
+    pub mode: ModeColorscheme,
 }
 
+#[derive(Debug, Clone)]
 pub struct GeneralColorscheme {
     pub border_fg: Color,
-    pub background: Color,
+    //pub background: Color,
 }
 
+#[derive(Debug, Clone)]
 pub struct HelpColorscheme {
-    pub action_fg: Color,
     pub metadata_field_name_fg: Color,
     pub metadata_field_value_fg: Color,
 }
 
+#[derive(Debug, Clone)]
 pub struct ResultsColorscheme {
     pub result_name_fg: Color,
     pub result_preview_fg: Color,
@@ -27,6 +31,7 @@ pub struct ResultsColorscheme {
     pub match_foreground_color: Color,
 }
 
+#[derive(Debug, Clone, Copy)]
 pub struct PreviewColorscheme {
     pub title_fg: Color,
     pub highlight_bg: Color,
@@ -35,67 +40,15 @@ pub struct PreviewColorscheme {
     pub gutter_selected_fg: Color,
 }
 
+#[derive(Debug, Clone)]
 pub struct InputColorscheme {
     pub input_fg: Color,
     pub results_count_fg: Color,
 }
 
-pub const METADATA_FIELD_NAME_COLOR: Color = Color::DarkGray;
-pub const METADATA_FIELD_VALUE_COLOR: Color = Color::Gray;
-
-pub const BORDER_COLOR: Color = Color::Blue;
-pub const ACTION_COLOR: Color = Color::DarkGray;
-// Styles
-//  input
-pub const DEFAULT_INPUT_FG: Color = Color::LightRed;
-pub const DEFAULT_RESULTS_COUNT_FG: Color = Color::LightRed;
-//  preview
-pub const DEFAULT_PREVIEW_TITLE_FG: Color = Color::Blue;
-pub const DEFAULT_SELECTED_PREVIEW_BG: Color = Color::Rgb(50, 50, 50);
-pub const DEFAULT_PREVIEW_CONTENT_FG: Color = Color::Rgb(150, 150, 180);
-pub const DEFAULT_PREVIEW_GUTTER_FG: Color = Color::Rgb(70, 70, 70);
-pub const DEFAULT_PREVIEW_GUTTER_SELECTED_FG: Color =
-    Color::Rgb(255, 150, 150);
-// Styles
-pub const DEFAULT_RESULT_NAME_FG: Color = Color::Blue;
-pub const DEFAULT_RESULT_PREVIEW_FG: Color = Color::Rgb(150, 150, 150);
-pub const DEFAULT_RESULT_LINE_NUMBER_FG: Color = Color::Yellow;
-pub const DEFAULT_RESULT_SELECTED_BG: Color = Color::Rgb(50, 50, 50);
-
-pub const DEFAULT_RESULTS_LIST_MATCH_FOREGROUND_COLOR: Color = Color::Red;
-
-impl Default for ResultsColorscheme {
-    fn default() -> Self {
-        Self {
-            result_name_fg: DEFAULT_RESULT_NAME_FG,
-            result_preview_fg: DEFAULT_RESULT_PREVIEW_FG,
-            result_line_number_fg: DEFAULT_RESULT_LINE_NUMBER_FG,
-            result_selected_bg: DEFAULT_RESULT_SELECTED_BG,
-            match_foreground_color:
-                DEFAULT_RESULTS_LIST_MATCH_FOREGROUND_COLOR,
-        }
-    }
-}
-
-#[allow(dead_code)]
-impl ResultsColorscheme {
-    pub fn result_name_fg(mut self, color: Color) -> Self {
-        self.result_name_fg = color;
-        self
-    }
-
-    pub fn result_preview_fg(mut self, color: Color) -> Self {
-        self.result_preview_fg = color;
-        self
-    }
-
-    pub fn result_line_number_fg(mut self, color: Color) -> Self {
-        self.result_line_number_fg = color;
-        self
-    }
-
-    pub fn result_selected_bg(mut self, color: Color) -> Self {
-        self.result_selected_bg = color;
-        self
-    }
+#[derive(Debug, Clone)]
+pub struct ModeColorscheme {
+    pub channel: Color,
+    pub remote_control: Color,
+    pub send_to_channel: Color,
 }

--- a/crates/television-screen/src/help.rs
+++ b/crates/television-screen/src/help.rs
@@ -1,5 +1,5 @@
 use super::layout::HelpBarLayout;
-use crate::colors::BORDER_COLOR;
+use crate::colors::{Colorscheme, GeneralColorscheme, HelpColorscheme};
 use crate::logo::build_logo_paragraph;
 use crate::metadata::build_metadata_table;
 use crate::mode::{mode_color, Mode};
@@ -10,12 +10,17 @@ use ratatui::Frame;
 use television_channels::channels::UnitChannel;
 use television_utils::metadata::AppMetadata;
 
-pub fn draw_logo_block(f: &mut Frame, area: Rect, color: Color) {
+pub fn draw_logo_block(
+    f: &mut Frame,
+    area: Rect,
+    mode_color: Color,
+    general_colorscheme: &GeneralColorscheme,
+) {
     let logo_block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .border_style(Style::default().fg(BORDER_COLOR))
-        .style(Style::default().fg(color))
+        .border_style(Style::default().fg(general_colorscheme.border_fg))
+        .style(Style::default().fg(mode_color))
         .padding(Padding::horizontal(1));
 
     let logo_paragraph = build_logo_paragraph().block(logo_block);
@@ -29,32 +34,43 @@ fn draw_metadata_block(
     mode: Mode,
     current_channel: UnitChannel,
     app_metadata: &AppMetadata,
+    general_colorscheme: &GeneralColorscheme,
+    help_colorscheme: &HelpColorscheme,
 ) {
     let metadata_block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .border_style(Style::default().fg(Color::Blue))
+        .border_style(Style::default().fg(general_colorscheme.border_fg))
         .padding(Padding::horizontal(1))
         .style(Style::default());
 
-    let metadata_table =
-        build_metadata_table(mode, current_channel, app_metadata)
-            .block(metadata_block);
+    let metadata_table = build_metadata_table(
+        mode,
+        current_channel,
+        app_metadata,
+        help_colorscheme,
+    )
+    .block(metadata_block);
 
     f.render_widget(metadata_table, area);
 }
 
-fn draw_keymaps_block(f: &mut Frame, area: Rect, keymap_table: Table) {
+fn draw_keymaps_block(
+    f: &mut Frame,
+    area: Rect,
+    keymap_table: Table,
+    colorscheme: &GeneralColorscheme,
+) {
     let keymaps_block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .border_style(Style::default().fg(Color::Blue))
+        .border_style(Style::default().fg(colorscheme.border_fg))
         .style(Style::default())
         .padding(Padding::horizontal(1));
 
-    let keymaps_table = keymap_table.block(keymaps_block);
+    let table = keymap_table.block(keymaps_block);
 
-    f.render_widget(keymaps_table, area);
+    f.render_widget(table, area);
 }
 
 pub fn draw_help_bar(
@@ -64,6 +80,7 @@ pub fn draw_help_bar(
     keymap_table: Table,
     mode: Mode,
     app_metadata: &AppMetadata,
+    colorscheme: &Colorscheme,
 ) {
     if let Some(help_bar) = layout {
         draw_metadata_block(
@@ -72,8 +89,20 @@ pub fn draw_help_bar(
             mode,
             current_channel,
             app_metadata,
+            &colorscheme.general,
+            &colorscheme.help,
         );
-        draw_keymaps_block(f, help_bar.middle, keymap_table);
-        draw_logo_block(f, help_bar.right, mode_color(mode));
+        draw_keymaps_block(
+            f,
+            help_bar.middle,
+            keymap_table,
+            &colorscheme.general,
+        );
+        draw_logo_block(
+            f,
+            help_bar.right,
+            mode_color(mode),
+            &colorscheme.general,
+        );
     }
 }

--- a/crates/television-screen/src/help.rs
+++ b/crates/television-screen/src/help.rs
@@ -1,5 +1,5 @@
 use super::layout::HelpBarLayout;
-use crate::colors::{Colorscheme, GeneralColorscheme, HelpColorscheme};
+use crate::colors::{Colorscheme, GeneralColorscheme};
 use crate::logo::build_logo_paragraph;
 use crate::metadata::build_metadata_table;
 use crate::mode::{mode_color, Mode};
@@ -34,23 +34,18 @@ fn draw_metadata_block(
     mode: Mode,
     current_channel: UnitChannel,
     app_metadata: &AppMetadata,
-    general_colorscheme: &GeneralColorscheme,
-    help_colorscheme: &HelpColorscheme,
+    colorscheme: &Colorscheme,
 ) {
     let metadata_block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .border_style(Style::default().fg(general_colorscheme.border_fg))
+        .border_style(Style::default().fg(colorscheme.general.border_fg))
         .padding(Padding::horizontal(1))
         .style(Style::default());
 
-    let metadata_table = build_metadata_table(
-        mode,
-        current_channel,
-        app_metadata,
-        help_colorscheme,
-    )
-    .block(metadata_block);
+    let metadata_table =
+        build_metadata_table(mode, current_channel, app_metadata, colorscheme)
+            .block(metadata_block);
 
     f.render_widget(metadata_table, area);
 }
@@ -89,8 +84,7 @@ pub fn draw_help_bar(
             mode,
             current_channel,
             app_metadata,
-            &colorscheme.general,
-            &colorscheme.help,
+            colorscheme,
         );
         draw_keymaps_block(
             f,
@@ -101,7 +95,7 @@ pub fn draw_help_bar(
         draw_logo_block(
             f,
             help_bar.right,
-            mode_color(mode),
+            mode_color(mode, &colorscheme.mode),
             &colorscheme.general,
         );
     }

--- a/crates/television-screen/src/input.rs
+++ b/crates/television-screen/src/input.rs
@@ -11,7 +11,7 @@ use ratatui::{
 use television_utils::input::Input;
 
 use crate::{
-    colors::{BORDER_COLOR, DEFAULT_INPUT_FG, DEFAULT_RESULTS_COUNT_FG},
+    colors::Colorscheme,
     spinner::{Spinner, SpinnerState},
 };
 
@@ -27,12 +27,13 @@ pub fn draw_input_box(
     matcher_running: bool,
     spinner: &Spinner,
     spinner_state: &mut SpinnerState,
+    colorscheme: &Colorscheme,
 ) -> Result<()> {
     let input_block = Block::default()
         .title_top(Line::from(" Pattern ").alignment(Alignment::Center))
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .border_style(Style::default().fg(BORDER_COLOR))
+        .border_style(Style::default().fg(colorscheme.general.border_fg))
         .style(Style::default());
 
     let input_block_inner = input_block.inner(rect);
@@ -62,7 +63,7 @@ pub fn draw_input_box(
     let arrow_block = Block::default();
     let arrow = Paragraph::new(Span::styled(
         "> ",
-        Style::default().fg(DEFAULT_INPUT_FG).bold(),
+        Style::default().fg(colorscheme.input.input_fg).bold(),
     ))
     .block(arrow_block);
     f.render_widget(arrow, inner_input_chunks[0]);
@@ -74,7 +75,12 @@ pub fn draw_input_box(
     let input = Paragraph::new(input_state.value())
         .scroll((0, u16::try_from(scroll)?))
         .block(interactive_input_block)
-        .style(Style::default().fg(DEFAULT_INPUT_FG).bold().italic())
+        .style(
+            Style::default()
+                .fg(colorscheme.input.input_fg)
+                .bold()
+                .italic(),
+        )
         .alignment(Alignment::Left);
     f.render_widget(input, inner_input_chunks[1]);
 
@@ -97,7 +103,9 @@ pub fn draw_input_box(
             },
             results_count,
         ),
-        Style::default().fg(DEFAULT_RESULTS_COUNT_FG).italic(),
+        Style::default()
+            .fg(colorscheme.input.results_count_fg)
+            .italic(),
     ))
     .block(result_count_block)
     .alignment(Alignment::Right);

--- a/crates/television-screen/src/keybindings.rs
+++ b/crates/television-screen/src/keybindings.rs
@@ -1,9 +1,6 @@
 use std::{collections::HashMap, fmt::Display};
 
-use crate::{
-    colors::ACTION_COLOR,
-    mode::{Mode, CHANNEL_COLOR, REMOTE_CONTROL_COLOR, SEND_TO_CHANNEL_COLOR},
-};
+use crate::{colors::Colorscheme, mode::Mode};
 use ratatui::{
     layout::Constraint,
     style::{Color, Style},
@@ -52,28 +49,33 @@ impl Display for DisplayableAction {
     }
 }
 
-pub fn build_keybindings_table(
-    keybindings: &HashMap<Mode, DisplayableKeybindings>,
+pub fn build_keybindings_table<'a>(
+    keybindings: &'a HashMap<Mode, DisplayableKeybindings>,
     mode: Mode,
-) -> Table<'_> {
+    colorscheme: &'a Colorscheme,
+) -> Table<'a> {
     match mode {
-        Mode::Channel => {
-            build_keybindings_table_for_channel(&keybindings[&mode])
-        }
-        Mode::RemoteControl => {
-            build_keybindings_table_for_channel_selection(&keybindings[&mode])
-        }
+        Mode::Channel => build_keybindings_table_for_channel(
+            &keybindings[&mode],
+            &colorscheme,
+        ),
+        Mode::RemoteControl => build_keybindings_table_for_channel_selection(
+            &keybindings[&mode],
+            &colorscheme,
+        ),
         Mode::SendToChannel => {
             build_keybindings_table_for_channel_transitions(
                 &keybindings[&mode],
+                &colorscheme,
             )
         }
     }
 }
 
-fn build_keybindings_table_for_channel(
-    keybindings: &DisplayableKeybindings,
-) -> Table<'_> {
+fn build_keybindings_table_for_channel<'a>(
+    keybindings: &'a DisplayableKeybindings,
+    colorscheme: &'a Colorscheme,
+) -> Table<'a> {
     // Results navigation
     let results_navigation_keys = keybindings
         .bindings
@@ -82,7 +84,8 @@ fn build_keybindings_table_for_channel(
     let results_row = Row::new(build_cells_for_group(
         "Results navigation",
         results_navigation_keys,
-        CHANNEL_COLOR,
+        colorscheme.help.metadata_field_name_fg,
+        colorscheme.mode.channel,
     ));
 
     // Preview navigation
@@ -93,7 +96,8 @@ fn build_keybindings_table_for_channel(
     let preview_row = Row::new(build_cells_for_group(
         "Preview navigation",
         preview_navigation_keys,
-        CHANNEL_COLOR,
+        colorscheme.help.metadata_field_name_fg,
+        colorscheme.mode.channel,
     ));
 
     // Select entry
@@ -104,7 +108,8 @@ fn build_keybindings_table_for_channel(
     let select_entry_row = Row::new(build_cells_for_group(
         "Select entry",
         select_entry_keys,
-        CHANNEL_COLOR,
+        colorscheme.help.metadata_field_name_fg,
+        colorscheme.mode.channel,
     ));
 
     // Copy entry to clipboard
@@ -115,7 +120,8 @@ fn build_keybindings_table_for_channel(
     let copy_entry_row = Row::new(build_cells_for_group(
         "Copy entry to clipboard",
         copy_entry_keys,
-        CHANNEL_COLOR,
+        colorscheme.help.metadata_field_name_fg,
+        colorscheme.mode.channel,
     ));
 
     // Send to channel
@@ -126,7 +132,8 @@ fn build_keybindings_table_for_channel(
     let send_to_channel_row = Row::new(build_cells_for_group(
         "Send results to",
         send_to_channel_keys,
-        CHANNEL_COLOR,
+        colorscheme.help.metadata_field_name_fg,
+        colorscheme.mode.channel,
     ));
 
     // Switch channels
@@ -137,15 +144,20 @@ fn build_keybindings_table_for_channel(
     let switch_channels_row = Row::new(build_cells_for_group(
         "Toggle Remote control",
         switch_channels_keys,
-        CHANNEL_COLOR,
+        colorscheme.help.metadata_field_name_fg,
+        colorscheme.mode.channel,
     ));
 
     // MISC line (quit, help, etc.)
     // Quit ⏼
     let quit_keys =
         keybindings.bindings.get(&DisplayableAction::Quit).unwrap();
-    let quit_row =
-        Row::new(build_cells_for_group("Quit", quit_keys, CHANNEL_COLOR));
+    let quit_row = Row::new(build_cells_for_group(
+        "Quit",
+        quit_keys,
+        colorscheme.help.metadata_field_name_fg,
+        colorscheme.mode.channel,
+    ));
 
     let widths = vec![Constraint::Fill(1), Constraint::Fill(2)];
 
@@ -163,9 +175,10 @@ fn build_keybindings_table_for_channel(
     )
 }
 
-fn build_keybindings_table_for_channel_selection(
-    keybindings: &DisplayableKeybindings,
-) -> Table<'_> {
+fn build_keybindings_table_for_channel_selection<'a>(
+    keybindings: &'a DisplayableKeybindings,
+    colorscheme: &'a Colorscheme,
+) -> Table<'a> {
     // Results navigation
     let navigation_keys = keybindings
         .bindings
@@ -174,7 +187,8 @@ fn build_keybindings_table_for_channel_selection(
     let results_row = Row::new(build_cells_for_group(
         "Browse channels",
         navigation_keys,
-        REMOTE_CONTROL_COLOR,
+        colorscheme.help.metadata_field_name_fg,
+        colorscheme.mode.remote_control,
     ));
 
     // Select entry
@@ -185,7 +199,8 @@ fn build_keybindings_table_for_channel_selection(
     let select_entry_row = Row::new(build_cells_for_group(
         "Select channel",
         select_entry_keys,
-        REMOTE_CONTROL_COLOR,
+        colorscheme.help.metadata_field_name_fg,
+        colorscheme.mode.remote_control,
     ));
 
     // Remote control
@@ -196,7 +211,8 @@ fn build_keybindings_table_for_channel_selection(
     let switch_channels_row = Row::new(build_cells_for_group(
         "Toggle Remote control",
         switch_channels_keys,
-        REMOTE_CONTROL_COLOR,
+        colorscheme.help.metadata_field_name_fg,
+        colorscheme.mode.remote_control,
     ));
 
     Table::new(
@@ -205,9 +221,10 @@ fn build_keybindings_table_for_channel_selection(
     )
 }
 
-fn build_keybindings_table_for_channel_transitions(
-    keybindings: &DisplayableKeybindings,
-) -> Table<'_> {
+fn build_keybindings_table_for_channel_transitions<'a>(
+    keybindings: &'a DisplayableKeybindings,
+    colorscheme: &'a Colorscheme,
+) -> Table<'a> {
     // Results navigation
     let results_navigation_keys = keybindings
         .bindings
@@ -216,7 +233,8 @@ fn build_keybindings_table_for_channel_transitions(
     let results_row = Row::new(build_cells_for_group(
         "Browse channels",
         results_navigation_keys,
-        SEND_TO_CHANNEL_COLOR,
+        colorscheme.help.metadata_field_name_fg,
+        colorscheme.mode.send_to_channel,
     ));
 
     // Select entry
@@ -227,7 +245,8 @@ fn build_keybindings_table_for_channel_transitions(
     let select_entry_row = Row::new(build_cells_for_group(
         "Send to channel",
         select_entry_keys,
-        SEND_TO_CHANNEL_COLOR,
+        colorscheme.help.metadata_field_name_fg,
+        colorscheme.mode.send_to_channel,
     ));
 
     // Cancel
@@ -238,7 +257,8 @@ fn build_keybindings_table_for_channel_transitions(
     let cancel_row = Row::new(build_cells_for_group(
         "Cancel",
         cancel_keys,
-        SEND_TO_CHANNEL_COLOR,
+        colorscheme.help.metadata_field_name_fg,
+        colorscheme.mode.send_to_channel,
     ));
 
     Table::new(
@@ -251,23 +271,24 @@ fn build_cells_for_group<'a>(
     group_name: &str,
     keys: &'a [String],
     key_color: Color,
+    value_color: Color,
 ) -> Vec<Cell<'a>> {
     // group name
     let mut cells = vec![Cell::from(Span::styled(
         group_name.to_owned() + ": ",
-        Style::default().fg(ACTION_COLOR),
+        Style::default().fg(key_color),
     ))];
 
     let spans = keys.iter().skip(1).fold(
         vec![Span::styled(
             keys[0].clone(),
-            Style::default().fg(key_color),
+            Style::default().fg(value_color),
         )],
         |mut acc, key| {
             acc.push(Span::raw(" / "));
             acc.push(Span::styled(
                 key.to_owned(),
-                Style::default().fg(key_color),
+                Style::default().fg(value_color),
             ));
             acc
         },

--- a/crates/television-screen/src/keybindings.rs
+++ b/crates/television-screen/src/keybindings.rs
@@ -45,7 +45,7 @@ impl Display for DisplayableAction {
             DisplayableAction::Cancel => "Cancel",
             DisplayableAction::Quit => "Quit",
         };
-        write!(f, "{}", action)
+        write!(f, "{action}")
     }
 }
 
@@ -57,16 +57,16 @@ pub fn build_keybindings_table<'a>(
     match mode {
         Mode::Channel => build_keybindings_table_for_channel(
             &keybindings[&mode],
-            &colorscheme,
+            colorscheme,
         ),
         Mode::RemoteControl => build_keybindings_table_for_channel_selection(
             &keybindings[&mode],
-            &colorscheme,
+            colorscheme,
         ),
         Mode::SendToChannel => {
             build_keybindings_table_for_channel_transitions(
                 &keybindings[&mode],
-                &colorscheme,
+                colorscheme,
             )
         }
     }

--- a/crates/television-screen/src/metadata.rs
+++ b/crates/television-screen/src/metadata.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use crate::{
-    colors::HelpColorscheme,
+    colors::Colorscheme,
     mode::{mode_color, Mode},
 };
 use ratatui::{
@@ -27,86 +27,86 @@ pub fn build_metadata_table<'a>(
     mode: Mode,
     current_channel: UnitChannel,
     app_metadata: &'a AppMetadata,
-    help_colorscheme: &'a HelpColorscheme,
+    colorscheme: &'a Colorscheme,
 ) -> Table<'a> {
     let version_row = Row::new(vec![
         Cell::from(Span::styled(
             "version: ",
-            Style::default().fg(help_colorscheme.metadata_field_name_fg),
+            Style::default().fg(colorscheme.help.metadata_field_name_fg),
         )),
         Cell::from(Span::styled(
             &app_metadata.version,
-            Style::default().fg(help_colorscheme.metadata_field_value_fg),
+            Style::default().fg(colorscheme.help.metadata_field_value_fg),
         )),
     ]);
 
     let target_triple_row = Row::new(vec![
         Cell::from(Span::styled(
             "target triple: ",
-            Style::default().fg(help_colorscheme.metadata_field_name_fg),
+            Style::default().fg(colorscheme.help.metadata_field_name_fg),
         )),
         Cell::from(Span::styled(
             &app_metadata.build.target_triple,
-            Style::default().fg(help_colorscheme.metadata_field_value_fg),
+            Style::default().fg(colorscheme.help.metadata_field_value_fg),
         )),
     ]);
 
     let build_row = Row::new(vec![
         Cell::from(Span::styled(
             "build: ",
-            Style::default().fg(help_colorscheme.metadata_field_name_fg),
+            Style::default().fg(colorscheme.help.metadata_field_name_fg),
         )),
         Cell::from(Span::styled(
             &app_metadata.build.rustc_version,
-            Style::default().fg(help_colorscheme.metadata_field_value_fg),
+            Style::default().fg(colorscheme.help.metadata_field_value_fg),
         )),
         Cell::from(Span::styled(
             " (",
-            Style::default().fg(help_colorscheme.metadata_field_name_fg),
+            Style::default().fg(colorscheme.help.metadata_field_name_fg),
         )),
         Cell::from(Span::styled(
             &app_metadata.build.build_date,
-            Style::default().fg(help_colorscheme.metadata_field_value_fg),
+            Style::default().fg(colorscheme.help.metadata_field_value_fg),
         )),
         Cell::from(Span::styled(
             ")",
-            Style::default().fg(help_colorscheme.metadata_field_name_fg),
+            Style::default().fg(colorscheme.help.metadata_field_name_fg),
         )),
     ]);
 
     let current_dir_row = Row::new(vec![
         Cell::from(Span::styled(
             "current directory: ",
-            Style::default().fg(help_colorscheme.metadata_field_name_fg),
+            Style::default().fg(colorscheme.help.metadata_field_name_fg),
         )),
         Cell::from(Span::styled(
             std::env::current_dir()
                 .expect("Could not get current directory")
                 .display()
                 .to_string(),
-            Style::default().fg(help_colorscheme.metadata_field_value_fg),
+            Style::default().fg(colorscheme.help.metadata_field_value_fg),
         )),
     ]);
 
     let current_channel_row = Row::new(vec![
         Cell::from(Span::styled(
             "current channel: ",
-            Style::default().fg(help_colorscheme.metadata_field_name_fg),
+            Style::default().fg(colorscheme.help.metadata_field_name_fg),
         )),
         Cell::from(Span::styled(
             current_channel.to_string(),
-            Style::default().fg(help_colorscheme.metadata_field_value_fg),
+            Style::default().fg(colorscheme.help.metadata_field_value_fg),
         )),
     ]);
 
     let current_mode_row = Row::new(vec![
         Cell::from(Span::styled(
             "current mode: ",
-            Style::default().fg(help_colorscheme.metadata_field_name_fg),
+            Style::default().fg(colorscheme.help.metadata_field_name_fg),
         )),
         Cell::from(Span::styled(
             mode.to_string(),
-            Style::default().fg(mode_color(mode)),
+            Style::default().fg(mode_color(mode, &colorscheme.mode)),
         )),
     ]);
 

--- a/crates/television-screen/src/metadata.rs
+++ b/crates/television-screen/src/metadata.rs
@@ -1,17 +1,17 @@
 use std::fmt::Display;
 
-use crate::mode::{mode_color, Mode};
+use crate::{
+    colors::HelpColorscheme,
+    mode::{mode_color, Mode},
+};
 use ratatui::{
     layout::Constraint,
-    style::{Color, Style},
+    style::Style,
     text::Span,
     widgets::{Cell, Row, Table},
 };
 use television_channels::channels::UnitChannel;
 use television_utils::metadata::AppMetadata;
-
-const METADATA_FIELD_NAME_COLOR: Color = Color::DarkGray;
-const METADATA_FIELD_VALUE_COLOR: Color = Color::Gray;
 
 impl Display for Mode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -23,85 +23,86 @@ impl Display for Mode {
     }
 }
 
-pub fn build_metadata_table(
+pub fn build_metadata_table<'a>(
     mode: Mode,
     current_channel: UnitChannel,
-    app_metadata: &AppMetadata,
-) -> Table<'_> {
+    app_metadata: &'a AppMetadata,
+    help_colorscheme: &'a HelpColorscheme,
+) -> Table<'a> {
     let version_row = Row::new(vec![
         Cell::from(Span::styled(
             "version: ",
-            Style::default().fg(METADATA_FIELD_NAME_COLOR),
+            Style::default().fg(help_colorscheme.metadata_field_name_fg),
         )),
         Cell::from(Span::styled(
             &app_metadata.version,
-            Style::default().fg(METADATA_FIELD_VALUE_COLOR),
+            Style::default().fg(help_colorscheme.metadata_field_value_fg),
         )),
     ]);
 
     let target_triple_row = Row::new(vec![
         Cell::from(Span::styled(
             "target triple: ",
-            Style::default().fg(METADATA_FIELD_NAME_COLOR),
+            Style::default().fg(help_colorscheme.metadata_field_name_fg),
         )),
         Cell::from(Span::styled(
             &app_metadata.build.target_triple,
-            Style::default().fg(METADATA_FIELD_VALUE_COLOR),
+            Style::default().fg(help_colorscheme.metadata_field_value_fg),
         )),
     ]);
 
     let build_row = Row::new(vec![
         Cell::from(Span::styled(
             "build: ",
-            Style::default().fg(METADATA_FIELD_NAME_COLOR),
+            Style::default().fg(help_colorscheme.metadata_field_name_fg),
         )),
         Cell::from(Span::styled(
             &app_metadata.build.rustc_version,
-            Style::default().fg(METADATA_FIELD_VALUE_COLOR),
+            Style::default().fg(help_colorscheme.metadata_field_value_fg),
         )),
         Cell::from(Span::styled(
             " (",
-            Style::default().fg(METADATA_FIELD_NAME_COLOR),
+            Style::default().fg(help_colorscheme.metadata_field_name_fg),
         )),
         Cell::from(Span::styled(
             &app_metadata.build.build_date,
-            Style::default().fg(METADATA_FIELD_VALUE_COLOR),
+            Style::default().fg(help_colorscheme.metadata_field_value_fg),
         )),
         Cell::from(Span::styled(
             ")",
-            Style::default().fg(METADATA_FIELD_NAME_COLOR),
+            Style::default().fg(help_colorscheme.metadata_field_name_fg),
         )),
     ]);
 
     let current_dir_row = Row::new(vec![
         Cell::from(Span::styled(
             "current directory: ",
-            Style::default().fg(METADATA_FIELD_NAME_COLOR),
+            Style::default().fg(help_colorscheme.metadata_field_name_fg),
         )),
         Cell::from(Span::styled(
             std::env::current_dir()
                 .expect("Could not get current directory")
                 .display()
                 .to_string(),
-            Style::default().fg(METADATA_FIELD_VALUE_COLOR),
+            Style::default().fg(help_colorscheme.metadata_field_value_fg),
         )),
     ]);
 
     let current_channel_row = Row::new(vec![
         Cell::from(Span::styled(
             "current channel: ",
-            Style::default().fg(METADATA_FIELD_NAME_COLOR),
+            Style::default().fg(help_colorscheme.metadata_field_name_fg),
         )),
         Cell::from(Span::styled(
             current_channel.to_string(),
-            Style::default().fg(METADATA_FIELD_VALUE_COLOR),
+            Style::default().fg(help_colorscheme.metadata_field_value_fg),
         )),
     ]);
 
     let current_mode_row = Row::new(vec![
         Cell::from(Span::styled(
             "current mode: ",
-            Style::default().fg(METADATA_FIELD_NAME_COLOR),
+            Style::default().fg(help_colorscheme.metadata_field_name_fg),
         )),
         Cell::from(Span::styled(
             mode.to_string(),

--- a/crates/television-screen/src/mode.rs
+++ b/crates/television-screen/src/mode.rs
@@ -1,15 +1,13 @@
 use ratatui::style::Color;
 use serde::{Deserialize, Serialize};
 
-pub const CHANNEL_COLOR: Color = Color::Indexed(222);
-pub const REMOTE_CONTROL_COLOR: Color = Color::Indexed(1);
-pub const SEND_TO_CHANNEL_COLOR: Color = Color::Indexed(105);
+use crate::colors::ModeColorscheme;
 
-pub fn mode_color(mode: Mode) -> Color {
+pub fn mode_color(mode: Mode, colorscheme: &ModeColorscheme) -> Color {
     match mode {
-        Mode::Channel => CHANNEL_COLOR,
-        Mode::RemoteControl => REMOTE_CONTROL_COLOR,
-        Mode::SendToChannel => SEND_TO_CHANNEL_COLOR,
+        Mode::Channel => colorscheme.channel,
+        Mode::RemoteControl => colorscheme.remote_control,
+        Mode::SendToChannel => colorscheme.send_to_channel,
     }
 }
 

--- a/crates/television-screen/src/remote_control.rs
+++ b/crates/television-screen/src/remote_control.rs
@@ -1,12 +1,12 @@
 use std::collections::HashMap;
 
+use crate::colors::Colorscheme;
 use crate::logo::build_remote_logo_paragraph;
-use crate::mode::REMOTE_CONTROL_COLOR;
+use crate::mode::{mode_color, Mode};
 use crate::results::build_results_list;
 use television_channels::entry::Entry;
 use television_utils::input::Input;
 
-use crate::colors::{ResultsColorscheme, BORDER_COLOR, DEFAULT_INPUT_FG};
 use color_eyre::eyre::Result;
 use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
 use ratatui::prelude::Style;
@@ -17,6 +17,7 @@ use ratatui::widgets::{
 };
 use ratatui::Frame;
 
+#[allow(clippy::too_many_arguments)]
 pub fn draw_remote_control(
     f: &mut Frame,
     rect: Rect,
@@ -25,6 +26,8 @@ pub fn draw_remote_control(
     picker_state: &mut ListState,
     input_state: &mut Input,
     icon_color_cache: &mut HashMap<String, Color>,
+    mode: &Mode,
+    colorscheme: &Colorscheme,
 ) -> Result<()> {
     let layout = Layout::default()
         .direction(Direction::Vertical)
@@ -44,9 +47,10 @@ pub fn draw_remote_control(
         use_nerd_font_icons,
         picker_state,
         icon_color_cache,
+        colorscheme,
     );
-    draw_rc_input(f, layout[1], input_state)?;
-    draw_rc_logo(f, layout[2]);
+    draw_rc_input(f, layout[1], input_state, colorscheme)?;
+    draw_rc_logo(f, layout[2], mode_color(*mode, &colorscheme.mode));
     Ok(())
 }
 
@@ -57,12 +61,12 @@ fn draw_rc_channels(
     use_nerd_font_icons: bool,
     picker_state: &mut ListState,
     icon_color_cache: &mut HashMap<String, Color>,
-    results_colorscheme: &ResultsColorscheme,
+    colorscheme: &Colorscheme,
 ) {
     let rc_block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .border_style(Style::default().fg(BORDER_COLOR))
+        .border_style(Style::default().fg(colorscheme.general.border_fg))
         .style(Style::default())
         .padding(Padding::right(1));
 
@@ -72,18 +76,23 @@ fn draw_rc_channels(
         ListDirection::TopToBottom,
         use_nerd_font_icons,
         icon_color_cache,
-        &results_colorscheme,
+        &colorscheme.results,
     );
 
     f.render_stateful_widget(channel_list, area, picker_state);
 }
 
-fn draw_rc_input(f: &mut Frame, area: Rect, input: &mut Input) -> Result<()> {
+fn draw_rc_input(
+    f: &mut Frame,
+    area: Rect,
+    input: &mut Input,
+    colorscheme: &Colorscheme,
+) -> Result<()> {
     let input_block = Block::default()
         .title_top(Line::from("Remote Control").alignment(Alignment::Center))
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .border_style(Style::default().fg(BORDER_COLOR))
+        .border_style(Style::default().fg(colorscheme.general.border_fg))
         .style(Style::default());
 
     let input_block_inner = input_block.inner(area);
@@ -104,7 +113,7 @@ fn draw_rc_input(f: &mut Frame, area: Rect, input: &mut Input) -> Result<()> {
     let prompt_symbol_block = Block::default();
     let arrow = Paragraph::new(Span::styled(
         "> ",
-        Style::default().fg(DEFAULT_INPUT_FG).bold(),
+        Style::default().fg(colorscheme.input.input_fg).bold(),
     ))
     .block(prompt_symbol_block);
     f.render_widget(arrow, inner_input_chunks[0]);
@@ -116,7 +125,12 @@ fn draw_rc_input(f: &mut Frame, area: Rect, input: &mut Input) -> Result<()> {
     let input_paragraph = Paragraph::new(input.value())
         .scroll((0, u16::try_from(scroll)?))
         .block(interactive_input_block)
-        .style(Style::default().fg(DEFAULT_INPUT_FG).bold().italic())
+        .style(
+            Style::default()
+                .fg(colorscheme.input.input_fg)
+                .bold()
+                .italic(),
+        )
         .alignment(Alignment::Left);
     f.render_widget(input_paragraph, inner_input_chunks[1]);
 
@@ -131,9 +145,8 @@ fn draw_rc_input(f: &mut Frame, area: Rect, input: &mut Input) -> Result<()> {
     ));
     Ok(())
 }
-fn draw_rc_logo(f: &mut Frame, area: Rect) {
-    let logo_block =
-        Block::default().style(Style::default().fg(REMOTE_CONTROL_COLOR));
+fn draw_rc_logo(f: &mut Frame, area: Rect, mode_color: Color) {
+    let logo_block = Block::default().style(Style::default().fg(mode_color));
 
     let logo_paragraph = build_remote_logo_paragraph()
         .alignment(Alignment::Center)

--- a/crates/television-screen/src/remote_control.rs
+++ b/crates/television-screen/src/remote_control.rs
@@ -6,7 +6,7 @@ use crate::results::build_results_list;
 use television_channels::entry::Entry;
 use television_utils::input::Input;
 
-use crate::colors::{ResultsListColors, BORDER_COLOR, DEFAULT_INPUT_FG};
+use crate::colors::{ResultsColorscheme, BORDER_COLOR, DEFAULT_INPUT_FG};
 use color_eyre::eyre::Result;
 use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
 use ratatui::prelude::Style;
@@ -57,6 +57,7 @@ fn draw_rc_channels(
     use_nerd_font_icons: bool,
     picker_state: &mut ListState,
     icon_color_cache: &mut HashMap<String, Color>,
+    results_colorscheme: &ResultsColorscheme,
 ) {
     let rc_block = Block::default()
         .borders(Borders::ALL)
@@ -69,11 +70,9 @@ fn draw_rc_channels(
         rc_block,
         entries,
         ListDirection::TopToBottom,
-        Some(
-            ResultsListColors::default().result_name_fg(REMOTE_CONTROL_COLOR),
-        ),
         use_nerd_font_icons,
         icon_color_cache,
+        &results_colorscheme,
     );
 
     f.render_stateful_widget(channel_list, area, picker_state);

--- a/crates/television-screen/src/results.rs
+++ b/crates/television-screen/src/results.rs
@@ -3,6 +3,7 @@ use crate::layout::InputPosition;
 use color_eyre::eyre::Result;
 use ratatui::layout::{Alignment, Rect};
 use ratatui::prelude::{Color, Line, Span, Style};
+use ratatui::style::Stylize;
 use ratatui::widgets::{
     Block, BorderType, Borders, List, ListDirection, ListState, Padding,
 };
@@ -21,7 +22,7 @@ pub fn build_results_list<'a, 'b>(
     list_direction: ListDirection,
     use_icons: bool,
     icon_color_cache: &mut HashMap<String, Color>,
-    results_colorscheme: &ResultsColorscheme,
+    colorscheme: &ResultsColorscheme,
 ) -> List<'a>
 where
     'b: 'a,
@@ -63,13 +64,12 @@ where
             spans.push(Span::styled(
                 slice_at_char_boundaries(&entry_name, last_match_end, start)
                     .to_string(),
-                Style::default().fg(results_colorscheme.result_name_fg),
+                Style::default().fg(colorscheme.result_name_fg),
             ));
             // the current match
             spans.push(Span::styled(
                 slice_at_char_boundaries(&entry_name, start, end).to_string(),
-                Style::default()
-                    .fg(results_colorscheme.match_foreground_color),
+                Style::default().fg(colorscheme.match_foreground_color),
             ));
             last_match_end = end;
         }
@@ -80,14 +80,14 @@ where
             let remainder = entry_name[next_boundary..].to_string();
             spans.push(Span::styled(
                 remainder,
-                Style::default().fg(results_colorscheme.result_name_fg),
+                Style::default().fg(colorscheme.result_name_fg),
             ));
         }
         // optional line number
         if let Some(line_number) = entry.line_number {
             spans.push(Span::styled(
                 format!(":{line_number}"),
-                Style::default().fg(results_colorscheme.result_line_number_fg),
+                Style::default().fg(colorscheme.result_line_number_fg),
             ));
         }
         // optional preview
@@ -107,12 +107,11 @@ where
                 spans.push(Span::styled(
                     slice_at_char_boundaries(&preview, last_match_end, start)
                         .to_string(),
-                    Style::default().fg(results_colorscheme.result_preview_fg),
+                    Style::default().fg(colorscheme.result_preview_fg),
                 ));
                 spans.push(Span::styled(
                     slice_at_char_boundaries(&preview, start, end).to_string(),
-                    Style::default()
-                        .fg(results_colorscheme.match_foreground_color),
+                    Style::default().fg(colorscheme.match_foreground_color),
                 ));
                 last_match_end = end;
             }
@@ -120,7 +119,7 @@ where
             if next_boundary < preview.len() {
                 spans.push(Span::styled(
                     preview[next_boundary..].to_string(),
-                    Style::default().fg(results_colorscheme.result_preview_fg),
+                    Style::default().fg(colorscheme.result_preview_fg),
                 ));
             }
         }
@@ -128,7 +127,7 @@ where
     }))
     .direction(list_direction)
     .highlight_style(
-        Style::default().bg(results_colorscheme.result_selected_bg),
+        Style::default().bg(colorscheme.result_selected_bg).bold(),
     )
     .highlight_symbol("> ")
     .block(results_block)

--- a/crates/television/app.rs
+++ b/crates/television/app.rs
@@ -5,12 +5,11 @@ use television_screen::mode::Mode;
 use tokio::sync::{mpsc, Mutex};
 use tracing::{debug, info};
 
-use crate::config::parse_key;
+use crate::config::{parse_key, Config};
 use crate::keymap::Keymap;
 use crate::television::Television;
 use crate::{
     action::Action,
-    config::Config,
     event::{Event, EventLoop, Key},
     render::{render, RenderingTask},
 };

--- a/crates/television/config.rs
+++ b/crates/television/config.rs
@@ -9,6 +9,7 @@ use lazy_static::lazy_static;
 use previewers::PreviewersConfig;
 use serde::Deserialize;
 use styles::Styles;
+pub use themes::Theme;
 use tracing::{debug, warn};
 use ui::UiConfig;
 
@@ -43,8 +44,6 @@ pub struct Config {
     pub ui: UiConfig,
     #[serde(default)]
     pub previewers: PreviewersConfig,
-    #[serde(default)]
-    pub theme: themes::Theme,
 }
 
 lazy_static! {
@@ -82,7 +81,7 @@ impl Config {
             .set_default("config_dir", config_dir.to_str().unwrap())?
             .set_default("ui", UiConfig::default())?
             .set_default("previewers", PreviewersConfig::default())?
-            .set_default("theme", themes::Theme::default())?;
+            .set_default("theme", default_config.ui.theme.clone())?;
 
         // Load the user's config file
         let source = config::File::from(config_dir.join(CONFIG_FILE_NAME))
@@ -92,13 +91,13 @@ impl Config {
 
         if config_dir.join(CONFIG_FILE_NAME).is_file() {
             debug!("Found config file at {:?}", config_dir);
-            let mut cfg: Self =
-                builder.build()?.try_deserialize().with_context(|| {
-                    format!(
-                        "Error parsing config file at {:?}",
-                        config_dir.join(CONFIG_FILE_NAME)
-                    )
-                })?;
+            let mut cfg: Self = builder.build()?.try_deserialize().unwrap();
+            //.with_context(|| {
+            //    format!(
+            //        "Error parsing config file at {:?}",
+            //        config_dir.join(CONFIG_FILE_NAME)
+            //    )
+            //})?;
 
             for (mode, default_bindings) in default_config.keybindings.iter() {
                 let user_bindings = cfg.keybindings.entry(*mode).or_default();

--- a/crates/television/config.rs
+++ b/crates/television/config.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::module_name_repetitions)]
 use std::{env, path::PathBuf};
 
-use color_eyre::{eyre::Context, Result};
+use color_eyre::Result;
 use directories::ProjectDirs;
 pub use keybindings::parse_key;
 pub use keybindings::KeyBindings;

--- a/crates/television/config.rs
+++ b/crates/television/config.rs
@@ -15,6 +15,7 @@ use ui::UiConfig;
 mod keybindings;
 mod previewers;
 mod styles;
+mod themes;
 mod ui;
 
 const CONFIG: &str = include_str!("../../.config/config.toml");
@@ -42,6 +43,8 @@ pub struct Config {
     pub ui: UiConfig,
     #[serde(default)]
     pub previewers: PreviewersConfig,
+    #[serde(default)]
+    pub theme: themes::Theme,
 }
 
 lazy_static! {
@@ -64,6 +67,7 @@ lazy_static! {
 const CONFIG_FILE_NAME: &str = "config.toml";
 
 impl Config {
+    // FIXME: default management is a bit of a mess right now
     #[allow(clippy::missing_panics_doc, clippy::missing_errors_doc)]
     pub fn new() -> Result<Self> {
         // Load the default_config values as base defaults
@@ -77,7 +81,8 @@ impl Config {
             .set_default("data_dir", data_dir.to_str().unwrap())?
             .set_default("config_dir", config_dir.to_str().unwrap())?
             .set_default("ui", UiConfig::default())?
-            .set_default("previewers", PreviewersConfig::default())?;
+            .set_default("previewers", PreviewersConfig::default())?
+            .set_default("theme", themes::Theme::default())?;
 
         // Load the user's config file
         let source = config::File::from(config_dir.join(CONFIG_FILE_NAME))
@@ -128,7 +133,7 @@ pub fn get_data_dir() -> PathBuf {
         debug!("Falling back to default data dir");
         proj_dirs.data_local_dir().to_path_buf()
     } else {
-        PathBuf::from(".").join(".data")
+        PathBuf::from("../../../../..").join(".data")
     };
     directory
 }
@@ -141,32 +146,11 @@ pub fn get_config_dir() -> PathBuf {
         debug!("Falling back to default config dir");
         proj_dirs.config_local_dir().to_path_buf()
     } else {
-        PathBuf::from(".").join(".config")
+        PathBuf::from("../../../../..").join("../../../../../.config")
     };
     directory
 }
 
 fn project_directory() -> Option<ProjectDirs> {
     ProjectDirs::from("com", "", env!("CARGO_PKG_NAME"))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::action::Action;
-    use crate::config::keybindings::parse_key;
-    use television_screen::mode::Mode;
-
-    #[test]
-    fn test_config() -> Result<()> {
-        let c = Config::new()?;
-        assert_eq!(
-            c.keybindings
-                .get(&Mode::Channel)
-                .unwrap()
-                .get(&Action::Quit),
-            Some(&parse_key("esc").unwrap())
-        );
-        Ok(())
-    }
 }

--- a/crates/television/config/previewers.rs
+++ b/crates/television/config/previewers.rs
@@ -39,10 +39,19 @@ impl From<BasicPreviewerConfig> for ValueKind {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Default)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct FilePreviewerConfig {
     //pub max_file_size: u64,
     pub theme: String,
+}
+
+impl Default for FilePreviewerConfig {
+    fn default() -> Self {
+        Self {
+            //max_file_size: 1024 * 1024,
+            theme: String::from("gruvbox-dark"),
+        }
+    }
 }
 
 impl From<FilePreviewerConfig> for ValueKind {

--- a/crates/television/config/themes.rs
+++ b/crates/television/config/themes.rs
@@ -168,12 +168,14 @@ impl<'de> Deserialize<'de> for Theme {
     }
 }
 
+#[allow(clippy::from_over_into)]
 impl Into<RatatuiColor> for &Color {
     fn into(self) -> RatatuiColor {
         RatatuiColor::Rgb(self.r, self.g, self.b)
     }
 }
 
+#[allow(clippy::from_over_into)]
 impl Into<Colorscheme> for &Theme {
     fn into(self) -> Colorscheme {
         Colorscheme {
@@ -187,6 +189,7 @@ impl Into<Colorscheme> for &Theme {
     }
 }
 
+#[allow(clippy::from_over_into)]
 impl Into<GeneralColorscheme> for &Theme {
     fn into(self) -> GeneralColorscheme {
         GeneralColorscheme {
@@ -195,6 +198,7 @@ impl Into<GeneralColorscheme> for &Theme {
     }
 }
 
+#[allow(clippy::from_over_into)]
 impl Into<HelpColorscheme> for &Theme {
     fn into(self) -> HelpColorscheme {
         HelpColorscheme {
@@ -204,6 +208,7 @@ impl Into<HelpColorscheme> for &Theme {
     }
 }
 
+#[allow(clippy::from_over_into)]
 impl Into<ResultsColorscheme> for &Theme {
     fn into(self) -> ResultsColorscheme {
         ResultsColorscheme {
@@ -216,6 +221,7 @@ impl Into<ResultsColorscheme> for &Theme {
     }
 }
 
+#[allow(clippy::from_over_into)]
 impl Into<PreviewColorscheme> for &Theme {
     fn into(self) -> PreviewColorscheme {
         PreviewColorscheme {
@@ -228,6 +234,7 @@ impl Into<PreviewColorscheme> for &Theme {
     }
 }
 
+#[allow(clippy::from_over_into)]
 impl Into<InputColorscheme> for &Theme {
     fn into(self) -> InputColorscheme {
         InputColorscheme {
@@ -237,6 +244,7 @@ impl Into<InputColorscheme> for &Theme {
     }
 }
 
+#[allow(clippy::from_over_into)]
 impl Into<ModeColorscheme> for &Theme {
     fn into(self) -> ModeColorscheme {
         ModeColorscheme {

--- a/crates/television/config/themes.rs
+++ b/crates/television/config/themes.rs
@@ -1,0 +1,372 @@
+use std::collections::HashMap;
+
+use config::ValueKind;
+use ratatui::style::Color as RatatuiColor;
+use serde::Deserialize;
+use television_screen::colors::{
+    Colorscheme, GeneralColorscheme, HelpColorscheme, InputColorscheme,
+    PreviewColorscheme, ResultsColorscheme,
+};
+
+#[derive(Clone, Debug, Default)]
+pub struct Color {
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+}
+
+impl Color {
+    pub fn new(r: u8, g: u8, b: u8) -> Self {
+        Self { r, g, b }
+    }
+
+    pub fn from_str(s: &str) -> Option<Self> {
+        let s = s.trim_start_matches('#');
+        let r = u8::from_str_radix(&s[0..2], 16).ok()?;
+        let g = u8::from_str_radix(&s[2..4], 16).ok()?;
+        let b = u8::from_str_radix(&s[4..6], 16).ok()?;
+        Some(Self { r, g, b })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Theme {
+    pub background: Color,
+    pub foreground: Color,
+    pub black: Color,
+    pub red: Color,
+    pub green: Color,
+    pub yellow: Color,
+    pub blue: Color,
+    pub magenta: Color,
+    pub cyan: Color,
+    pub white: Color,
+    pub bright_black: Color,
+    pub bright_red: Color,
+    pub bright_green: Color,
+    pub bright_yellow: Color,
+    pub bright_blue: Color,
+    pub bright_magenta: Color,
+    pub bright_cyan: Color,
+    pub bright_white: Color,
+}
+
+const DEFAULT_THEME: &str = r##"
+background = "#282c34"
+foreground = "#abb2bf"
+black = "#5c6370"
+red = "#e06c75"
+green = "#98c379"
+yellow = "#e5c07b"
+blue = "#61afef"
+magenta = "#c678dd"
+cyan = "#56b6c2"
+white = "#abb2bf"
+bright_black = "#5c6370"
+bright_red = "#e06c75"
+bright_green = "#98c379"
+bright_yellow = "#e5c07b"
+bright_blue = "#61afef"
+bright_magenta = "#c678dd"
+bright_cyan = "#56b6c2"
+bright_white = "#abb2bf"
+"##;
+
+impl Default for Theme {
+    fn default() -> Self {
+        toml::from_str(DEFAULT_THEME).unwrap()
+    }
+}
+
+impl<'de> Deserialize<'de> for Theme {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename = "theme")]
+        struct Inner {
+            background: String,
+            foreground: String,
+            black: String,
+            red: String,
+            green: String,
+            yellow: String,
+            blue: String,
+            magenta: String,
+            cyan: String,
+            white: String,
+            bright_black: String,
+            bright_red: String,
+            bright_green: String,
+            bright_yellow: String,
+            bright_blue: String,
+            bright_magenta: String,
+            bright_cyan: String,
+            bright_white: String,
+        }
+
+        let inner = Inner::deserialize(deserializer)?;
+        Ok(Self {
+            background: Color::from_str(&inner.background)
+                .ok_or_else(|| serde::de::Error::custom("invalid color"))?,
+            foreground: Color::from_str(&inner.foreground)
+                .ok_or_else(|| serde::de::Error::custom("invalid color"))?,
+            black: Color::from_str(&inner.black)
+                .ok_or_else(|| serde::de::Error::custom("invalid color"))?,
+            red: Color::from_str(&inner.red)
+                .ok_or_else(|| serde::de::Error::custom("invalid color"))?,
+            green: Color::from_str(&inner.green)
+                .ok_or_else(|| serde::de::Error::custom("invalid color"))?,
+            yellow: Color::from_str(&inner.yellow)
+                .ok_or_else(|| serde::de::Error::custom("invalid color"))?,
+            blue: Color::from_str(&inner.blue)
+                .ok_or_else(|| serde::de::Error::custom("invalid color"))?,
+            magenta: Color::from_str(&inner.magenta)
+                .ok_or_else(|| serde::de::Error::custom("invalid color"))?,
+            cyan: Color::from_str(&inner.cyan)
+                .ok_or_else(|| serde::de::Error::custom("invalid color"))?,
+            white: Color::from_str(&inner.white)
+                .ok_or_else(|| serde::de::Error::custom("invalid color"))?,
+            bright_black: Color::from_str(&inner.bright_black)
+                .ok_or_else(|| serde::de::Error::custom("invalid color"))?,
+            bright_red: Color::from_str(&inner.bright_red)
+                .ok_or_else(|| serde::de::Error::custom("invalid color"))?,
+            bright_green: Color::from_str(&inner.bright_green)
+                .ok_or_else(|| serde::de::Error::custom("invalid color"))?,
+            bright_yellow: Color::from_str(&inner.bright_yellow)
+                .ok_or_else(|| serde::de::Error::custom("invalid color"))?,
+            bright_blue: Color::from_str(&inner.bright_blue)
+                .ok_or_else(|| serde::de::Error::custom("invalid color"))?,
+            bright_magenta: Color::from_str(&inner.bright_magenta)
+                .ok_or_else(|| serde::de::Error::custom("invalid color"))?,
+            bright_cyan: Color::from_str(&inner.bright_cyan)
+                .ok_or_else(|| serde::de::Error::custom("invalid color"))?,
+            bright_white: Color::from_str(&inner.bright_white)
+                .ok_or_else(|| serde::de::Error::custom("invalid color"))?,
+        })
+    }
+}
+
+impl From<Theme> for ValueKind {
+    fn from(val: Theme) -> Self {
+        let mut m = HashMap::new();
+        m.insert(
+            String::from("background"),
+            ValueKind::String(format!(
+                "#{:02x}{:02x}{:02x}",
+                val.background.r, val.background.g, val.background.b
+            ))
+            .into(),
+        );
+        m.insert(
+            String::from("foreground"),
+            ValueKind::String(format!(
+                "#{:02x}{:02x}{:02x}",
+                val.foreground.r, val.foreground.g, val.foreground.b
+            ))
+            .into(),
+        );
+        m.insert(
+            String::from("black"),
+            ValueKind::String(format!(
+                "#{:02x}{:02x}{:02x}",
+                val.black.r, val.black.g, val.black.b
+            ))
+            .into(),
+        );
+        m.insert(
+            String::from("red"),
+            ValueKind::String(format!(
+                "#{:02x}{:02x}{:02x}",
+                val.red.r, val.red.g, val.red.b
+            ))
+            .into(),
+        );
+        m.insert(
+            String::from("green"),
+            ValueKind::String(format!(
+                "#{:02x}{:02x}{:02x}",
+                val.green.r, val.green.g, val.green.b
+            ))
+            .into(),
+        );
+        m.insert(
+            String::from("yellow"),
+            ValueKind::String(format!(
+                "#{:02x}{:02x}{:02x}",
+                val.yellow.r, val.yellow.g, val.yellow.b
+            ))
+            .into(),
+        );
+        m.insert(
+            String::from("blue"),
+            ValueKind::String(format!(
+                "#{:02x}{:02x}{:02x}",
+                val.blue.r, val.blue.g, val.blue.b
+            ))
+            .into(),
+        );
+        m.insert(
+            String::from("magenta"),
+            ValueKind::String(format!(
+                "#{:02x}{:02x}{:02x}",
+                val.magenta.r, val.magenta.g, val.magenta.b
+            ))
+            .into(),
+        );
+        m.insert(
+            String::from("cyan"),
+            ValueKind::String(format!(
+                "#{:02x}{:02x}{:02x}",
+                val.cyan.r, val.cyan.g, val.cyan.b
+            ))
+            .into(),
+        );
+        m.insert(
+            String::from("white"),
+            ValueKind::String(format!(
+                "#{:02x}{:02x}{:02x}",
+                val.white.r, val.white.g, val.white.b
+            ))
+            .into(),
+        );
+        m.insert(
+            String::from("bright_black"),
+            ValueKind::String(format!(
+                "#{:02x}{:02x}{:02x}",
+                val.bright_black.r, val.bright_black.g, val.bright_black.b
+            ))
+            .into(),
+        );
+        m.insert(
+            String::from("bright_red"),
+            ValueKind::String(format!(
+                "#{:02x}{:02x}{:02x}",
+                val.bright_red.r, val.bright_red.g, val.bright_red.b
+            ))
+            .into(),
+        );
+        m.insert(
+            String::from("bright_green"),
+            ValueKind::String(format!(
+                "#{:02x}{:02x}{:02x}",
+                val.bright_green.r, val.bright_green.g, val.bright_green.b
+            ))
+            .into(),
+        );
+        m.insert(
+            String::from("bright_yellow"),
+            ValueKind::String(format!(
+                "#{:02x}{:02x}{:02x}",
+                val.bright_yellow.r, val.bright_yellow.g, val.bright_yellow.b
+            ))
+            .into(),
+        );
+        m.insert(
+            String::from("bright_blue"),
+            ValueKind::String(format!(
+                "#{:02x}{:02x}{:02x}",
+                val.bright_blue.r, val.bright_blue.g, val.bright_blue.b
+            ))
+            .into(),
+        );
+        m.insert(
+            String::from("bright_magenta"),
+            ValueKind::String(format!(
+                "#{:02x}{:02x}{:02x}",
+                val.bright_magenta.r,
+                val.bright_magenta.g,
+                val.bright_magenta.b
+            ))
+            .into(),
+        );
+        m.insert(
+            String::from("bright_cyan"),
+            ValueKind::String(format!(
+                "#{:02x}{:02x}{:02x}",
+                val.bright_cyan.r, val.bright_cyan.g, val.bright_cyan.b
+            ))
+            .into(),
+        );
+        m.insert(
+            String::from("bright_white"),
+            ValueKind::String(format!(
+                "#{:02x}{:02x}{:02x}",
+                val.bright_white.r, val.bright_white.g, val.bright_white.b
+            ))
+            .into(),
+        );
+        ValueKind::Table(m)
+    }
+}
+
+impl Into<RatatuiColor> for &Color {
+    fn into(self) -> RatatuiColor {
+        RatatuiColor::Rgb(self.r, self.g, self.b)
+    }
+}
+
+impl Into<Colorscheme> for &Theme {
+    fn into(self) -> Colorscheme {
+        Colorscheme {
+            general: self.into(),
+            help: self.into(),
+            results: self.into(),
+            preview: self.into(),
+            input: self.into(),
+        }
+    }
+}
+
+impl Into<GeneralColorscheme> for &Theme {
+    fn into(self) -> GeneralColorscheme {
+        GeneralColorscheme {
+            background: (&self.background).into(),
+            border_fg: (&self.bright_black).into(),
+        }
+    }
+}
+
+impl Into<HelpColorscheme> for &Theme {
+    fn into(self) -> HelpColorscheme {
+        HelpColorscheme {
+            action_fg: (&self.bright_black).into(),
+            metadata_field_name_fg: (&self.bright_black).into(),
+            metadata_field_value_fg: (&self.bright_white).into(),
+        }
+    }
+}
+
+impl Into<ResultsColorscheme> for &Theme {
+    fn into(self) -> ResultsColorscheme {
+        ResultsColorscheme {
+            result_name_fg: (&self.blue).into(),
+            result_preview_fg: (&self.bright_white).into(),
+            result_line_number_fg: (&self.yellow).into(),
+            result_selected_bg: (&self.bright_black).into(),
+            match_foreground_color: (&self.red).into(),
+        }
+    }
+}
+
+impl Into<PreviewColorscheme> for &Theme {
+    fn into(self) -> PreviewColorscheme {
+        PreviewColorscheme {
+            title_fg: (&self.bright_blue).into(),
+            highlight_bg: (&self.bright_black).into(),
+            content_fg: (&self.bright_white).into(),
+            gutter_fg: (&self.bright_black).into(),
+            gutter_selected_fg: (&self.red).into(),
+        }
+    }
+}
+
+impl Into<InputColorscheme> for &Theme {
+    fn into(self) -> InputColorscheme {
+        InputColorscheme {
+            input_fg: (&self.bright_red).into(),
+            results_count_fg: (&self.red).into(),
+        }
+    }
+}

--- a/crates/television/config/themes/builtin.rs
+++ b/crates/television/config/themes/builtin.rs
@@ -1,0 +1,19 @@
+use std::collections::HashMap;
+
+use lazy_static::lazy_static;
+
+lazy_static! {
+    pub static ref BUILTIN_THEMES: HashMap<&'static str, &'static str> = {
+        let mut m = HashMap::new();
+        m.insert(
+            "gruvbox-dark",
+            include_str!("../../../../themes/gruvbox-dark.toml"),
+        );
+        m.insert(
+            "catppuccin",
+            include_str!("../../../../themes/catppuccin.toml"),
+        );
+        m.insert("nord", include_str!("../../../../themes/nord.toml"));
+        m
+    };
+}

--- a/crates/television/config/themes/builtin.rs
+++ b/crates/television/config/themes/builtin.rs
@@ -14,6 +14,10 @@ lazy_static! {
             include_str!("../../../../themes/catppuccin.toml"),
         );
         m.insert("nord", include_str!("../../../../themes/nord.toml"));
+        m.insert(
+            "solarized-dark",
+            include_str!("../../../../themes/solarized-dark.toml"),
+        );
         m
     };
 }

--- a/crates/television/config/ui.rs
+++ b/crates/television/config/ui.rs
@@ -4,6 +4,8 @@ use std::collections::HashMap;
 
 use television_screen::layout::InputPosition;
 
+use super::themes::DEFAULT_THEME;
+
 const DEFAULT_UI_SCALE: u16 = 90;
 
 #[derive(Clone, Debug, Deserialize)]
@@ -13,6 +15,7 @@ pub struct UiConfig {
     pub show_help_bar: bool,
     #[serde(default)]
     pub input_bar_position: InputPosition,
+    pub theme: String,
 }
 
 impl Default for UiConfig {
@@ -22,6 +25,7 @@ impl Default for UiConfig {
             ui_scale: DEFAULT_UI_SCALE,
             show_help_bar: true,
             input_bar_position: InputPosition::Bottom,
+            theme: String::from(DEFAULT_THEME),
         }
     }
 }
@@ -45,6 +49,7 @@ impl From<UiConfig> for ValueKind {
             String::from("input_position"),
             ValueKind::String(val.input_bar_position.to_string()).into(),
         );
+        m.insert(String::from("theme"), ValueKind::String(val.theme).into());
         ValueKind::Table(m)
     }
 }

--- a/crates/television/television.rs
+++ b/crates/television/television.rs
@@ -1,7 +1,7 @@
-use crate::config::KeyBindings;
+use crate::action::Action;
+use crate::config::{Config, KeyBindings};
 use crate::input::convert_action_to_input_request;
 use crate::picker::Picker;
-use crate::{action::Action, config::Config};
 use crate::{cable::load_cable_channels, keymap::Keymap};
 use color_eyre::Result;
 use copypasta::{ClipboardContext, ClipboardProvider};
@@ -415,6 +415,7 @@ impl Television {
             ),
             self.mode,
             &self.app_metadata,
+            &(&self.config.theme).into(),
         );
 
         self.results_area_height =
@@ -439,6 +440,7 @@ impl Television {
             self.config.ui.input_bar_position,
             self.config.ui.use_nerd_font_icons,
             &mut self.icon_color_cache,
+            &(&self.config.theme).into(),
         )?;
 
         // input box

--- a/crates/television/television.rs
+++ b/crates/television/television.rs
@@ -1,5 +1,5 @@
 use crate::action::Action;
-use crate::config::{Config, KeyBindings};
+use crate::config::{Config, KeyBindings, Theme};
 use crate::input::convert_action_to_input_request;
 use crate::picker::Picker;
 use crate::{cable::load_cable_channels, keymap::Keymap};
@@ -15,6 +15,7 @@ use television_channels::channels::{
 use television_channels::entry::{Entry, ENTRY_PLACEHOLDER};
 use television_previewers::previewers::Previewer;
 use television_screen::cache::RenderedPreviewCache;
+use television_screen::colors::Colorscheme;
 use television_screen::help::draw_help_bar;
 use television_screen::input::draw_input_box;
 use television_screen::keybindings::{
@@ -52,6 +53,7 @@ pub struct Television {
     pub(crate) spinner: Spinner,
     pub(crate) spinner_state: SpinnerState,
     pub app_metadata: AppMetadata,
+    pub colorscheme: Colorscheme,
 }
 
 impl Television {
@@ -77,6 +79,7 @@ impl Television {
                 .to_string_lossy()
                 .to_string(),
         );
+        let colorscheme = (&Theme::from_name(&config.ui.theme)).into();
 
         channel.find(EMPTY_STRING);
         let spinner = Spinner::default();
@@ -104,6 +107,7 @@ impl Television {
             spinner,
             spinner_state: SpinnerState::from(&spinner),
             app_metadata,
+            colorscheme,
         }
     }
 
@@ -412,10 +416,11 @@ impl Television {
             build_keybindings_table(
                 &self.config.keybindings.to_displayable(),
                 self.mode,
+                &self.colorscheme,
             ),
             self.mode,
             &self.app_metadata,
-            &(&self.config.theme).into(),
+            &self.colorscheme,
         );
 
         self.results_area_height =
@@ -440,7 +445,7 @@ impl Television {
             self.config.ui.input_bar_position,
             self.config.ui.use_nerd_font_icons,
             &mut self.icon_color_cache,
-            &(&self.config.theme).into(),
+            &self.colorscheme,
         )?;
 
         // input box
@@ -454,6 +459,7 @@ impl Television {
             self.channel.running(),
             &self.spinner,
             &mut self.spinner_state,
+            &self.colorscheme,
         )?;
 
         let selected_entry = self
@@ -468,6 +474,7 @@ impl Television {
             layout.preview_title,
             &preview,
             self.config.ui.use_nerd_font_icons,
+            &self.colorscheme,
         )?;
 
         // preview content
@@ -485,6 +492,7 @@ impl Television {
             &preview,
             &self.rendered_preview_cache,
             self.preview_scroll.unwrap_or(0),
+            &self.colorscheme,
         );
 
         // remote control
@@ -507,6 +515,8 @@ impl Television {
                 &mut self.rc_picker.state,
                 &mut self.rc_picker.input,
                 &mut self.icon_color_cache,
+                &self.mode,
+                &self.colorscheme,
             )?;
         }
         Ok(())

--- a/themes/catppuccin.toml
+++ b/themes/catppuccin.toml
@@ -1,0 +1,19 @@
+# general
+border_fg = '#6c7086'
+text_fg = '#cdd6f4'
+dimmed_text_fg = '#6c7086'
+# input
+input_text_fg = '#f38ba8'
+result_count_fg = '#f38ba8'
+# results
+result_name_fg = '#b4befe'
+result_line_number_fg = '#f9e2af'
+result_value_fg = '#a6adc8'
+selection_bg = '#313244'
+match_fg = '#f38ba8'
+# preview
+preview_title_fg = '#fab387'
+# modes
+channel_mode_fg = '#f5c2e7'
+remote_control_mode_fg = '#a6e3a1'
+send_to_channel_mode_fg = '#89dceb'

--- a/themes/gruvbox-dark.toml
+++ b/themes/gruvbox-dark.toml
@@ -1,0 +1,19 @@
+# general
+border_fg = '#928374'
+text_fg = '#ebdbb2'
+dimmed_text_fg = '#a89984'
+# input
+input_text_fg = '#fb4934'
+result_count_fg = '#cc241d'
+# results
+result_name_fg = '#83a598'
+result_line_number_fg = '#fabd2f'
+result_value_fg = '#ebdbb2'
+selection_bg = '#32302f'
+match_fg = '#fb4934'
+# preview
+preview_title_fg = '#b8bb26'
+# modes
+channel_mode_fg = '#b16286'
+remote_control_mode_fg = '#8ec07c'
+send_to_channel_mode_fg = '#458588'

--- a/themes/nord.toml
+++ b/themes/nord.toml
@@ -1,0 +1,19 @@
+# general
+border_fg = '#434c5e'
+text_fg = '#d8dee9'
+dimmed_text_fg = '#4c566a'
+# input
+input_text_fg = '#bf616a'
+result_count_fg = '#bf616a'
+# results
+result_name_fg = '#81a1c1'
+result_line_number_fg = '#ebcb8b'
+result_value_fg = '#d8dee9'
+selection_bg = '#3b4252'
+match_fg = '#bf616a'
+# preview
+preview_title_fg = '#8fbcbb'
+# modes
+channel_mode_fg = '#b48ead'
+remote_control_mode_fg = '#a3be8c'
+send_to_channel_mode_fg = '#d08770'

--- a/themes/solarized-dark.toml
+++ b/themes/solarized-dark.toml
@@ -1,0 +1,19 @@
+# general
+border_fg = '#586e75'
+text_fg = '#eee8d5'
+dimmed_text_fg = '#93a1a1'
+# input
+input_text_fg = '#cb4b16'
+result_count_fg = '#cb4b16'
+# results
+result_name_fg = '#268bd2'
+result_line_number_fg = '#b58900'
+result_value_fg = '#657b83'
+selection_bg = '#073642'
+match_fg = '#cb4b16'
+# preview
+preview_title_fg = '#859900'
+# modes
+channel_mode_fg = '#2aa198'
+remote_control_mode_fg = '#859900'
+send_to_channel_mode_fg = '#dc322f'


### PR DESCRIPTION
fixes #80 

### examples
| gruvbox | solarized |
| :-: | :-: |
| <img width="1792" alt="gruvbox" src="https://github.com/user-attachments/assets/c0c168a5-5c95-4113-93fd-24b34a9344d8" /> | ![Screenshot 2024-12-13 at 14 38 57](https://github.com/user-attachments/assets/368e3e37-7fdd-493a-8c0b-47e3731ae67b) |
