### PR TITLE
feat(shell): allow mapping ctrl-space for builtin shell autocomplete integration

### DIFF
--- a/television/config/keybindings.rs
+++ b/television/config/keybindings.rs
@@ -196,7 +196,7 @@ fn parse_key_code_with_modifiers(
         "f10" => KeyCode::F(10),
         "f11" => KeyCode::F(11),
         "f12" => KeyCode::F(12),
-        "space" => KeyCode::Char(' '),
+        "space" | " " => KeyCode::Char(' '),
         "hyphen" | "minus" => KeyCode::Char('-'),
         "tab" => KeyCode::Tab,
         c if c.len() == 1 => {

--- a/television/config/shell_integration.rs
+++ b/television/config/shell_integration.rs
@@ -52,6 +52,7 @@ impl ShellIntegrationConfig {
         match self.keybindings.get(SMART_AUTOCOMPLETE_CONFIGURATION_KEY) {
             Some(s) => match parse_key(s) {
                 Ok(Key::Ctrl(c)) => c.to_uppercase().next().unwrap(),
+                Ok(Key::CtrlSpace) => ' ',
                 _ => DEFAULT_SHELL_AUTOCOMPLETE_KEY,
             },
             None => DEFAULT_SHELL_AUTOCOMPLETE_KEY,
@@ -64,6 +65,7 @@ impl ShellIntegrationConfig {
         match self.keybindings.get(COMMAND_HISTORY_CONFIGURATION_KEY) {
             Some(s) => match parse_key(s) {
                 Ok(Key::Ctrl(c)) => c.to_uppercase().next().unwrap(),
+                Ok(Key::CtrlSpace) => ' ',
                 _ => DEFAULT_COMMAND_HISTORY_KEY,
             },
             None => DEFAULT_COMMAND_HISTORY_KEY,


### PR DESCRIPTION
fixes #366 