### PR TITLE
Updating for nushell syntax

### DIFF
--- a/television/utils/shell/completion.nu
+++ b/television/utils/shell/completion.nu
@@ -1,29 +1,59 @@
 def tv_smart_autocomplete [] {
-    let current_prompt = $env.PROMPT # Fetch the current prompt input
-
+    let current_prompt = (commandline)
+    let cursor = (commandline get-cursor)
+    let current_prompt = ($current_prompt | str substring 0..$cursor)
+ 
     let output = (tv --autocomplete-prompt $current_prompt | str trim)
 
     if ($output | str length) > 0 {
         let needs_space = not ($current_prompt | str ends-with " ")
         let new_prompt = if $needs_space { $"($current_prompt) " + $output } else { $current_prompt + $output }
+    }
+    # Update the line editor with the new prompt
 
-        # Update the line editor with the new prompt
-        $env.PROMPT = $new_prompt
+    if ($output | is-not-empty) {
+        commandline edit --replace $output
+        commandline set-cursor --end
     }
 }
 
 def tv_shell_history [] {
-    let current_prompt = $env.PROMPT
-
+    let current_prompt = (commandline)
+    let cursor = (commandline get-cursor)
+    let current_prompt = ($current_prompt | str substring 0..$cursor)
+    
     let output = (tv nu-history --input $current_prompt | str trim)
 
-    if ($output | str length) > 0 {
-        $env.PROMPT = $output
+    if ($output | is-not-empty) {
+        commandline edit --replace $output
+        commandline set-cursor --end
     }
 }
 
 # Bind custom keybindings
-$env.config = ($env.config | upsert keybindings [
-    { name: "tv_completion", modifier: none, keycode: "{tv_smart_autocomplete_keybinding}", mode: "vi_normal", action: { send: "tv_smart_autocomplete" } }
-    { name: "tv_history", modifier: none, keycode: "{tv_shell_history_keybinding}", mode: "vi_normal", action: { send: "tv_shell_history" } }
-])
+
+$env.config = (
+  $env.config
+  | upsert keybindings [
+        {
+            name: tv_completion,
+            modifier: Control,
+            keycode: char_t,
+            mode: [vi_normal, vi_insert, emacs],
+            event: {
+                send: executehostcommand,
+                cmd: "tv_smart_autocomplete"
+            }
+        }
+        {
+            name: tv_history,
+            modifier: Control,
+            keycode: char_r,
+            mode: [vi_normal, vi_insert, emacs],
+            event: {
+                send: executehostcommand,
+                cmd: "tv_shell_history"
+            }
+        }
+    ]
+)


### PR DESCRIPTION
I've updated the completion.nu script to use nushell syntax. I tested this with a custom cable channel and placed the keybinding logic directly within completion.nu. Next steps will mean figuring out how to move that logic into, I think, shell.rs.