### PR TITLE
perf(bin): compile binary as a single code unit and use fat LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,8 @@ debug = true
 
 
 [profile.release]
-lto = "thin"
+codegen-units = 1
+lto = "fat"
 
 [profile.deb]
 inherits = "release"


### PR DESCRIPTION
Fixes #185 

> Release + codegen-units = 1: 11 Mib
Release + Thin LTO (current default): 14 Mib
Release + Fat LTO: 11 Mib
Release + codegen-units = 1 + Fat LTO: 9.7 Mib
Release + codegen-units = 1 + Thin LTO: 11 Mib