### PR TITLE
fix(ingestion): use lossy conversion when source doesn't produce valid utf8

### DIFF
--- a/crates/television-channels/src/channels/alias.rs
+++ b/crates/television-channels/src/channels/alias.rs
@@ -44,7 +44,7 @@ fn get_raw_aliases(shell: &str) -> Vec<String> {
         .arg("alias")
         .output()
         .expect("failed to execute process");
-    let aliases = String::from_utf8(output.stdout).unwrap();
+    let aliases = String::from_utf8_lossy(&output.stdout);
     aliases.lines().map(ToString::to_string).collect()
 }
 

--- a/crates/television-channels/src/channels/cable.rs
+++ b/crates/television-channels/src/channels/cable.rs
@@ -109,7 +109,7 @@ async fn load_candidates(command: String, injector: Injector<String>) {
         .output()
         .expect("failed to execute process");
 
-    let decoded_output = String::from_utf8(output.stdout).unwrap();
+    let decoded_output = String::from_utf8_lossy(&output.stdout);
     debug!("Decoded output: {:?}", decoded_output);
 
     for line in decoded_output.lines().collect::<HashSet<_>>() {

--- a/crates/television-previewers/src/previewers/command.rs
+++ b/crates/television-previewers/src/previewers/command.rs
@@ -160,11 +160,10 @@ pub fn try_preview(
         .expect("failed to execute process");
 
     if output.status.success() {
-        let content = String::from_utf8(output.stdout)
-            .unwrap_or(String::from("Failed to read output\n"));
+        let content = String::from_utf8_lossy(&output.stdout);
         let preview = Arc::new(Preview::new(
             entry.name.clone(),
-            PreviewContent::AnsiText(content),
+            PreviewContent::AnsiText(content.to_string()),
             None,
             false,
         ));
@@ -173,11 +172,10 @@ pub fn try_preview(
         let mut tp = last_previewed.lock();
         *tp = preview.stale().into();
     } else {
-        let content = String::from_utf8(output.stderr)
-            .unwrap_or(String::from("Failed to read error\n"));
+        let content = String::from_utf8_lossy(&output.stderr);
         let preview = Arc::new(Preview::new(
             entry.name.clone(),
-            PreviewContent::AnsiText(content),
+            PreviewContent::AnsiText(content.to_string()),
             None,
             false,
         ));


### PR DESCRIPTION
Fixes #233 