### PR TITLE
POC of changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,21 +33,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,21 +211,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
-dependencies = [
- "android-tzdata",
- "iana-time-zone",
- "js-sys",
- "num-traits",
- "serde",
- "wasm-bindgen",
- "windows-link",
-]
-
-[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,12 +328,6 @@ dependencies = [
  "once_cell",
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -801,30 +765,6 @@ dependencies = [
  "serde_derive",
  "toml",
  "uuid",
-]
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1644,16 +1584,14 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "string_pipeline"
 version = "0.11.2"
-source = "git+https://github.com/lalvarezt/string_pipeline?rev=2bb3553#2bb35536436665b8a2f6d81cf6a98655d3892208"
+source = "git+https://github.com/lalvarezt/string_pipeline?rev=bf551fb68ddd#bf551fb68ddd9f94139179f15d75f306275e80d9"
 dependencies = [
- "chrono",
  "clap",
  "clap_mangen",
  "once_cell",
  "pest",
  "pest_derive",
  "regex",
- "serde_json",
  "strip-ansi-escapes",
 ]
 
@@ -2210,65 +2148,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-link"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1643,9 +1643,8 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_pipeline"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0af3613597e31606b54dd5d62be86b8f50922b40d2b7d3d145146caf5c154c05"
+version = "0.11.2"
+source = "git+https://github.com/lalvarezt/string_pipeline?rev=2bb3553#2bb35536436665b8a2f6d81cf6a98655d3892208"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ lazy-regex = { version = "3.4.1", features = [
 ], default-features = false }
 ansi-to-tui = "7.0.0"
 walkdir = "2.5.0"
-string_pipeline = { git = "https://github.com/lalvarezt/string_pipeline", rev = "2bb3553" }
+string_pipeline = { git = "https://github.com/lalvarezt/string_pipeline", rev = "bf551fb68ddd" }
 ureq = "3.0.11"
 serde_json = "1.0.140"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ lazy-regex = { version = "3.4.1", features = [
 ], default-features = false }
 ansi-to-tui = "7.0.0"
 walkdir = "2.5.0"
-string_pipeline = "0.11.1"
+string_pipeline = { git = "https://github.com/lalvarezt/string_pipeline", rev = "2bb3553" }
 ureq = "3.0.11"
 serde_json = "1.0.140"
 

--- a/cable/unix/text.toml
+++ b/cable/unix/text.toml
@@ -5,7 +5,7 @@ requirements = ["rg", "bat"]
 
 [source]
 command = "rg . --no-heading --line-number"
-display = "[{split:\\::..2}]\t{split:\\::2}"
+display = "[{split:\\::..2}]\t{split:\\::2..}"
 output = "{split:\\::..2}"
 
 [preview]

--- a/television/channels/entry.rs
+++ b/television/channels/entry.rs
@@ -175,7 +175,8 @@ mod tests {
             line_number: None,
         };
         assert_eq!(
-            entry.stdout_repr(&Some(MultiTemplate::parse("{}").unwrap())),
+            entry
+                .stdout_repr(&Some(MultiTemplate::parse("{}", None).unwrap())),
             "test name with spaces"
         );
     }

--- a/television/channels/prototypes.rs
+++ b/television/channels/prototypes.rs
@@ -116,9 +116,10 @@ impl ChannelPrototype {
             },
             source: SourceSpec {
                 command: CommandSpec {
-                    inner: MultiTemplate::parse(source_command, None).expect(
-                        "Failed to parse source command MultiTemplate",
-                    ),
+                    inner: MultiTemplate::parse(source_command, Some(false))
+                        .expect(
+                            "Failed to parse source command MultiTemplate",
+                        ),
                     interactive: false,
                     env: FxHashMap::default(),
                 },
@@ -142,7 +143,7 @@ impl ChannelPrototype {
             },
             source: SourceSpec {
                 command: CommandSpec {
-                    inner: MultiTemplate::parse("cat", None).unwrap(),
+                    inner: MultiTemplate::parse("cat", Some(false)).unwrap(),
                     interactive: false,
                     env: FxHashMap::default(),
                 },
@@ -213,7 +214,7 @@ impl PreviewSpec {
     pub fn from_str_command(command: &str) -> Self {
         Self {
             command: CommandSpec {
-                inner: MultiTemplate::parse(command, None)
+                inner: MultiTemplate::parse(command, Some(false))
                     .expect("Failed to parse preview command"),
                 interactive: false,
                 env: FxHashMap::default(),

--- a/television/channels/prototypes.rs
+++ b/television/channels/prototypes.rs
@@ -73,7 +73,7 @@ where
     D: serde::Deserializer<'de>,
 {
     let raw: String = serde::Deserialize::deserialize(deserializer)?;
-    MultiTemplate::parse(&raw).map_err(serde::de::Error::custom)
+    MultiTemplate::parse(&raw, None).map_err(serde::de::Error::custom)
 }
 
 fn deserialize_maybe_template<'de, D>(
@@ -84,7 +84,7 @@ where
 {
     let raw: Option<String> = serde::Deserialize::deserialize(deserializer)?;
     match raw {
-        Some(template) => MultiTemplate::parse(&template)
+        Some(template) => MultiTemplate::parse(&template, None)
             .map(Some)
             .map_err(serde::de::Error::custom),
         None => Ok(None),
@@ -116,7 +116,7 @@ impl ChannelPrototype {
             },
             source: SourceSpec {
                 command: CommandSpec {
-                    inner: MultiTemplate::parse(source_command).expect(
+                    inner: MultiTemplate::parse(source_command, None).expect(
                         "Failed to parse source command MultiTemplate",
                     ),
                     interactive: false,
@@ -142,7 +142,7 @@ impl ChannelPrototype {
             },
             source: SourceSpec {
                 command: CommandSpec {
-                    inner: MultiTemplate::parse("cat").unwrap(),
+                    inner: MultiTemplate::parse("cat", None).unwrap(),
                     interactive: false,
                     env: FxHashMap::default(),
                 },
@@ -213,7 +213,7 @@ impl PreviewSpec {
     pub fn from_str_command(command: &str) -> Self {
         Self {
             command: CommandSpec {
-                inner: MultiTemplate::parse(command)
+                inner: MultiTemplate::parse(command, None)
                     .expect("Failed to parse preview command"),
                 interactive: false,
                 env: FxHashMap::default(),

--- a/television/cli/mod.rs
+++ b/television/cli/mod.rs
@@ -68,7 +68,7 @@ pub fn post_process(cli: Cli) -> PostProcessedCli {
     // Parse the preview spec if provided
     let preview_spec = cli.preview.as_ref().map(|preview| {
         let command_spec = CommandSpec::new(
-            MultiTemplate::parse(preview, None).unwrap_or_else(|e| {
+            MultiTemplate::parse(preview, Some(false)).unwrap_or_else(|e| {
                 cli_parsing_error_exit(&format!(
                     "Error parsing preview command: {e}"
                 ))
@@ -79,11 +79,13 @@ pub fn post_process(cli: Cli) -> PostProcessedCli {
         PreviewSpec::new(
             command_spec,
             cli.preview_offset.map(|offset_str| {
-                MultiTemplate::parse(&offset_str, None).unwrap_or_else(|e| {
-                    cli_parsing_error_exit(&format!(
-                        "Error parsing preview offset: {e}"
-                    ))
-                })
+                MultiTemplate::parse(&offset_str, Some(false)).unwrap_or_else(
+                    |e| {
+                        cli_parsing_error_exit(&format!(
+                            "Error parsing preview offset: {e}"
+                        ))
+                    },
+                )
             }),
         )
     });

--- a/television/cli/mod.rs
+++ b/television/cli/mod.rs
@@ -68,7 +68,7 @@ pub fn post_process(cli: Cli) -> PostProcessedCli {
     // Parse the preview spec if provided
     let preview_spec = cli.preview.as_ref().map(|preview| {
         let command_spec = CommandSpec::new(
-            MultiTemplate::parse(preview).unwrap_or_else(|e| {
+            MultiTemplate::parse(preview, None).unwrap_or_else(|e| {
                 cli_parsing_error_exit(&format!(
                     "Error parsing preview command: {e}"
                 ))
@@ -79,7 +79,7 @@ pub fn post_process(cli: Cli) -> PostProcessedCli {
         PreviewSpec::new(
             command_spec,
             cli.preview_offset.map(|offset_str| {
-                MultiTemplate::parse(&offset_str).unwrap_or_else(|e| {
+                MultiTemplate::parse(&offset_str, None).unwrap_or_else(|e| {
                     cli_parsing_error_exit(&format!(
                         "Error parsing preview offset: {e}"
                     ))

--- a/television/main.rs
+++ b/television/main.rs
@@ -335,7 +335,7 @@ mod tests {
     fn test_determine_channel_with_cli_preview() {
         let preview_spec = PreviewSpec::new(
             CommandSpec::new(
-                MultiTemplate::parse("echo hello", None).unwrap(),
+                MultiTemplate::parse("echo hello", Some(false)).unwrap(),
                 false,
                 FxHashMap::default(),
             ),

--- a/television/main.rs
+++ b/television/main.rs
@@ -335,7 +335,7 @@ mod tests {
     fn test_determine_channel_with_cli_preview() {
         let preview_spec = PreviewSpec::new(
             CommandSpec::new(
-                MultiTemplate::parse("echo hello").unwrap(),
+                MultiTemplate::parse("echo hello", None).unwrap(),
                 false,
                 FxHashMap::default(),
             ),

--- a/television/previewer/mod.rs
+++ b/television/previewer/mod.rs
@@ -173,8 +173,9 @@ impl Previewer {
                         let results_handle = self.results.clone();
                         self.last_job_entry = Some(ticket.entry.clone());
                         // try to execute the preview with a timeout
-                        let preview_command =
+                        let mut preview_command =
                             self.preview_spec.command.clone();
+                        preview_command.inner.set_debug(false);
                         match timeout(
                             self.config.job_timeout,
                             tokio::spawn(async move {
@@ -222,8 +223,6 @@ pub fn try_preview(
     let child = shell_command(
         &command
             .inner
-            .clone()
-            .with_debug(false)
             .format(&entry.raw)
             .expect("Failed to format command"),
         command.interactive,

--- a/television/previewer/mod.rs
+++ b/television/previewer/mod.rs
@@ -222,6 +222,8 @@ pub fn try_preview(
     let child = shell_command(
         &command
             .inner
+            .clone()
+            .with_debug(false)
             .format(&entry.raw)
             .expect("Failed to format command"),
         command.interactive,

--- a/television/previewer/mod.rs
+++ b/television/previewer/mod.rs
@@ -173,9 +173,8 @@ impl Previewer {
                         let results_handle = self.results.clone();
                         self.last_job_entry = Some(ticket.entry.clone());
                         // try to execute the preview with a timeout
-                        let mut preview_command =
+                        let preview_command =
                             self.preview_spec.command.clone();
-                        preview_command.inner.set_debug(false);
                         match timeout(
                             self.config.job_timeout,
                             tokio::spawn(async move {


### PR DESCRIPTION
## text cable update
there was a minor bug in the text cable template

before
`display = "[{split:\\::..2}]\t{split:\\::2..}"`

after
`display = "[{split:\\::..2}]\t{split:\\::2}"`

this allows to capture items after the split that also contain the separator

## artifact when rendering the preview with debug flag enabled

this is POC you can solve it in another way