### PR TITLE
refactor!(cable): update cable channel preview configuration format + add custom preview offsets

### DIFF
--- a/benches/main/ui.rs
+++ b/benches/main/ui.rs
@@ -472,11 +472,11 @@ pub fn draw(c: &mut Criterion) {
                 let backend = TestBackend::new(width, height);
                 let terminal = Terminal::new(backend).unwrap();
                 let (tx, _) = tokio::sync::mpsc::unbounded_channel();
-                let channel = ChannelPrototype::default();
+                let channel_prototype = ChannelPrototype::default();
                 // Wait for the channel to finish loading
                 let mut tv = Television::new(
                     tx,
-                    channel,
+                    &channel_prototype,
                     config,
                     None,
                     false,

--- a/cable/unix-channels.toml
+++ b/cable/unix-channels.toml
@@ -8,8 +8,9 @@ preview_command = "bat -n --color=always {}"
 [[cable_channel]]
 name = "text"
 source_command = "rg . --no-heading --line-number"
-preview_command = "bat -n --color=always {0} -H {1}"
+preview_command = "bat -n --color=always {0}"
 preview_delimiter = ":"
+preview_offset = "{1}"
 
 # Directories
 [[cable_channel]]

--- a/cable/unix-channels.toml
+++ b/cable/unix-channels.toml
@@ -2,27 +2,27 @@
 [[cable_channel]]
 name = "files"
 source_command = "fd -t f"
-preview_command = "bat -n --color=always {}"
+preview.command = "bat -n --color=always {}"
 
 # Text
 [[cable_channel]]
 name = "text"
 source_command = "rg . --no-heading --line-number"
-preview_command = "bat -n --color=always {0}"
-preview_delimiter = ":"
-preview_offset = "{1}"
+preview.command = "bat -n --color=always {0}"
+preview.delimiter = ":"
+preview.offset = "{1}"
 
 # Directories
 [[cable_channel]]
 name = "dirs"
 source_command = "fd -t d"
-preview_command = "ls -la --color=always {}"
+preview.command = "ls -la --color=always {}"
 
 # Environment variables
 [[cable_channel]]
 name = "env"
 source_command = "printenv"
-preview_command = "cut -d= -f2 <<< ${0} | cut -d\" \" -f2- | sed 's/:/\\n/g'"
+preview.command = "cut -d= -f2 <<< ${0} | cut -d\" \" -f2- | sed 's/:/\\n/g'"
 
 # Aliases
 [[cable_channel]]
@@ -33,47 +33,50 @@ interactive = true
 # GIT
 [[cable_channel]]
 name = "git-repos"
-# this is a MacOS version but feel free to change it to fit your needs
+# this is a MacOS version but feel free to override it to fit your needs
 source_command = "fd -g .git -HL -t d -d 10 --prune ~ -E 'Library' -E 'Application Support' --exec dirname {}"
-preview_command = "cd {} && git log -n 200 --pretty=medium --all --graph --color"
+preview.command = "cd {} && git log -n 200 --pretty=medium --all --graph --color"
 
 [[cable_channel]]
 name = "git-diff"
 source_command = "git diff --name-only"
-preview_command = "git diff --color=always {0}"
+preview.command = "git diff --color=always {0}"
 
 [[cable_channel]]
 name = "git-reflog"
 source_command = 'git reflog'
-preview_command = 'git show -p --stat --pretty=fuller --color=always {0}'
+preview.command = 'git show -p --stat --pretty=fuller --color=always {0}'
+
 
 [[cable_channel]]
 name = "git-log"
 source_command = "git log --oneline --date=short --pretty=\"format:%h %s %an %cd\" \"$@\""
-preview_command = "git show -p --stat --pretty=fuller --color=always {0}"
+preview.command = 'git show -p --stat --pretty=fuller --color=always {0}'
 
 [[cable_channel]]
 name = "git-branch"
 source_command = "git --no-pager branch --all --format=\"%(refname:short)\""
-preview_command = "git show -p --stat --pretty=fuller --color=always {0}"
+preview.command = 'git show -p --stat --pretty=fuller --color=always {0}'
 
 # Docker
 [[cable_channel]]
 name = "docker-images"
 source_command = "docker image list --format \"{{.ID}}\""
-preview_command = "docker image inspect {0} | jq -C"
+preview.command = "docker image inspect {0} | jq -C"
+
 
 # S3
 [[cable_channel]]
 name = "s3-buckets"
 source_command = "aws s3 ls | cut -d \" \" -f 3"
-preview_command = "aws s3 ls s3://{0}"
+preview.command = "aws s3 ls s3://{0}"
+
 
 # Dotfiles
 [[cable_channel]]
 name = "my-dotfiles"
 source_command = "fd -t f . $HOME/.config"
-preview_command = "bat -n --color=always {}"
+preview.command = "bat -n --color=always {}"
 
 # Shell history
 [[cable_channel]]

--- a/cable/windows-channels.toml
+++ b/cable/windows-channels.toml
@@ -2,13 +2,13 @@
 [[cable_channel]]
 name = "files"
 source_command = "Get-ChildItem -Recurse -File | Select-Object -ExpandProperty FullName"
-preview_command = "bat -n --color=always {}"
+preview.command = "bat -n --color=always {}"
 
 # Directories
 [[cable_channel]]
 name = "dirs"
 source_command = "Get-ChildItem -Recurse -Directory | Select-Object -ExpandProperty FullName"
-preview_command = "ls -l {}"
+preview.command = "ls -l {}"
 
 # Environment variables
 [[cable_channel]]
@@ -24,39 +24,39 @@ source_command = "Get-Alias"
 [[cable_channel]]
 name = "git-repos"
 source_command = "Get-ChildItem -Path 'C:\\Users' -Recurse -Directory -Force -ErrorAction SilentlyContinue | Where-Object { Test-Path \"$($_.FullName)\\.git\" } | Select-Object -ExpandProperty FullName"
-preview_command = "cd '{}' ; git log -n 200 --pretty=medium --all --graph --color"
+preview.command = "cd '{}' ; git log -n 200 --pretty=medium --all --graph --color"
 
 [[cable_channel]]
 name = "git-diff"
 source_command = "git diff --name-only"
-preview_command = "git diff --color=always {}"
+preview.command = "git diff --color=always {}"
 
 [[cable_channel]]
 name = "git-reflog"
 source_command = "git reflog"
-preview_command = "git show -p --stat --pretty=fuller --color=always {0}"
+preview.command = "git show -p --stat --pretty=fuller --color=always {0}"
 
 [[cable_channel]]
 name = "git-log"
 source_command = "git log --oneline --date=short --pretty='format:%h %s %an %cd'"
-preview_command = "git show -p --stat --pretty=fuller --color=always {0}"
+preview.command = "git show -p --stat --pretty=fuller --color=always {0}"
 
 [[cable_channel]]
 name = "git-branch"
 source_command = "git branch --all --format='%(refname:short)'"
-preview_command = "git show -p --stat --pretty=fuller --color=always {0}"
+preview.command = "git show -p --stat --pretty=fuller --color=always {0}"
 
 # Docker
 [[cable_channel]]
 name = "docker-images"
 source_command = "docker image ls --format '{{.ID}}'"
-preview_command = "docker image inspect {0} | jq -C"
+preview.command = "docker image inspect {0} | jq -C"
 
 # Dotfiles (adapted to common Windows dotfile locations)
 [[cable_channel]]
 name = "my-dotfiles"
 source_command = "Get-ChildItem -Recurse -File -Path \"$env:USERPROFILE\\AppData\\Roaming\\\""
-preview_command = "bat -n --color=always {}"
+preview.command = "bat -n --color=always {}"
 
 # Shell history
 [[cable_channel]]

--- a/television/app.rs
+++ b/television/app.rs
@@ -137,7 +137,7 @@ const ACTION_BUF_SIZE: usize = 8;
 
 impl App {
     pub fn new(
-        channel_prototype: ChannelPrototype,
+        channel_prototype: &ChannelPrototype,
         config: Config,
         input: Option<String>,
         options: AppOptions,

--- a/television/cable.rs
+++ b/television/cable.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 use rustc_hash::FxHashMap;
 
 use anyhow::Result;
-#[cfg(debug_assertions)]
 use tracing::{debug, error};
 
 use crate::{
@@ -53,12 +52,9 @@ pub fn load_cable() -> Result<Cable> {
         .filter(|p| is_cable_file_format(p) && p.is_file())
         .collect();
 
-    #[cfg(debug_assertions)]
-    {
-        debug!("Found cable channel files: {:?}", file_paths);
-        if file_paths.is_empty() {
-            debug!("No user defined cable channels found");
-        }
+    debug!("Found cable channel files: {:?}", file_paths);
+    if file_paths.is_empty() {
+        debug!("No user defined cable channels found");
     }
 
     let default_prototypes =
@@ -74,25 +70,19 @@ pub fn load_cable() -> Result<Cable> {
             ) {
                 Ok(pts) => acc.extend(pts.prototypes),
                 Err(e) => {
-                    #[cfg(debug_assertions)]
-                    {
-                        error!(
-                            "Failed to parse cable channel file {:?}: {}",
-                            p, e
-                        );
-                    }
+                    error!(
+                        "Failed to parse cable channel file {:?}: {}",
+                        p, e
+                    );
                 }
             }
             acc
         },
     );
 
-    #[cfg(debug_assertions)]
-    {
-        debug!("Loaded {} custom cable channels", prototypes.len());
-        if prototypes.is_empty() {
-            debug!("No custom cable channels found");
-        }
+    debug!("Loaded {} custom cable channels", prototypes.len());
+    if prototypes.is_empty() {
+        debug!("No custom cable channels found");
     }
 
     let mut cable_channels = FxHashMap::default();

--- a/television/cable.rs
+++ b/television/cable.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use rustc_hash::FxHashMap;
 
 use anyhow::Result;
+#[cfg(debug_assertions)]
 use tracing::{debug, error};
 
 use crate::{
@@ -52,9 +53,12 @@ pub fn load_cable() -> Result<Cable> {
         .filter(|p| is_cable_file_format(p) && p.is_file())
         .collect();
 
-    debug!("Found cable channel files: {:?}", file_paths);
-    if file_paths.is_empty() {
-        debug!("No user defined cable channels found");
+    #[cfg(debug_assertions)]
+    {
+        debug!("Found cable channel files: {:?}", file_paths);
+        if file_paths.is_empty() {
+            debug!("No user defined cable channels found");
+        }
     }
 
     let default_prototypes =
@@ -70,21 +74,26 @@ pub fn load_cable() -> Result<Cable> {
             ) {
                 Ok(pts) => acc.extend(pts.prototypes),
                 Err(e) => {
-                    error!(
-                        "Failed to parse cable channel file {:?}: {}",
-                        p, e
-                    );
+                    #[cfg(debug_assertions)]
+                    {
+                        error!(
+                            "Failed to parse cable channel file {:?}: {}",
+                            p, e
+                        );
+                    }
                 }
             }
             acc
         },
     );
 
-    debug!(
-        "Loaded {} default and {} custom prototypes",
-        default_prototypes.prototypes.len(),
-        prototypes.len()
-    );
+    #[cfg(debug_assertions)]
+    {
+        debug!("Loaded {} custom cable channels", prototypes.len());
+        if prototypes.is_empty() {
+            debug!("No custom cable channels found");
+        }
+    }
 
     let mut cable_channels = FxHashMap::default();
     // custom prototypes take precedence over default ones

--- a/television/channels/preview.rs
+++ b/television/channels/preview.rs
@@ -2,12 +2,10 @@ use std::fmt::Display;
 
 use crate::channels::{
     entry::Entry,
-    prototypes::{ChannelPrototype, DEFAULT_DELIMITER},
+    prototypes::{
+        format_prototype_string, ChannelPrototype, DEFAULT_DELIMITER,
+    },
 };
-use lazy_regex::{regex, Lazy, Regex};
-use tracing::debug;
-
-static CMD_RE: &Lazy<Regex> = regex!(r"\{(\d+)\}");
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Default)]
 pub struct PreviewCommand {
@@ -47,23 +45,7 @@ impl PreviewCommand {
     /// assert_eq!(formatted_command, "something 'a:given:entry:to:preview' 'entry' 'a'");
     /// ```
     pub fn format_with(&self, entry: &Entry) -> String {
-        let parts = entry.name.split(&self.delimiter).collect::<Vec<&str>>();
-
-        let mut formatted_command = self
-            .command
-            .replace("{}", format!("'{}'", entry.name).as_str());
-        debug!("FORMATTED_COMMAND: {formatted_command}");
-        debug!("PARTS: {parts:?}");
-
-        formatted_command = CMD_RE
-            .replace_all(&formatted_command, |caps: &regex::Captures| {
-                let index =
-                    caps.get(1).unwrap().as_str().parse::<usize>().unwrap();
-                format!("'{}'", parts[index])
-            })
-            .to_string();
-
-        formatted_command
+        format_prototype_string(&self.command, &entry.name, &self.delimiter)
     }
 }
 

--- a/television/channels/preview.rs
+++ b/television/channels/preview.rs
@@ -1,17 +1,25 @@
 use std::fmt::Display;
 
-use crate::channels::{
-    entry::Entry,
-    prototypes::{
-        format_prototype_string, ChannelPrototype, DEFAULT_DELIMITER,
-    },
-};
+use serde::Deserialize;
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Default)]
+use crate::channels::{entry::Entry, prototypes::format_prototype_string};
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Default, Deserialize)]
 pub struct PreviewCommand {
     pub command: String,
+    #[serde(default = "default_delimiter")]
     pub delimiter: String,
+    #[serde(rename = "offset")]
     pub offset_expr: Option<String>,
+}
+
+pub const DEFAULT_DELIMITER: &str = " ";
+
+/// The default delimiter to use for the preview command to use to split
+/// entries into multiple referenceable parts.
+#[allow(clippy::unnecessary_wraps)]
+fn default_delimiter() -> String {
+    DEFAULT_DELIMITER.to_string()
 }
 
 impl PreviewCommand {
@@ -46,26 +54,6 @@ impl PreviewCommand {
     /// ```
     pub fn format_with(&self, entry: &Entry) -> String {
         format_prototype_string(&self.command, &entry.name, &self.delimiter)
-    }
-}
-
-impl From<&ChannelPrototype> for Option<PreviewCommand> {
-    fn from(value: &ChannelPrototype) -> Self {
-        if let Some(command) = value.preview_command.as_ref() {
-            let delimiter = value
-                .preview_delimiter
-                .as_ref()
-                .map_or(DEFAULT_DELIMITER, |v| v);
-
-            let offset_expr = value.preview_offset.clone();
-
-            // FIXME: handle offset here (side note: we don't want to reparse the offset
-            // expression for each entry, so maybe just parse it once and try to store it
-            // as some sort of function we can call later on
-            Some(PreviewCommand::new(command, delimiter, offset_expr))
-        } else {
-            None
-        }
     }
 }
 

--- a/television/channels/prototypes.rs
+++ b/television/channels/prototypes.rs
@@ -1,3 +1,4 @@
+use lazy_regex::{regex, Lazy, Regex};
 use rustc_hash::FxHashMap;
 use std::{
     fmt::{self, Display, Formatter},
@@ -124,6 +125,29 @@ impl Display for ChannelPrototype {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{}", self.name)
     }
+}
+
+pub static CMD_RE: &Lazy<Regex> = regex!(r"\{(\d+)\}");
+
+pub fn format_prototype_string(
+    template: &str,
+    source: &str,
+    delimiter: &str,
+) -> String {
+    let parts = source.split(delimiter).collect::<Vec<&str>>();
+
+    let mut formatted_string =
+        template.replace("{}", format!("'{}'", source).as_str());
+
+    formatted_string = CMD_RE
+        .replace_all(&formatted_string, |caps: &regex::Captures| {
+            let index =
+                caps.get(1).unwrap().as_str().parse::<usize>().unwrap();
+            format!("'{}'", parts[index])
+        })
+        .to_string();
+
+    formatted_string
 }
 
 /// A neat `HashMap` of channel prototypes indexed by their name.

--- a/television/cli/args.rs
+++ b/television/cli/args.rs
@@ -25,6 +25,14 @@ pub struct Cli {
     #[arg(short, long, value_name = "STRING", verbatim_doc_comment)]
     pub preview: Option<String>,
 
+    /// A preview line number offset template to use to scroll the preview to for each
+    /// entry.
+    ///
+    /// This template uses the same syntax as the `preview` option and will be formatted
+    /// using the currently selected entry.
+    #[arg(long, value_name = "STRING", verbatim_doc_comment)]
+    pub preview_offset: Option<String>,
+
     /// Disable the preview panel entirely on startup.
     #[arg(long, default_value = "false", verbatim_doc_comment)]
     pub no_preview: bool,

--- a/television/cli/mod.rs
+++ b/television/cli/mod.rs
@@ -75,8 +75,7 @@ impl From<Cli> for PostProcessedCli {
         let preview_command = cli.preview.map(|preview| PreviewCommand {
             command: preview,
             delimiter: cli.delimiter.clone(),
-            // TODO: add the --preview-offset option to the CLI
-            offset_expr: None,
+            offset_expr: cli.preview_offset.clone(),
         });
 
         let mut channel: ChannelPrototype;

--- a/television/cli/mod.rs
+++ b/television/cli/mod.rs
@@ -11,7 +11,7 @@ use crate::{
         prototypes::{Cable, ChannelPrototype},
     },
     cli::args::{Cli, Command},
-    config::{get_config_dir, get_data_dir, KeyBindings, DEFAULT_CHANNEL},
+    config::{get_config_dir, get_data_dir, KeyBindings},
 };
 
 pub mod args;
@@ -81,16 +81,13 @@ impl From<Cli> for PostProcessedCli {
         let mut channel: ChannelPrototype;
         let working_directory: Option<String>;
 
-        let cable_channels = cable::load_cable().unwrap_or_default();
+        let cable = cable::load_cable().unwrap_or_default();
         if cli.channel.is_none() {
-            channel = cable_channels
-                .get(DEFAULT_CHANNEL)
-                .expect("Default channel not found in cable channels")
-                .clone();
+            channel = cable.default_channel();
             working_directory = cli.working_directory;
         } else {
             let cli_channel = cli.channel.as_ref().unwrap().to_owned();
-            match parse_channel(&cli_channel, &cable_channels) {
+            match parse_channel(&cli_channel, &cable) {
                 Ok(p) => {
                     channel = p;
                     working_directory = cli.working_directory;
@@ -101,12 +98,7 @@ impl From<Cli> for PostProcessedCli {
                     if cli.working_directory.is_none()
                         && Path::new(&cli_channel).exists()
                     {
-                        channel = cable_channels
-                            .get(DEFAULT_CHANNEL)
-                            .expect(
-                                "Default channel not found in cable channels",
-                            )
-                            .clone();
+                        channel = cable.default_channel();
                         working_directory = Some(cli.channel.unwrap().clone());
                     } else {
                         unknown_channel_exit(&cli.channel.unwrap());
@@ -116,10 +108,9 @@ impl From<Cli> for PostProcessedCli {
             }
         }
 
+        // override the default previewer
         if let Some(preview_cmd) = &preview_command {
-            channel.preview_command = Some(preview_cmd.command.clone());
-            channel.preview_delimiter = Some(preview_cmd.delimiter.clone());
-            channel.preview_offset.clone_from(&preview_cmd.offset_expr);
+            channel.preview_command = Some(preview_cmd.clone());
         }
 
         Self {
@@ -316,7 +307,11 @@ mod tests {
         let post_processed_cli: PostProcessedCli = cli.into();
 
         let expected = ChannelPrototype {
-            preview_delimiter: Some(":".to_string()),
+            preview_command: Some(PreviewCommand {
+                command: "bat -n --color=always {}".to_string(),
+                delimiter: ":".to_string(),
+                offset_expr: None,
+            }),
             ..Default::default()
         };
 

--- a/television/config/mod.rs
+++ b/television/config/mod.rs
@@ -15,6 +15,8 @@ pub use themes::Theme;
 use tracing::{debug, warn};
 pub use ui::UiConfig;
 
+use crate::channels::prototypes::DEFAULT_PROTOTYPE_NAME;
+
 mod keybindings;
 pub mod shell_integration;
 mod themes;
@@ -39,10 +41,8 @@ pub struct AppConfig {
     pub default_channel: String,
 }
 
-pub const DEFAULT_CHANNEL: &str = "files";
-
 fn default_channel() -> String {
-    DEFAULT_CHANNEL.to_string()
+    DEFAULT_PROTOTYPE_NAME.to_string()
 }
 
 impl Hash for AppConfig {

--- a/television/main.rs
+++ b/television/main.rs
@@ -60,7 +60,7 @@ async fn main() -> Result<()> {
 
     // determine the channel to use based on the CLI arguments and configuration
     debug!("Determining channel...");
-    let channel = determine_channel(
+    let channel_prototype = determine_channel(
         args.clone(),
         &config,
         is_readable_stdin(),
@@ -77,8 +77,13 @@ async fn main() -> Result<()> {
         args.no_help,
         config.application.tick_rate,
     );
-    let mut app =
-        App::new(channel, config, args.input, options, &cable_channels);
+    let mut app = App::new(
+        &channel_prototype,
+        config,
+        args.input,
+        options,
+        &cable_channels,
+    );
     stdout().flush()?;
     debug!("Running application...");
     let output = app.run(stdout().is_terminal(), false).await?;
@@ -217,7 +222,7 @@ mod tests {
             &args,
             &config,
             true,
-            &ChannelPrototype::new("stdin", "cat", false, None, None, None),
+            &ChannelPrototype::new("stdin", "cat", false, None),
             None,
         );
     }
@@ -226,7 +231,7 @@ mod tests {
     async fn test_determine_channel_autocomplete_prompt() {
         let autocomplete_prompt = Some("cd".to_string());
         let expected_channel =
-            ChannelPrototype::new("dirs", "ls {}", false, None, None, None);
+            ChannelPrototype::new("dirs", "ls {}", false, None);
         let args = PostProcessedCli {
             autocomplete_prompt,
             ..Default::default()
@@ -258,8 +263,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_determine_channel_standard_case() {
-        let channel =
-            ChannelPrototype::new("dirs", "", false, None, None, None);
+        let channel = ChannelPrototype::new("dirs", "", false, None);
         let args = PostProcessedCli {
             channel,
             ..Default::default()
@@ -269,7 +273,7 @@ mod tests {
             &args,
             &config,
             false,
-            &ChannelPrototype::new("dirs", "", false, None, None, None),
+            &ChannelPrototype::new("dirs", "", false, None),
             None,
         );
     }

--- a/tests/app.rs
+++ b/tests/app.rs
@@ -47,7 +47,7 @@ fn setup_app(
         false,
         config.application.tick_rate,
     );
-    let mut app = App::new(chan, config, input, options, &Cable::default());
+    let mut app = App::new(&chan, config, input, options, &Cable::default());
 
     // retrieve the app's action channel handle in order to send a quit action
     let tx = app.action_tx.clone();
@@ -212,14 +212,8 @@ async fn test_app_exact_search_positive() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
 async fn test_app_exits_when_select_1_and_only_one_result() {
-    let prototype = ChannelPrototype::new(
-        "some_channel",
-        "echo file1.txt",
-        false,
-        None,
-        None,
-        None,
-    );
+    let prototype =
+        ChannelPrototype::new("some_channel", "echo file1.txt", false, None);
     let (f, tx) = setup_app(Some(prototype), true, false);
 
     // tick a few times to get the results
@@ -254,8 +248,6 @@ async fn test_app_does_not_exit_when_select_1_and_more_than_one_result() {
         "some_channel",
         "echo 'file1.txt\nfile2.txt'",
         false,
-        None,
-        None,
         None,
     );
     let (f, tx) = setup_app(Some(prototype), true, false);


### PR DESCRIPTION
BREAKING CHANGE: the format of the cable channel files and more specifically the preview specification is updated to be a single table named `preview` (with keys `command`, `delimiter`, and `offset`) instead of three flat fields.

```toml
preview_command = "echo 3"
preview_delimiter = " "
preview_offset = "{1}"
```

becomes: 

```toml
preview.command = "echo 3"
preview.delimiter = " "
preview.offset = "{1}"
```