### PR TITLE
feat(cli): add a `--no-remote` flag to lock the application on the cli-invoked channel

### DIFF
--- a/television/app.rs
+++ b/television/app.rs
@@ -100,6 +100,7 @@ impl App {
         config: Config,
         input: Option<String>,
         select_1: bool,
+        no_remote: bool,
     ) -> Self {
         let (action_tx, action_rx) = mpsc::unbounded_channel();
         let (render_tx, render_rx) = mpsc::unbounded_channel();
@@ -110,8 +111,13 @@ impl App {
 
         debug!("{:?}", keymap);
         let (ui_state_tx, ui_state_rx) = mpsc::unbounded_channel();
-        let television =
-            Television::new(action_tx.clone(), channel, config, input);
+        let television = Television::new(
+            action_tx.clone(),
+            channel,
+            config,
+            input,
+            no_remote,
+        );
 
         Self {
             keymap,
@@ -401,6 +407,7 @@ mod test {
             Config::default(),
             None,
             true,
+            false,
         );
         app.television
             .results_picker

--- a/television/cli/args.rs
+++ b/television/cli/args.rs
@@ -102,6 +102,16 @@ pub struct Cli {
     #[arg(long, default_value = "false", verbatim_doc_comment)]
     pub select_1: bool,
 
+    /// Disable the remote control.
+    ///
+    /// This will disable the remote control panel and associated actions
+    /// entirely. This is useful when the remote control is not needed or
+    /// when the user wants `tv` to run in single-channel mode (e.g. when
+    /// using it as a file picker for a script or embedding it in a larger
+    /// application).
+    #[arg(long, default_value = "false", verbatim_doc_comment)]
+    pub no_remote: bool,
+
     #[command(subcommand)]
     pub command: Option<Command>,
 }

--- a/television/cli/mod.rs
+++ b/television/cli/mod.rs
@@ -30,6 +30,7 @@ pub struct PostProcessedCli {
     pub autocomplete_prompt: Option<String>,
     pub keybindings: Option<KeyBindings>,
     pub select_1: bool,
+    pub no_remote: bool,
 }
 
 impl Default for PostProcessedCli {
@@ -46,6 +47,7 @@ impl Default for PostProcessedCli {
             autocomplete_prompt: None,
             keybindings: None,
             select_1: false,
+            no_remote: false,
         }
     }
 }
@@ -111,6 +113,7 @@ impl From<Cli> for PostProcessedCli {
             autocomplete_prompt: cli.autocomplete_prompt,
             keybindings,
             select_1: cli.select_1,
+            no_remote: cli.no_remote,
         }
     }
 }
@@ -326,6 +329,7 @@ mod tests {
             working_directory: Some("/home/user".to_string()),
             autocomplete_prompt: None,
             select_1: false,
+            no_remote: false,
         };
 
         let post_processed_cli: PostProcessedCli = cli.into();
@@ -365,6 +369,7 @@ mod tests {
             working_directory: None,
             autocomplete_prompt: None,
             select_1: false,
+            no_remote: false,
         };
 
         let post_processed_cli: PostProcessedCli = cli.into();
@@ -395,6 +400,7 @@ mod tests {
             working_directory: None,
             autocomplete_prompt: None,
             select_1: false,
+            no_remote: false,
         };
 
         let post_processed_cli: PostProcessedCli = cli.into();
@@ -420,6 +426,7 @@ mod tests {
             working_directory: None,
             autocomplete_prompt: None,
             select_1: false,
+            no_remote: false,
         };
 
         let post_processed_cli: PostProcessedCli = cli.into();
@@ -448,6 +455,7 @@ mod tests {
             working_directory: None,
             autocomplete_prompt: None,
             select_1: false,
+            no_remote: false,
         };
 
         let post_processed_cli: PostProcessedCli = cli.into();

--- a/television/main.rs
+++ b/television/main.rs
@@ -65,7 +65,8 @@ async fn main() -> Result<()> {
     CLIPBOARD.with(<_>::default);
 
     debug!("Creating application...");
-    let mut app = App::new(channel, config, args.input, args.select_1);
+    let mut app =
+        App::new(channel, config, args.input, args.select_1, args.no_remote);
     stdout().flush()?;
     debug!("Running application...");
     let output = app.run(stdout().is_terminal(), false).await?;

--- a/tests/app.rs
+++ b/tests/app.rs
@@ -39,7 +39,7 @@ fn setup_app(
     config.application.tick_rate = 100.0;
     let input = None;
 
-    let mut app = App::new(chan, config, input, select_1);
+    let mut app = App::new(chan, config, input, select_1, false);
 
     // retrieve the app's action channel handle in order to send a quit action
     let tx = app.action_tx.clone();


### PR DESCRIPTION
This will disable the remote control panel and associated actions entirely. This is useful when the remote control is not needed or when the user wants `tv` to run in single-channel mode (e.g. when using it as a file picker for a script or embedding it in a larger application).