### PR TITLE
update rust toolchain hash

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
             pkgs.rustChannelOf
             {
               rustToolchain = ./rust-toolchain.toml;
-              sha256 = "VZZnlyP69+Y3crrLHQyJirqlHrTtGTsyiSnZB8jEvVo=";
+              sha256 = "s1RPtyvDGJaX/BisLT+ifVfuhDT1nZkZ1NcK8sbwELM=";
             }
           )
           .rust;


### PR DESCRIPTION
Hey again, just realized there was an update with toolchain change 1.81 -> 1.83, so updating the hash for it :)