### PR TITLE
fix(filter): include hidden files

### DIFF
--- a/television/utils/files.rs
+++ b/television/utils/files.rs
@@ -75,6 +75,9 @@ pub fn walk_builder(
 ) -> WalkBuilder {
     let mut builder = WalkBuilder::new(path);
 
+    // Include hidden files
+    builder.hidden(false);
+
     // ft-based filtering
     let mut types_builder = TypesBuilder::new();
     types_builder.add_defaults();


### PR DESCRIPTION
Include hidden files in the search so that repositories starting with a dot, like `.config`, can also be found.