### PR TITLE
feat(cli): allow passing builtin previewers through the cli (e.g. `--preview ':files:'`)

### DIFF
--- a/television/channels/cable.rs
+++ b/television/channels/cable.rs
@@ -19,8 +19,8 @@ use crate::matcher::Matcher;
 use crate::matcher::{config::Config, injector::Injector};
 use crate::utils::command::shell_command;
 
-#[derive(Debug, Clone)]
-enum PreviewKind {
+#[derive(Debug, Clone, PartialEq)]
+pub enum PreviewKind {
     Command(PreviewCommand),
     Builtin(PreviewType),
     None,
@@ -63,7 +63,7 @@ impl From<CableChannelPrototype> for Channel {
     }
 }
 
-fn parse_preview_kind(command: &PreviewCommand) -> Result<PreviewKind> {
+pub fn parse_preview_kind(command: &PreviewCommand) -> Result<PreviewKind> {
     debug!("Parsing preview kind for command: {:?}", command);
     let re = Regex::new(r"^\:(\w+)\:$").unwrap();
     if let Some(captures) = re.captures(&command.command) {

--- a/television/channels/stdin.rs
+++ b/television/channels/stdin.rs
@@ -18,7 +18,7 @@ pub struct Channel {
 }
 
 impl Channel {
-    pub fn new(preview_type: Option<PreviewType>) -> Self {
+    pub fn new(preview_type: PreviewType) -> Self {
         let matcher = Matcher::new(Config::default());
         let injector = matcher.injector();
 
@@ -26,7 +26,7 @@ impl Channel {
 
         Self {
             matcher,
-            preview_type: preview_type.unwrap_or_default(),
+            preview_type,
             selected_entries: HashSet::with_hasher(FxBuildHasher),
         }
     }
@@ -34,7 +34,7 @@ impl Channel {
 
 impl Default for Channel {
     fn default() -> Self {
-        Self::new(None)
+        Self::new(PreviewType::default())
     }
 }
 

--- a/television/utils/shell.rs
+++ b/television/utils/shell.rs
@@ -1,5 +1,7 @@
+use crate::cli::args::Shell as CliShell;
 use crate::config::shell_integration::ShellIntegrationConfig;
 use anyhow::Result;
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Shell {
     Bash,
@@ -7,6 +9,30 @@ pub enum Shell {
     Fish,
     PowerShell,
     Cmd,
+}
+
+impl From<CliShell> for Shell {
+    fn from(val: CliShell) -> Self {
+        match val {
+            CliShell::Bash => Shell::Bash,
+            CliShell::Zsh => Shell::Zsh,
+            CliShell::Fish => Shell::Fish,
+            CliShell::PowerShell => Shell::PowerShell,
+            CliShell::Cmd => Shell::Cmd,
+        }
+    }
+}
+
+impl From<&CliShell> for Shell {
+    fn from(val: &CliShell) -> Self {
+        match val {
+            CliShell::Bash => Shell::Bash,
+            CliShell::Zsh => Shell::Zsh,
+            CliShell::Fish => Shell::Fish,
+            CliShell::PowerShell => Shell::PowerShell,
+            CliShell::Cmd => Shell::Cmd,
+        }
+    }
 }
 
 const COMPLETION_ZSH: &str = include_str!("shell/completion.zsh");


### PR DESCRIPTION
fixes #392
