### PR TITLE
refactor(config)!: simplify keybindings configuration syntax

### DIFF
--- a/.config/config.toml
+++ b/.config/config.toml
@@ -72,7 +72,7 @@ theme = "TwoDark"
 #
 # Channel mode
 # ------------------------
-[keybindings.Channel]
+[keybindings]
 # Quit the application
 quit = ["esc", "ctrl-c"]
 # Scrolling through entries
@@ -93,46 +93,6 @@ confirm_selection = "enter"
 copy_entry_to_clipboard = "ctrl-y"
 # Toggle the remote control mode
 toggle_remote_control = "ctrl-r"
-# Toggle the send to channel mode
-toggle_send_to_channel = "ctrl-s"
-# Toggle the help bar
-toggle_help = "ctrl-g"
-# Toggle the preview panel
-toggle_preview = "ctrl-o"
-
-
-# Remote control mode
-# -------------------------------
-[keybindings.RemoteControl]
-# Quit the application
-quit = "esc"
-# Scrolling through entries
-select_next_entry = ["down", "ctrl-n", "ctrl-j"]
-select_prev_entry = ["up", "ctrl-p", "ctrl-k"]
-select_next_page = "pagedown"
-select_prev_page = "pageup"
-# Select an entry
-select_entry = "enter"
-# Toggle the remote control mode
-toggle_remote_control = "ctrl-r"
-# Toggle the help bar
-toggle_help = "ctrl-g"
-# Toggle the preview panel
-toggle_preview = "ctrl-o"
-
-
-# Send to channel mode
-# --------------------------------
-[keybindings.SendToChannel]
-# Quit the application
-quit = "esc"
-# Scrolling through entries
-select_next_entry = ["down", "ctrl-n", "ctrl-j"]
-select_prev_entry = ["up", "ctrl-p", "ctrl-k"]
-select_next_page = "pagedown"
-select_prev_page = "pageup"
-# Select an entry
-select_entry = "enter"
 # Toggle the send to channel mode
 toggle_send_to_channel = "ctrl-s"
 # Toggle the help bar

--- a/television/draw.rs
+++ b/television/draw.rs
@@ -193,16 +193,12 @@ pub fn draw(ctx: &Ctx, f: &mut Frame<'_>, area: Rect) -> Result<Layout> {
         &ctx.colorscheme,
         &ctx.config
             .keybindings
-            .get(&ctx.tv_state.mode)
-            .unwrap()
             .get(&Action::ToggleHelp)
             // just display the first keybinding
             .unwrap()
             .to_string(),
         &ctx.config
             .keybindings
-            .get(&ctx.tv_state.mode)
-            .unwrap()
             .get(&Action::TogglePreview)
             // just display the first keybinding
             .unwrap()

--- a/television/keymap.rs
+++ b/television/keymap.rs
@@ -1,8 +1,6 @@
 use rustc_hash::FxHashMap;
 use std::ops::Deref;
 
-use crate::television::Mode;
-
 use crate::action::Action;
 use crate::config::{Binding, KeyBindings};
 use crate::event::Key;
@@ -13,20 +11,15 @@ use crate::event::Key;
 /// # Example:
 /// ```ignore
 ///     Keymap {
-///         Mode::Channel => {
-///             Key::Char('j') => Action::MoveDown,
-///             Key::Char('k') => Action::MoveUp,
-///             Key::Char('q') => Action::Quit,
-///         },
-///         Mode::Insert => {
-///             Key::Ctrl('a') => Action::MoveToStart,
-///         },
+///         Key::Char('j') => Action::MoveDown,
+///         Key::Char('k') => Action::MoveUp,
+///         Key::Char('q') => Action::Quit,
 ///     }
 /// ```
-pub struct Keymap(pub FxHashMap<Mode, FxHashMap<Key, Action>>);
+pub struct Keymap(pub FxHashMap<Key, Action>);
 
 impl Deref for Keymap {
-    type Target = FxHashMap<Mode, FxHashMap<Key, Action>>;
+    type Target = FxHashMap<Key, Action>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
@@ -40,38 +33,18 @@ impl From<&KeyBindings> for Keymap {
     /// key events.
     fn from(keybindings: &KeyBindings) -> Self {
         let mut keymap = FxHashMap::default();
-        for (mode, bindings) in keybindings.iter() {
-            let mut mode_keymap = FxHashMap::default();
-            for (action, binding) in bindings {
-                match binding {
-                    Binding::SingleKey(key) => {
-                        mode_keymap.insert(*key, action.clone());
-                    }
-                    Binding::MultipleKeys(keys) => {
-                        for key in keys {
-                            mode_keymap.insert(*key, action.clone());
-                        }
+        for (action, binding) in keybindings.iter() {
+            match binding {
+                Binding::SingleKey(key) => {
+                    keymap.insert(*key, action.clone());
+                }
+                Binding::MultipleKeys(keys) => {
+                    for key in keys {
+                        keymap.insert(*key, action.clone());
                     }
                 }
             }
-            keymap.insert(*mode, mode_keymap);
         }
         Self(keymap)
-    }
-}
-
-impl Keymap {
-    /// For a provided `Mode`, merge the given `mappings` into the keymap.
-    pub fn with_mode_mappings(
-        mut self,
-        mode: Mode,
-        mappings: Vec<(Key, Action)>,
-    ) -> Self {
-        let mode_keymap = self.0.entry(mode).or_default();
-
-        for (key, action) in mappings {
-            mode_keymap.insert(key, action);
-        }
-        self
     }
 }

--- a/television/screen/keybindings.rs
+++ b/television/screen/keybindings.rs
@@ -146,15 +146,7 @@ fn serialized_keys_for_actions(
 ) -> Vec<String> {
     actions
         .iter()
-        .map(|a| {
-            keybindings
-                .get(&Mode::Channel)
-                .unwrap()
-                .get(a)
-                .unwrap()
-                .clone()
-                .to_string()
-        })
+        .map(|a| keybindings.get(a).unwrap().clone().to_string())
         .collect()
 }
 


### PR DESCRIPTION
BREAKING CHANGE: mode keybindings dropped in favor of a global table

**What this means in practice:**
```toml
[keybindings.Channel]
quit = ["esc", "ctrl-c"]
# ...

[keybindings.RemoteControl]
quit = ["esc", "ctrl-c"]
# ...

[keybindings.SendToChannel]
quit = ["esc", "ctrl-c"]
# ...
```
are being replaced with
```toml
[keybindings]
quit = ["esc", "ctrl-c"]
# ...
```

Mode keybindings were I believe a premature optimization which only brought additional complexity and redundancy to the code and did not provide any real functionality in the current state of things for end users.