### PR TITLE
fix(ansi): catch implicit reset escape sequences

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3100,6 +3100,7 @@ dependencies = [
  "television-channels",
  "television-previewers",
  "television-utils",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/television-screen/Cargo.toml
+++ b/crates/television-screen/Cargo.toml
@@ -22,6 +22,7 @@ serde = { workspace = true }
 color-eyre = { workspace = true }
 syntect = { workspace = true }
 rustc-hash = { workspace = true }
+tracing = { workspace = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Fixes #232 

<img width="2549" alt="Screenshot 2025-01-07 at 16 04 15" src="https://github.com/user-attachments/assets/18be9901-757e-47a4-aa70-89aa7fc75e84" />
