### PR TITLE
feat(cli): add `--select-1` cli flag to automatically select unique result

### DIFF
--- a/man/tv.1
+++ b/man/tv.1
@@ -1,10 +1,10 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH television 1  "television 0.11.0" 
+.TH television 1  "television 0.11.5" 
 .SH NAME
 television \- A cross\-platform, fast and extensible general purpose fuzzy finder TUI.
 .SH SYNOPSIS
-\fBtelevision\fR [\fB\-p\fR|\fB\-\-preview\fR] [\fB\-\-no\-preview\fR] [\fB\-\-delimiter\fR] [\fB\-t\fR|\fB\-\-tick\-rate\fR] [\fB\-f\fR|\fB\-\-frame\-rate\fR] [\fB\-k\fR|\fB\-\-keybindings\fR] [\fB\-\-passthrough\-keybindings\fR] [\fB\-i\fR|\fB\-\-input\fR] [\fB\-\-autocomplete\-prompt\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fICHANNEL\fR] [\fIPATH\fR] [\fIsubcommands\fR]
+\fBtelevision\fR [\fB\-p\fR|\fB\-\-preview\fR] [\fB\-\-no\-preview\fR] [\fB\-\-delimiter\fR] [\fB\-t\fR|\fB\-\-tick\-rate\fR] [\fB\-f\fR|\fB\-\-frame\-rate\fR] [\fB\-k\fR|\fB\-\-keybindings\fR] [\fB\-i\fR|\fB\-\-input\fR] [\fB\-\-autocomplete\-prompt\fR] [\fB\-\-select\-1\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] [\fICHANNEL\fR] [\fIPATH\fR] [\fIsubcommands\fR]
 .SH DESCRIPTION
 A cross\-platform, fast and extensible general purpose fuzzy finder TUI.
 .SH OPTIONS
@@ -53,13 +53,6 @@ expressions using the configuration file formalism.
 
 Example: `tv \-\-keybindings=\*(Aqquit="esc";select_next_entry=["down","ctrl\-j"]\*(Aq`
 .TP
-\fB\-\-passthrough\-keybindings\fR=\fISTRING\fR
-Passthrough keybindings (comma separated, e.g. "q,ctrl\-w,ctrl\-t")
-
-These keybindings will trigger selection of the current entry and be
-passed through to stdout along with the entry to be handled by the
-parent process.
-.TP
 \fB\-i\fR, \fB\-\-input\fR=\fISTRING\fR
 Input text to pass to the channel to prefill the prompt.
 
@@ -72,6 +65,17 @@ Try to guess the channel from the provided input prompt.
 This can be used to automatically select a channel based on the input
 prompt by using the `shell_integration` mapping in the configuration
 file.
+.TP
+\fB\-\-select\-1\fR
+Automatically select and output the first entry if there is only one
+entry.
+
+Note that most channels stream entries asynchronously which means that
+knowing if there\*(Aqs only one entry will require waiting for the channel
+to finish loading first.
+
+For most channels and workloads this shouldn\*(Aqt be a problem since the
+loading times are usually very short and will go unnoticed by the user.
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help (see a summary with \*(Aq\-h\*(Aq)
@@ -104,6 +108,6 @@ Initializes shell completion ("tv init zsh")
 television\-help(1)
 Print this message or the help of the given subcommand(s)
 .SH VERSION
-v0.11.0
+v0.11.5
 .SH AUTHORS
 Alexandre Pasmantier <alex.pasmant@gmail.com>

--- a/television/channels/dirs.rs
+++ b/television/channels/dirs.rs
@@ -136,7 +136,7 @@ impl OnAir for Channel {
     }
 
     fn running(&self) -> bool {
-        self.matcher.status.running
+        self.matcher.status.running || !self.crawl_handle.is_finished()
     }
 
     fn shutdown(&self) {

--- a/television/channels/files.rs
+++ b/television/channels/files.rs
@@ -142,7 +142,7 @@ impl OnAir for Channel {
     }
 
     fn running(&self) -> bool {
-        self.matcher.status.running
+        self.matcher.status.running || !self.crawl_handle.is_finished()
     }
 
     fn shutdown(&self) {

--- a/television/channels/git_repos.rs
+++ b/television/channels/git_repos.rs
@@ -106,7 +106,7 @@ impl OnAir for Channel {
     }
 
     fn running(&self) -> bool {
-        self.matcher.status.running
+        self.matcher.status.running || !self.crawl_handle.is_finished()
     }
 
     fn shutdown(&self) {

--- a/television/channels/text.rs
+++ b/television/channels/text.rs
@@ -239,7 +239,7 @@ impl OnAir for Channel {
     }
 
     fn running(&self) -> bool {
-        self.matcher.status.running
+        self.matcher.status.running || !self.crawl_handle.is_finished()
     }
 
     fn shutdown(&self) {

--- a/television/cli/args.rs
+++ b/television/cli/args.rs
@@ -90,6 +90,18 @@ pub struct Cli {
     #[arg(long, value_name = "STRING", verbatim_doc_comment)]
     pub autocomplete_prompt: Option<String>,
 
+    /// Automatically select and output the first entry if there is only one
+    /// entry.
+    ///
+    /// Note that most channels stream entries asynchronously which means that
+    /// knowing if there's only one entry will require waiting for the channel
+    /// to finish loading first.
+    ///
+    /// For most channels and workloads this shouldn't be a problem since the
+    /// loading times are usually very short and will go unnoticed by the user.
+    #[arg(long, default_value = "false", verbatim_doc_comment)]
+    pub select_1: bool,
+
     #[command(subcommand)]
     pub command: Option<Command>,
 }

--- a/television/cli/mod.rs
+++ b/television/cli/mod.rs
@@ -29,6 +29,7 @@ pub struct PostProcessedCli {
     pub working_directory: Option<String>,
     pub autocomplete_prompt: Option<String>,
     pub keybindings: Option<KeyBindings>,
+    pub select_1: bool,
 }
 
 impl Default for PostProcessedCli {
@@ -44,6 +45,7 @@ impl Default for PostProcessedCli {
             working_directory: None,
             autocomplete_prompt: None,
             keybindings: None,
+            select_1: false,
         }
     }
 }
@@ -108,6 +110,7 @@ impl From<Cli> for PostProcessedCli {
             working_directory,
             autocomplete_prompt: cli.autocomplete_prompt,
             keybindings,
+            select_1: cli.select_1,
         }
     }
 }
@@ -322,6 +325,7 @@ mod tests {
             command: None,
             working_directory: Some("/home/user".to_string()),
             autocomplete_prompt: None,
+            select_1: false,
         };
 
         let post_processed_cli: PostProcessedCli = cli.into();
@@ -360,6 +364,7 @@ mod tests {
             command: None,
             working_directory: None,
             autocomplete_prompt: None,
+            select_1: false,
         };
 
         let post_processed_cli: PostProcessedCli = cli.into();
@@ -389,6 +394,7 @@ mod tests {
             command: None,
             working_directory: None,
             autocomplete_prompt: None,
+            select_1: false,
         };
 
         let post_processed_cli: PostProcessedCli = cli.into();
@@ -413,6 +419,7 @@ mod tests {
             command: None,
             working_directory: None,
             autocomplete_prompt: None,
+            select_1: false,
         };
 
         let post_processed_cli: PostProcessedCli = cli.into();
@@ -440,6 +447,7 @@ mod tests {
             command: None,
             working_directory: None,
             autocomplete_prompt: None,
+            select_1: false,
         };
 
         let post_processed_cli: PostProcessedCli = cli.into();

--- a/television/main.rs
+++ b/television/main.rs
@@ -65,8 +65,9 @@ async fn main() -> Result<()> {
     CLIPBOARD.with(<_>::default);
 
     debug!("Creating application...");
-    let mut app = App::new(channel, config, args.input);
+    let mut app = App::new(channel, config, args.input, args.select_1);
     stdout().flush()?;
+    debug!("Running application...");
     let output = app.run(stdout().is_terminal(), false).await?;
     info!("App output: {:?}", output);
     let stdout_handle = stdout().lock();

--- a/television/matcher/mod.rs
+++ b/television/matcher/mod.rs
@@ -84,7 +84,7 @@ where
     /// This can be used at any time to push items into the fuzzy matcher.
     ///
     /// # Example
-    /// ```
+    /// ```ignore
     /// use television::matcher::{config::Config, Matcher};
     ///
     /// let config = Config::default();
@@ -134,7 +134,7 @@ where
     /// indices of the matched characters.
     ///
     /// # Example
-    /// ```
+    /// ```ignore
     /// use television::matcher::{config::Config, Matcher};
     ///
     /// let config = Config::default();
@@ -190,7 +190,7 @@ where
     /// Get a single matched item.
     ///
     /// # Example
-    /// ```
+    /// ```ignore
     /// use television::matcher::{config::Config, Matcher};
     ///
     /// let config = Config::default();


### PR DESCRIPTION
Adds a `--select-1` flag that enables `tv` to automatically select the
only result and exit when such a case appears.

Fixes #440 