### PR TITLE
fix: silence the `string match` in tv_smart_autocomplete

### DIFF
--- a/television/utils/shell/completion.fish
+++ b/television/utils/shell/completion.fish
@@ -5,7 +5,7 @@ function tv_smart_autocomplete
 
     if test -n "$output"
         # add a space if the prompt does not end with one (unless the prompt is an implicit cd, e.g. '\.')
-        string match -r '.*( |./)$' -- "$current_prompt" || set current_prompt "$current_prompt "
+        string match -q -r '.*( |./)$' -- "$current_prompt" || set current_prompt "$current_prompt "
         commandline -r "$current_prompt$output"
         commandline -f repaint
     end


### PR DESCRIPTION
The `string match` statement outputs strings if they match, so the `tv_smart_autocomplete` function was doing this if I invoke it with `'cd '` on my command line
![image](https://github.com/user-attachments/assets/50a4dcee-e847-437e-8782-343432aba8d3)

It outputs `cd ` (in the first line) since the `$current_prompt` successfully matches (cause it ends with a space).

Let's fix this by making the `string match` silent with `-q`. 