### PR TITLE
fix: Add repaint command to the fish shell scripts

### DIFF
--- a/crates/television-utils/shell/completion.fish
+++ b/crates/television-utils/shell/completion.fish
@@ -7,6 +7,7 @@ function tv_smart_autocomplete
         # add a space if the prompt does not end with one (unless the prompt is an implicit cd, e.g. '\.')
         string match -r '.*( |./)$' -- "$current_prompt" || set current_prompt "$current_prompt "
         commandline -r "$current_prompt$output"
+        commandline -f repaint
     end
 end
 
@@ -17,6 +18,7 @@ function tv_shell_history
 
     if test -n "$output"
         commandline -r "$output"
+        commandline -f repaint
     end
 end
 


### PR DESCRIPTION
The call ensures that the prompt restores properly and looks correct after using television. This fixes #300 for me locally.