### PR TITLE
fix(stdout): never quote selected entries

### DIFF
--- a/television/app.rs
+++ b/television/app.rs
@@ -271,6 +271,7 @@ impl App {
                     {
                         return Ok(ActionOutcome::Entries(entries));
                     }
+
                     return Ok(ActionOutcome::Input(
                         self.television.lock().await.current_pattern.clone(),
                     ));

--- a/television/channels/alias.rs
+++ b/television/channels/alias.rs
@@ -170,7 +170,7 @@ async fn load_aliases(injector: Injector<Alias>) {
             None
         })
         .for_each(|alias| {
-            let () = injector.push(alias.clone(), |e, cols| {
+            let () = injector.push(alias, |e, cols| {
                 cols[0] = (e.name.clone() + &e.value).into();
             });
         });

--- a/television/channels/cable.rs
+++ b/television/channels/cable.rs
@@ -159,7 +159,7 @@ impl OnAir for Channel {
             .map(|item| {
                 let path = item.matched_string;
                 Entry::new(
-                    path.clone(),
+                    path,
                     match &self.preview_kind {
                         PreviewKind::Command(ref preview_command) => {
                             PreviewType::Command(preview_command.clone())
@@ -179,7 +179,7 @@ impl OnAir for Channel {
         self.matcher.get_result(index).map(|item| {
             let path = item.matched_string;
             Entry::new(
-                path.clone(),
+                path,
                 match &self.preview_kind {
                     PreviewKind::Command(ref preview_command) => {
                         PreviewType::Command(preview_command.clone())

--- a/television/channels/entry.rs
+++ b/television/channels/entry.rs
@@ -1,7 +1,6 @@
 use std::{
     fmt::Display,
     hash::{Hash, Hasher},
-    path::PathBuf,
 };
 
 use devicons::FileIcon;
@@ -143,12 +142,6 @@ impl Entry {
 
     pub fn stdout_repr(&self) -> String {
         let mut repr = self.name.clone();
-        if PathBuf::from(&repr).exists()
-            && repr.contains(|c| char::is_ascii_whitespace(&c))
-        {
-            repr.insert(0, '\'');
-            repr.push('\'');
-        }
         if let Some(line_number) = self.line_number {
             repr.push_str(&format!(":{line_number}"));
         }
@@ -225,5 +218,33 @@ mod tests {
     fn test_non_contiguous_ranges() {
         let ranges = vec![(1, 2), (3, 4), (5, 6)];
         assert_eq!(merge_ranges(&ranges), vec![(1, 2), (3, 4), (5, 6)]);
+    }
+
+    #[test]
+    fn test_leaves_name_intact() {
+        let entry = Entry {
+            name: "test name with spaces".to_string(),
+            value: None,
+            name_match_ranges: None,
+            value_match_ranges: None,
+            icon: None,
+            line_number: None,
+            preview_type: PreviewType::Basic,
+        };
+        assert_eq!(entry.stdout_repr(), "test name with spaces");
+    }
+    #[test]
+    fn test_uses_line_number_information() {
+        let a: usize = 10;
+        let entry = Entry {
+            name: "test_file_name.rs".to_string(),
+            value: None,
+            name_match_ranges: None,
+            value_match_ranges: None,
+            icon: None,
+            line_number: Some(a),
+            preview_type: PreviewType::Basic,
+        };
+        assert_eq!(entry.stdout_repr(), "test_file_name.rs:10");
     }
 }

--- a/television/channels/git_repos.rs
+++ b/television/channels/git_repos.rs
@@ -64,12 +64,9 @@ impl OnAir for Channel {
             .into_iter()
             .map(|item| {
                 let path = item.matched_string;
-                Entry::new(
-                    path.clone(),
-                    PreviewType::Command(PREVIEW_COMMAND.clone()),
-                )
-                .with_name_match_ranges(&item.match_indices)
-                .with_icon(self.icon)
+                Entry::new(path, PreviewType::Command(PREVIEW_COMMAND.clone()))
+                    .with_name_match_ranges(&item.match_indices)
+                    .with_icon(self.icon)
             })
             .collect()
     }
@@ -77,11 +74,8 @@ impl OnAir for Channel {
     fn get_result(&self, index: u32) -> Option<Entry> {
         self.matcher.get_result(index).map(|item| {
             let path = item.matched_string;
-            Entry::new(
-                path.clone(),
-                PreviewType::Command(PREVIEW_COMMAND.clone()),
-            )
-            .with_icon(self.icon)
+            Entry::new(path, PreviewType::Command(PREVIEW_COMMAND.clone()))
+                .with_icon(self.icon)
         })
     }
 

--- a/television/channels/remote_control.rs
+++ b/television/channels/remote_control.rs
@@ -78,9 +78,9 @@ impl RemoteControl {
             .as_ref()
             .and_then(|channels| channels.get(channel_name).cloned())
         {
-            Some(prototype) => Ok(TelevisionChannel::Cable(
-                cable::Channel::from(prototype.clone()),
-            )),
+            Some(prototype) => {
+                Ok(TelevisionChannel::Cable(cable::Channel::from(prototype)))
+            }
             None => match UnitChannel::try_from(channel_name) {
                 Ok(channel) => Ok(channel.into()),
                 Err(_) => Err(color_eyre::eyre::eyre!(

--- a/television/channels/stdin.rs
+++ b/television/channels/stdin.rs
@@ -91,7 +91,7 @@ impl OnAir for Channel {
 
     fn get_result(&self, index: u32) -> Option<Entry> {
         self.matcher.get_result(index).map(|item| {
-            Entry::new(item.matched_string.clone(), self.preview_type.clone())
+            Entry::new(item.matched_string, self.preview_type.clone())
         })
     }
 

--- a/television/television.rs
+++ b/television/television.rs
@@ -423,9 +423,7 @@ impl Television {
                                 .iter()
                                 .map(|e| e.name.clone())
                                 .collect::<Vec<_>>()
-                                .join(" ")
-                                .to_string()
-                                .to_string(),
+                                .join(" "),
                         )
                         .unwrap();
                     }


### PR DESCRIPTION
fixes #284

the outcome of entry selection quoting was not consistent depending on whether the entry existed on the filesystem or not

this PR removes all entry quoting, making the behaviour consistent and predictible

- remove quoting of entries in Entry#stdout_repr
- apply clippy suggestions for redundant clones