### PR TITLE
fix(channels): use default_channel from config

### DIFF
--- a/television/channels/prototypes.rs
+++ b/television/channels/prototypes.rs
@@ -4,6 +4,7 @@ use std::{
     ops::Deref,
 };
 
+use crate::config::default_channel;
 use crate::{cable::CableSpec, channels::preview::PreviewCommand};
 
 /// A prototype for cable channels.
@@ -110,11 +111,10 @@ impl Deref for Cable {
 
 impl Cable {
     pub fn default_channel(&self) -> ChannelPrototype {
-        self.get(DEFAULT_PROTOTYPE_NAME)
-            .cloned()
-            .unwrap_or_else(|| {
-                panic!("Default channel '{DEFAULT_PROTOTYPE_NAME}' not found")
-            })
+        let default_channel = &default_channel();
+        self.get(default_channel).cloned().unwrap_or_else(|| {
+            panic!("Default channel '{default_channel}' not found")
+        })
     }
 }
 

--- a/television/config/mod.rs
+++ b/television/config/mod.rs
@@ -15,8 +15,6 @@ pub use themes::Theme;
 use tracing::{debug, warn};
 pub use ui::UiConfig;
 
-use crate::channels::prototypes::DEFAULT_PROTOTYPE_NAME;
-
 mod keybindings;
 pub mod shell_integration;
 mod themes;
@@ -41,8 +39,9 @@ pub struct AppConfig {
     pub default_channel: String,
 }
 
-fn default_channel() -> String {
-    DEFAULT_PROTOTYPE_NAME.to_string()
+pub fn default_channel() -> String {
+    let config = Config::load_user_config(&get_config_dir()).unwrap();
+    config.application.default_channel.to_string()
 }
 
 impl Hash for AppConfig {


### PR DESCRIPTION
sorry, first rust code ever 😅
solves https://github.com/alexpasmantier/television/issues/520.

With the current implementation the `default_channel` value from config was never loaded