### PR TITLE
fix: bump version to match with the release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2988,7 +2988,7 @@ dependencies = [
 
 [[package]]
 name = "television"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "better-panic",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "television"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 description = "The revolution will be televised."
 license = "MIT"


### PR DESCRIPTION
👋 seeing some version mismatch with the release build. 

relates to https://github.com/Homebrew/homebrew-core/pull/202798