### PR TITLE
fix(zsh): use history command to include recent entries

### DIFF
--- a/television/utils/shell/completion.zsh
+++ b/television/utils/shell/completion.zsh
@@ -32,8 +32,7 @@ _tv_shell_history() {
 
     local output
 
-    output=$(tv zsh-history --input "$current_prompt" $*)
-
+    output=$(history -n -1 0 | tv --input "$current_prompt" $*)
 
     if [[ -n $output ]]; then
         zle reset-prompt


### PR DESCRIPTION
Problem: The `_tv_shell_history` command does not include the most recent entries in that shell's history.

It uses the `zsh-history` channel, but that's flawed because only the current shell knows its most recent history; it has not yet been written to `$HISTFILE`.

Instead, take input from the shell's history command.