### PR TITLE
fix: automatically create configuration directory if it doesnt exist

### DIFF
--- a/crates/television/config.rs
+++ b/crates/television/config.rs
@@ -83,7 +83,10 @@ impl Config {
         // initialize the config builder
         let data_dir = get_data_dir();
         let config_dir = get_config_dir();
-        std::fs::create_dir_all(config_dir.clone()).expect("Failed creating configuration directory");
+        std::fs::create_dir_all(&config_dir)
+            .expect("Failed creating configuration directory");
+        std::fs::create_dir_all(&data_dir)
+            .expect("Failed creating data directory");
 
         let mut builder = config::Config::builder()
             .set_default("data_dir", data_dir.to_str().unwrap())?

--- a/crates/television/config.rs
+++ b/crates/television/config.rs
@@ -83,6 +83,8 @@ impl Config {
         // initialize the config builder
         let data_dir = get_data_dir();
         let config_dir = get_config_dir();
+        std::fs::create_dir_all(config_dir.clone()).expect("Failed creating configuration directory");
+
         let mut builder = config::Config::builder()
             .set_default("data_dir", data_dir.to_str().unwrap())?
             .set_default("config_dir", config_dir.to_str().unwrap())?


### PR DESCRIPTION
I've noticed that the latest release (0.85.0) failed to start up if `$HOME/.config/television` doesnt exist. This should force the directory creation if the user doesn't have it.

Before:
![image](https://github.com/user-attachments/assets/d54245f7-e9b7-4baf-87d9-75869821e519)

After:
![image](https://github.com/user-attachments/assets/e0af2a16-987f-4943-85e7-59d427f64abb)

