### PR TITLE
feat(shell): support completion in the middle of a prompt

### DIFF
--- a/television/utils/shell/completion.bash
+++ b/television/utils/shell/completion.bash
@@ -1,15 +1,17 @@
 function tv_smart_autocomplete() {
-  local prompt_prefix="${READLINE_LINE:0:$READLINE_POINT}"
-  local prompt_suffix="${READLINE_LINE:$READLINE_POINT}"
+  # prefix (lhs of cursor)
+  local current_prompt="${READLINE_LINE:0:$READLINE_POINT}"
 
-  local output=$(tv --autocomplete-prompt "$prompt_prefix" | tr '\n' ' ')
+  local output=$(tv --autocomplete-prompt "$current_prompt" | tr '\n' ' ')
 
   if [[ -n $output ]]; then
+    # suffix (rhs of cursor)
+    local rhs="${READLINE_LINE:$READLINE_POINT}"
     # add a space if the prompt does not end with one
-    [[ "${prompt_prefix}" != *" " ]] && prompt_prefix="${prompt_prefix} "
+    [[ "${current_prompt}" != *" " ]] && current_prompt="${current_prompt} "
 
-    local lhs=$prompt_prefix$output
-    READLINE_LINE=$lhs$prompt_suffix
+    local lhs=$current_prompt$output
+    READLINE_LINE=$lhs$rhs
     READLINE_POINT=${#lhs}
   fi
 }

--- a/television/utils/shell/completion.bash
+++ b/television/utils/shell/completion.bash
@@ -1,14 +1,16 @@
 function tv_smart_autocomplete() {
-  local current_prompt="${READLINE_LINE:0:$READLINE_POINT}"
+  local prompt_prefix="${READLINE_LINE:0:$READLINE_POINT}"
+  local prompt_suffix="${READLINE_LINE:$READLINE_POINT}"
 
-  local output=$(tv --autocomplete-prompt "$current_prompt")
+  local output=$(tv --autocomplete-prompt "$prompt_prefix" | tr '\n' ' ')
 
   if [[ -n $output ]]; then
     # add a space if the prompt does not end with one
-    [[ "${current_prompt}" != *" " ]] && current_prompt="${current_prompt} "
+    [[ "${prompt_prefix}" != *" " ]] && prompt_prefix="${prompt_prefix} "
 
-    READLINE_LINE=$current_prompt$output
-    READLINE_POINT=${#READLINE_LINE}
+    local lhs=$prompt_prefix$output
+    READLINE_LINE=$lhs$prompt_suffix
+    READLINE_POINT=${#lhs}
   fi
 }
 

--- a/television/utils/shell/completion.fish
+++ b/television/utils/shell/completion.fish
@@ -1,4 +1,5 @@
 function tv_smart_autocomplete
+    # prefix (lhs of cursor)
     set -l current_prompt (commandline -cp)
 
     set -l output (tv --autocomplete-prompt "$current_prompt")

--- a/television/utils/shell/completion.fish
+++ b/television/utils/shell/completion.fish
@@ -5,8 +5,8 @@ function tv_smart_autocomplete
 
     if test -n "$output"
         # add a space if the prompt does not end with one (unless the prompt is an implicit cd, e.g. '\.')
-        string match -q -r '.*( |./)$' -- "$current_prompt" || set current_prompt "$current_prompt "
-        commandline -r "$current_prompt$output"
+        string match -q -r '.*( |./)$' -- "$current_prompt" || set output " $output"
+        commandline -i "$output"
         commandline -f repaint
     end
 end

--- a/television/utils/shell/completion.zsh
+++ b/television/utils/shell/completion.zsh
@@ -2,6 +2,7 @@ _tv_smart_autocomplete() {
     emulate -L zsh
     zle -I
 
+    # prefix (lhs of cursor)
     local current_prompt
     current_prompt=$LBUFFER
 
@@ -9,6 +10,7 @@ _tv_smart_autocomplete() {
     output=$(tv --autocomplete-prompt "$current_prompt" $* | tr '\n' ' ')
 
     if [[ -n $output ]]; then
+        # suffix (rhs of cursor)
         local rhs=$RBUFFER
         # add a space if the prompt does not end with one
         [[ "${current_prompt}" != *" " ]] && current_prompt="${current_prompt} "

--- a/television/utils/shell/completion.zsh
+++ b/television/utils/shell/completion.zsh
@@ -6,18 +6,19 @@ _tv_smart_autocomplete() {
     current_prompt=$LBUFFER
 
     local output
-
-    output=$(tv --autocomplete-prompt "$current_prompt" $*)
-
+    output=$(tv --autocomplete-prompt "$current_prompt" $* | tr '\n' ' ')
 
     if [[ -n $output ]]; then
-        zle reset-prompt
-        RBUFFER=""
+        local rhs=$RBUFFER
         # add a space if the prompt does not end with one
         [[ "${current_prompt}" != *" " ]] && current_prompt="${current_prompt} "
-        LBUFFER=$current_prompt$output
 
-        # uncomment this to automatically accept the line 
+        LBUFFER=$current_prompt$output
+        CURSOR=${#LBUFFER}
+        RBUFFER=$rhs
+
+        zle reset-prompt
+        # uncomment this to automatically accept the line
         # (i.e. run the command without having to press enter twice)
         # zle accept-line
     fi
@@ -39,7 +40,7 @@ _tv_shell_history() {
         RBUFFER=""
         LBUFFER=$output
 
-        # uncomment this to automatically accept the line 
+        # uncomment this to automatically accept the line
         # (i.e. run the command without having to press enter twice)
         # zle accept-line
     fi
@@ -52,4 +53,3 @@ zle -N tv-shell-history _tv_shell_history
 
 bindkey '{tv_smart_autocomplete_keybinding}' tv-smart-autocomplete
 bindkey '{tv_shell_history_keybinding}' tv-shell-history
-


### PR DESCRIPTION
I think it's better to insert our output at the cursor so this can be invoked in the middle of a prompt. Previously we would assume the cursor is at the end of the prompt and invocation in the middle of one would discard everything after the cursor. 