### PR TITLE
ci(x86): add statically linked musl build for x86_64

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -67,6 +67,12 @@ jobs:
             architecture: x86_64
             binary-postfix: ""
             use-cross: false
+          - os: ubuntu-latest
+            os-name: linux
+            target: x86_64-unknown-linux-musl
+            architecture: x86_64
+            binary-postfix: ""
+            use-cross: false
           - os: windows-latest
             os-name: windows
             target: x86_64-pc-windows-msvc


### PR DESCRIPTION
Fixes #339 

```
$ ldd target/x86_64-unknown-linux-musl/release/tv
        statically linked
```