### PR TITLE
refactor(passthrough)!: drop support for unused passthrough keybindings

### DIFF
--- a/television/action.rs
+++ b/television/action.rs
@@ -51,10 +51,6 @@ pub enum Action {
     #[serde(alias = "select_entry")]
     #[serde(alias = "confirm_selection")]
     ConfirmSelection,
-    /// Select the entry currently under the cursor and pass the key that was pressed
-    /// through to be handled the parent process.
-    #[serde(alias = "select_passthrough")]
-    SelectPassthrough(String),
     /// Select the entry currently under the cursor and exit the application.
     #[serde(alias = "select_and_exit")]
     SelectAndExit,

--- a/television/cli/args.rs
+++ b/television/cli/args.rs
@@ -66,14 +66,6 @@ pub struct Cli {
     #[arg(short, long, value_name = "STRING", verbatim_doc_comment)]
     pub keybindings: Option<String>,
 
-    /// Passthrough keybindings (comma separated, e.g. "q,ctrl-w,ctrl-t")
-    ///
-    /// These keybindings will trigger selection of the current entry and be
-    /// passed through to stdout along with the entry to be handled by the
-    /// parent process.
-    #[arg(long, value_name = "STRING", verbatim_doc_comment)]
-    pub passthrough_keybindings: Option<String>,
-
     /// Input text to pass to the channel to prefill the prompt.
     ///
     /// This can be used to provide a default value for the prompt upon

--- a/television/main.rs
+++ b/television/main.rs
@@ -65,16 +65,12 @@ async fn main() -> Result<()> {
     CLIPBOARD.with(<_>::default);
 
     debug!("Creating application...");
-    let mut app =
-        App::new(channel, config, &args.passthrough_keybindings, args.input);
+    let mut app = App::new(channel, config, args.input);
     stdout().flush()?;
     let output = app.run(stdout().is_terminal(), false).await?;
-    info!("{:?}", output);
+    info!("App output: {:?}", output);
     let stdout_handle = stdout().lock();
     let mut bufwriter = BufWriter::new(stdout_handle);
-    if let Some(passthrough) = output.passthrough {
-        writeln!(bufwriter, "{passthrough}")?;
-    }
     if let Some(entries) = output.selected_entries {
         for entry in &entries {
             writeln!(bufwriter, "{}", entry.stdout_repr())?;

--- a/tests/app.rs
+++ b/tests/app.rs
@@ -30,10 +30,9 @@ fn setup_app() -> (
         television::channels::files::Channel::new(vec![target_dir]),
     );
     let config = default_config_from_file().unwrap();
-    let passthrough_keybindings = Vec::new();
     let input = None;
 
-    let mut app = App::new(channel, config, &passthrough_keybindings, input);
+    let mut app = App::new(channel, config, input);
 
     // retrieve the app's action channel handle in order to send a quit action
     let tx = app.action_tx.clone();


### PR DESCRIPTION
BREAKING CHANGE: the CLI `passthrough_keybindings` are no longer available. This feature wasn't used anywhere to my knowledge (github search) and was adding unnecessary complexity to the code.