### PR TITLE
fix(windows): bypass mouse capture disabling on windows

### DIFF
--- a/television/tui.rs
+++ b/television/tui.rs
@@ -44,7 +44,9 @@ where
         let mut buffered_stderr = LineWriter::new(stderr());
         execute!(buffered_stderr, EnterAlternateScreen)?;
         self.terminal.clear()?;
-        execute!(buffered_stderr, DisableMouseCapture)?;
+        if cfg!(not(windows)) {
+            execute!(buffered_stderr, DisableMouseCapture)?;
+        }
         Ok(())
     }
 


### PR DESCRIPTION
Fixes #338 

<img width="1838" alt="Screenshot 2025-02-07 at 20 15 42" src="https://github.com/user-attachments/assets/dd818856-7719-4def-a023-c1efbf5ea790" />
