### PR TITLE
feat(orientation): add orientation for television #489

### DIFF
--- a/.config/config.toml
+++ b/.config/config.toml
@@ -50,6 +50,8 @@ show_help_bar = false
 show_preview_panel = true
 # Where to place the input bar in the UI (top or bottom)
 input_bar_position = "top"
+# What orientation should tv be (landscape or portrait)
+orientation = "landscape"
 # DEPRECATED: title is now always displayed at the top as part of the border
 # Where to place the preview title in the UI (top or bottom)
 # preview_title_position = "top"

--- a/television/config/ui.rs
+++ b/television/config/ui.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 
-use crate::screen::layout::{InputPosition, PreviewTitlePosition};
+use crate::screen::layout::{
+    InputPosition, Orientation, PreviewTitlePosition,
+};
 
 use super::themes::DEFAULT_THEME;
 
@@ -17,6 +19,7 @@ pub struct UiConfig {
     pub show_preview_panel: bool,
     #[serde(default)]
     pub input_bar_position: InputPosition,
+    pub orientation: Orientation,
     pub preview_title_position: Option<PreviewTitlePosition>,
     pub theme: String,
     pub custom_header: Option<String>,
@@ -31,6 +34,7 @@ impl Default for UiConfig {
             show_help_bar: false,
             show_preview_panel: true,
             input_bar_position: InputPosition::Top,
+            orientation: Orientation::Landscape,
             preview_title_position: None,
             theme: String::from(DEFAULT_THEME),
             custom_header: None,

--- a/television/draw.rs
+++ b/television/draw.rs
@@ -241,12 +241,13 @@ pub fn draw(ctx: &Ctx, f: &mut Frame<'_>, area: Rect) -> Result<Layout> {
         &ctx.tv_state.spinner,
         &ctx.colorscheme,
         &ctx.config.ui.custom_header,
+        &ctx.config.ui.input_bar_position,
     )?;
 
-    if layout.preview_window.is_some() {
+    if let Some(preview_rect) = layout.preview_window {
         draw_preview_content_block(
             f,
-            layout.preview_window.unwrap(),
+            preview_rect,
             &ctx.tv_state.preview_state,
             ctx.config.ui.use_nerd_font_icons,
             &ctx.colorscheme,

--- a/television/screen/input.rs
+++ b/television/screen/input.rs
@@ -6,11 +6,15 @@ use ratatui::{
     },
     style::{Style, Stylize},
     text::{Line, Span},
-    widgets::{Block, BorderType, Borders, ListState, Paragraph},
+    widgets::{
+        block::Position, Block, BorderType, Borders, ListState, Paragraph,
+    },
     Frame,
 };
 
 use crate::screen::{colors::Colorscheme, spinner::Spinner};
+
+use super::layout::InputPosition;
 
 #[allow(clippy::too_many_arguments)]
 pub fn draw_input_box(
@@ -25,13 +29,18 @@ pub fn draw_input_box(
     spinner: &Spinner,
     colorscheme: &Colorscheme,
     custom_header: &Option<String>,
+    input_bar_position: &InputPosition,
 ) -> Result<()> {
     let header = custom_header.as_deref().unwrap_or(channel_name);
     let input_block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(colorscheme.general.border_fg))
-        .title_top(
+        .title_position(match input_bar_position {
+            InputPosition::Top => Position::Top,
+            InputPosition::Bottom => Position::Bottom,
+        })
+        .title(
             Line::from(String::from(" ") + header + " ")
                 .style(Style::default().fg(colorscheme.mode.channel).bold())
                 .centered(),


### PR DESCRIPTION
Fixes #489 

This PR adds support for television orientation, input_bar_position is preserved and activating/deactivating the preview works for both :

1. Landscape (default orientation)

a. input_bar_position = "top"

![image](https://github.com/user-attachments/assets/08f334c0-0780-46ee-aa80-0ccdd1a473eb)
![image](https://github.com/user-attachments/assets/9df6faf5-2211-4fa0-8f08-28688c48e8ee)

b. input_bar_position = "bottom"

![image](https://github.com/user-attachments/assets/223c9814-d1c6-4ed1-b407-b5ba67ebaa06)
![image](https://github.com/user-attachments/assets/9be95c92-f10b-4dec-b423-c7de1f8534d1)

2. Portrait (new orientation)

a. input_bar_position = "top"

![image](https://github.com/user-attachments/assets/71d07092-a175-4978-9ee6-c8978eb83cde)
![image](https://github.com/user-attachments/assets/64d891f4-7acc-456b-a01d-14cab54bff15)

b. input_bar_position = "bottom"

![image](https://github.com/user-attachments/assets/b2c527eb-2c47-404e-8f6d-685b54be71af)
![image](https://github.com/user-attachments/assets/39c9bcaa-cbd5-4d4b-81d8-1e7cfb5bfa10)