### PR TITLE
chore(cd): automatically bump winget-pkgs registered version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -12,9 +12,7 @@ jobs:
   publish:
     runs-on: windows-latest
     steps:
-      # Avoid using commit hash specifiers until dependabot/renovatebot is introduced.
-      # See the background: https://github.com/vedantmgoyal9/winget-releaser/blob/4ffc7888bffd451b357355dc214d43bb9f23917e/README.md?plain=1#L36-L37
-      - uses: vedantmgoyal9/winget-releaser@v2
+      - uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
         with:
           identifier: 'alexpasmantier.television'
           installers-regex: '-windows-x86_64\.zip$'

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,22 @@
+name: Publish to WinGet
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Specific tag name'
+        required: true
+        type: string
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      # Avoid using commit hash specifiers until dependabot/renovatebot is introduced.
+      # See the background: https://github.com/vedantmgoyal9/winget-releaser/blob/4ffc7888bffd451b357355dc214d43bb9f23917e/README.md?plain=1#L36-L37
+      - uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: 'alexpasmantier.television'
+          installers-regex: '-windows-x86_64\.zip$'
+          max-versions-to-keep: 5
+          token: ${{ secrets.PAT_FOR_WINGET_RELEASER }}


### PR DESCRIPTION
Resolves #332

ref: https://github.com/microsoft/winget-pkgs/pull/220105, #298

I have added the [winget section in wiki](https://github.com/alexpasmantier/television/wiki/Installation/_compare/2e18237501fab83f8428244c81055c0a4a09dcf8...5695e45a363239f0889d371d949029803f3077af).

This PR aims to keep latest version in the winget-pkgs.
[This action](https://github.com/vedantmgoyal9/winget-releaser) is widely used for this purpose.

- https://github.com/sharkdp/fd/blob/3a56c32a1c661c2cf615d6936b3032fcedc6faff/.github/workflows/CICD.yml#L261
- https://github.com/junegunn/fzf/blob/bbe1721a1883426f639c1efe6afef1d3e6c25181/.github/workflows/winget.yml#L10

However I couldn't test this action in my environment. Could you test after registering the secret?

Feel free to modify the code and/or secret name in this PR.


