### PR TITLE
feat(input): add action to delete input line

### DIFF
--- a/television/action.rs
+++ b/television/action.rs
@@ -18,6 +18,9 @@ pub enum Action {
     /// Delete the character after the cursor from the input buffer.
     #[serde(skip)]
     DeleteNextChar,
+    /// Delete the current line from the input buffer.
+    #[serde(skip)]
+    DeleteLine,
     /// Move the cursor to the character before the current cursor position.
     #[serde(skip)]
     GoToPrevChar,

--- a/television/app.rs
+++ b/television/app.rs
@@ -297,6 +297,7 @@ impl App {
                     match keycode {
                         Key::Backspace => Action::DeletePrevChar,
                         Key::Ctrl('w') => Action::DeletePrevWord,
+                        Key::Ctrl('u') => Action::DeleteLine,
                         Key::Delete => Action::DeleteNextChar,
                         Key::Left => Action::GoToPrevChar,
                         Key::Right => Action::GoToNextChar,

--- a/television/input.rs
+++ b/television/input.rs
@@ -9,6 +9,7 @@ pub fn convert_action_to_input_request(
         Action::DeletePrevChar => Some(InputRequest::DeletePrevChar),
         Action::DeletePrevWord => Some(InputRequest::DeletePrevWord),
         Action::DeleteNextChar => Some(InputRequest::DeleteNextChar),
+        Action::DeleteLine => Some(InputRequest::DeleteLine),
         Action::GoToPrevChar => Some(InputRequest::GoToPrevChar),
         Action::GoToNextChar => Some(InputRequest::GoToNextChar),
         Action::GoToInputStart => Some(InputRequest::GoToStart),

--- a/television/television.rs
+++ b/television/television.rs
@@ -428,6 +428,7 @@ impl Television {
             Action::AddInputChar(_)
             | Action::DeletePrevChar
             | Action::DeletePrevWord
+            | Action::DeleteLine
             | Action::DeleteNextChar => {
                 let new_pattern = input.value().to_string();
                 if new_pattern != self.current_pattern {
@@ -552,6 +553,7 @@ impl Television {
             | Action::DeletePrevChar
             | Action::DeletePrevWord
             | Action::DeleteNextChar
+            | Action::DeleteLine
             | Action::GoToInputEnd
             | Action::GoToInputStart
             | Action::GoToNextChar


### PR DESCRIPTION
This is hard-coded to be bound to <kbd>C-u</kbd> by default.

With tv's default keybindings configuration, this is overriden by `scroll_preview_half_page_up` which means users will need to bind that to something else in order to "unlock" that delete-line functionality.