### PR TITLE
feat(cable) keep data input order

### DIFF
--- a/crates/television-channels/Cargo.toml
+++ b/crates/television-channels/Cargo.toml
@@ -29,6 +29,7 @@ strum = { version = "0.26.3", features = ["derive"] }
 lazy_static = "1.5.0"
 toml = "0.8.19"
 regex = "1.11.1"
+indexmap = "2.7.0"
 
 [lints]
 workspace = true

--- a/crates/television-channels/src/channels/cable.rs
+++ b/crates/television-channels/src/channels/cable.rs
@@ -1,7 +1,7 @@
 use color_eyre::Result;
+use indexmap::IndexSet;
 use lazy_static::lazy_static;
 use regex::Regex;
-use std::collections::HashSet;
 use tracing::debug;
 
 use crate::cable::{CableChannelPrototype, DEFAULT_DELIMITER};
@@ -108,7 +108,7 @@ async fn load_candidates(command: String, injector: Injector<String>) {
     let decoded_output = String::from_utf8(output.stdout).unwrap();
     debug!("Decoded output: {:?}", decoded_output);
 
-    for line in decoded_output.lines().collect::<HashSet<_>>() {
+    for line in decoded_output.lines().collect::<IndexSet<_>>() {
         if !line.trim().is_empty() {
             let () = injector.push(line.to_string(), |e, cols| {
                 cols[0] = e.clone().into();


### PR DESCRIPTION
Hey, I had issues with the git log order getting shuffled in `tv git-log`.

If you want to add another dependency, `IndexSet` from [indexmap](https://crates.io/crates/indexmap), would do the same thing as the `HashSet` AND preserve order with roughly the same performance [rustc PR45282](https://github.com/rust-lang/rust/pull/45282). Also, `indexmap` is already included in the dependency tree, so this shouldn't really affect compile times either. Cheers