### PR TITLE
fix(fish): don't add extra space to prompt if it's an implicit cd (`\.`)

### DIFF
--- a/crates/television-utils/shell/completion.fish
+++ b/crates/television-utils/shell/completion.fish
@@ -4,8 +4,8 @@ function tv_smart_autocomplete
     set -l output (tv --autocomplete-prompt "$current_prompt")
 
     if test -n "$output"
-        # add a space if the prompt does not end with one
-        string match -q "* " -- "$current_prompt" || set current_prompt "$current_prompt "
+        # add a space if the prompt does not end with one (unless the prompt is an implicit cd, e.g. '\.')
+        string match -r '.*( |./)$' -- "$current_prompt" || set current_prompt "$current_prompt "
         commandline -r "$current_prompt$output"
     end
 end


### PR DESCRIPTION
Fixes #256 