### PR TITLE
New channel and added reload and toggle actions

### DIFF
--- a/cable/unix/env.toml
+++ b/cable/unix/env.toml
@@ -1,0 +1,39 @@
+[metadata]
+name = "env"
+description = "A channel to select from the environment variables"
+
+[source]
+command = "printenv"
+interactive = false
+# env
+display = "{}"           # show the key-value pair
+output = "{split:=:1..}" # output the value
+
+[preview]
+# command = "cut -d= -f2 <<< ${0} | cut -d\" \" -f2- | sed 's/:/\\n/g'"
+command = "echo '{split:=:1..}'" # output the value
+
+[ui]
+layout = "landscape"
+ui_scale = 100
+show_help_bar = false
+show_preview_panel = true
+input_bar_position = "top"
+
+[keybindings]
+quit = ["esc", "ctrl-c"]
+select_next_entry = ["down", "ctrl-n", "ctrl-j"]
+select_prev_entry = ["up", "ctrl-p", "ctrl-k"]
+confirm_selection = "enter"
+
+# [actions.'open in $EDITOR']
+# command = "$EDITOR {}"
+# mode = "become"          # "become" / "spawn" / "transform"
+#
+# [actions.'remove']
+# command = "rm {}"
+# mode = "spawn"
+#
+# [actions.'rename']
+# command = "read -p \"New name: \" new_name && mv {} $new_name"
+# mode = "spawn"

--- a/cable/unix/files.toml
+++ b/cable/unix/files.toml
@@ -4,7 +4,7 @@ description = "A channel to select files and directories"
 requirements = ["fd", "bat"]
 
 [source]
-command = "fd -t f"
+command = ["fd -t f", "fd -t f -H"]
 interactive = false
 # env
 display = "{}" # show the full path
@@ -26,6 +26,8 @@ quit = ["esc", "ctrl-c"]
 select_next_entry = ["down", "ctrl-n", "ctrl-j"]
 select_prev_entry = ["up", "ctrl-p", "ctrl-k"]
 confirm_selection = "enter"
+toggle_source = "ctrl-t"
+reload_source = "ctrl-r"
 
 # [actions.'open in $EDITOR']
 # command = "$EDITOR {}"

--- a/television/action.rs
+++ b/television/action.rs
@@ -121,8 +121,8 @@ pub enum Action {
     #[serde(alias = "toggle_send_to_channel")]
     ToggleSendToChannel,
     /// Toggle between different source commands.
-    #[serde(alias = "toggle_source")]
-    ToggleSource,
+    #[serde(alias = "cycle_through_sources")]
+    CycleThroughSources,
     /// Reload the current source command.
     #[serde(alias = "reload_source")]
     ReloadSource,

--- a/television/action.rs
+++ b/television/action.rs
@@ -120,4 +120,10 @@ pub enum Action {
     /// Toggle the remote control in `send to channel` mode.
     #[serde(alias = "toggle_send_to_channel")]
     ToggleSendToChannel,
+    /// Toggle between different source commands.
+    #[serde(alias = "toggle_source")]
+    ToggleSource,
+    /// Reload the current source command.
+    #[serde(alias = "reload_source")]
+    ReloadSource,
 }

--- a/television/channels/channel.rs
+++ b/television/channels/channel.rs
@@ -52,6 +52,14 @@ impl Channel {
         self.load();
     }
 
+    pub fn current_command(&self) -> &str {
+        self.prototype
+            .source
+            .command
+            .get_nth(self.current_source_index)
+            .template_string()
+    }
+
     pub fn find(&mut self, pattern: &str) {
         self.matcher.find(pattern);
     }

--- a/television/channels/channel.rs
+++ b/television/channels/channel.rs
@@ -15,21 +15,41 @@ pub struct Channel {
     pub prototype: ChannelPrototype,
     matcher: Matcher<String>,
     selected_entries: FxHashSet<Entry>,
-    crawl_handle: tokio::task::JoinHandle<()>,
+    crawl_handle: Option<tokio::task::JoinHandle<()>>,
+    current_source_index: usize,
 }
 
 impl Channel {
     pub fn new(prototype: ChannelPrototype) -> Self {
         let matcher = Matcher::new(Config::default());
-        let injector = matcher.injector();
-        let crawl_handle =
-            tokio::spawn(load_candidates(prototype.source.clone(), injector));
+        let current_source_index = 0;
         Self {
             prototype,
             matcher,
             selected_entries: HashSet::with_hasher(FxBuildHasher),
-            crawl_handle,
+            crawl_handle: None,
+            current_source_index,
         }
+    }
+
+    pub fn load(&mut self) {
+        let injector = self.matcher.injector();
+        let crawl_handle = tokio::spawn(load_candidates(
+            self.prototype.source.clone(),
+            self.current_source_index,
+            injector,
+        ));
+        self.crawl_handle = Some(crawl_handle);
+    }
+
+    pub fn reload(&mut self) {
+        if let Some(handle) = self.crawl_handle.take() {
+            if !handle.is_finished() {
+                handle.abort();
+            }
+        }
+        self.matcher.restart();
+        self.load();
     }
 
     pub fn find(&mut self, pattern: &str) {
@@ -55,6 +75,7 @@ impl Channel {
                 .with_display(item.matched_string)
                 .with_match_indices(&item.match_indices);
             if let Some(p) = &self.prototype.preview {
+                // FIXME: this should be done by the previewer instead
                 if let Some(offset_expr) = &p.offset {
                     let offset_str = offset_expr
                         .format(&item.inner)
@@ -95,7 +116,9 @@ impl Channel {
     }
 
     pub fn running(&self) -> bool {
-        self.matcher.status.running || !self.crawl_handle.is_finished()
+        self.matcher.status.running
+            || (self.crawl_handle.is_some()
+                && !self.crawl_handle.as_ref().unwrap().is_finished())
     }
 
     pub fn shutdown(&self) {}
@@ -103,13 +126,35 @@ impl Channel {
     pub fn supports_preview(&self) -> bool {
         self.prototype.preview.is_some()
     }
+
+    /// Cycles to the next source command
+    pub fn cycle_sources(&mut self) {
+        if self.prototype.source.command.inner.len() > 1 {
+            self.current_source_index = (self.current_source_index + 1)
+                % self.prototype.source.command.inner.len();
+            debug!(
+                "Cycling to source command index: {}",
+                self.current_source_index
+            );
+            self.reload();
+        } else {
+            debug!("No other source commands to cycle through.");
+        }
+    }
 }
 
 #[allow(clippy::unused_async)]
-async fn load_candidates(source: SourceSpec, injector: Injector<String>) {
+async fn load_candidates(
+    source: SourceSpec,
+    source_command_index: usize,
+    injector: Injector<String>,
+) {
     debug!("Loading candidates from command: {:?}", source.command);
     let mut child = shell_command(
-        source.command.inner.template_string(),
+        source
+            .command
+            .get_nth(source_command_index)
+            .template_string(),
         source.command.interactive,
         &source.command.env,
     )

--- a/television/channels/prototypes.rs
+++ b/television/channels/prototypes.rs
@@ -479,6 +479,41 @@ mod tests {
     }
 
     #[test]
+    fn test_channel_prototype_deserialization_multiple_commands() {
+        let toml_data = r#"
+        [metadata]
+        name = "files"
+        description = "A channel to select files and directories"
+        requirements = ["fd", "bat"]
+
+        [source]
+        command = ["fd -t f", "fd -t f --hidden"]
+        output = "{}"            # output the full path
+        "#;
+
+        let prototype: ChannelPrototype = from_str(toml_data).unwrap();
+
+        assert_eq!(prototype.metadata.name, "files");
+        assert_eq!(
+            prototype.metadata.description,
+            Some("A channel to select files and directories".to_string())
+        );
+        assert_eq!(
+            prototype
+                .source
+                .command
+                .inner
+                .iter()
+                .map(string_pipeline::MultiTemplate::template_string)
+                .collect::<Vec<_>>(),
+            vec!["fd -t f", "fd -t f --hidden"]
+        );
+        assert!(!prototype.source.command.interactive);
+        assert!(prototype.source.command.env.is_empty());
+        assert_eq!(prototype.source.output.unwrap().template_string(), "{}");
+    }
+
+    #[test]
     fn test_channel_prototype_deserialization_bare_minimum() {
         let toml_data = r#"
         [metadata]

--- a/television/channels/prototypes.rs
+++ b/television/channels/prototypes.rs
@@ -5,140 +5,86 @@ use crate::{
     screen::layout::{InputPosition, Orientation},
 };
 use rustc_hash::FxHashMap;
+use serde::ser::SerializeSeq;
 use string_pipeline::MultiTemplate;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct CommandSpec {
-    pub inner: MultiTemplate,
-    /// List of commands when multiple are provided (for source commands)
-    pub command_list: Vec<String>,
+    #[serde(
+        rename = "command",
+        deserialize_with = "deserialize_commands",
+        serialize_with = "serialize_commands"
+    )]
+    pub inner: Vec<MultiTemplate>,
+    #[serde(default)]
     pub interactive: bool,
+    #[serde(default)]
     pub env: FxHashMap<String, String>,
 }
 
-impl serde::Serialize for CommandSpec {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        use serde::ser::SerializeStruct;
-        let mut state = serializer.serialize_struct("CommandSpec", 3)?;
-
-        // Serialize command list if it has multiple commands, otherwise serialize the single command
-        if self.command_list.len() > 1 {
-            state.serialize_field("command", &self.command_list)?;
-        } else {
-            state.serialize_field("command", &self.inner.template_string())?;
-        }
-
-        state.serialize_field("interactive", &self.interactive)?;
-        state.serialize_field("env", &self.env)?;
-        state.end()
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for CommandSpec {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        #[derive(serde::Deserialize)]
-        struct Helper {
-            command: SerializedCommand,
-            #[serde(default)]
-            interactive: bool,
-            #[serde(default)]
-            env: FxHashMap<String, String>,
-        }
-
-        let helper = Helper::deserialize(deserializer)?;
-        let (inner, command_list) = match helper.command {
-            SerializedCommand::Single(s) => {
-                let template = MultiTemplate::parse(&s)
-                    .map_err(serde::de::Error::custom)?;
-                (template, vec![s])
-            }
-            SerializedCommand::Multiple(commands) => {
-                let first_command =
-                    commands.first().map(String::as_str).unwrap_or("");
-                let template = MultiTemplate::parse(first_command)
-                    .map_err(serde::de::Error::custom)?;
-                (template, commands)
-            }
-        };
-
-        Ok(CommandSpec {
-            inner,
-            command_list,
-            interactive: helper.interactive,
-            env: helper.env,
-        })
-    }
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(untagged)]
+enum SerializedCommand {
+    Single(String),
+    Multiple(Vec<String>),
 }
 
 impl Display for CommandSpec {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{}", self.inner.template_string())
+        write!(
+            f,
+            "[{}]",
+            self.inner
+                .iter()
+                .map(string_pipeline::MultiTemplate::template_string)
+                .collect::<Vec<_>>()
+                .join(";")
+        )
     }
 }
 
 impl CommandSpec {
     pub fn new(
-        inner: MultiTemplate,
+        inner: Vec<MultiTemplate>,
         interactive: bool,
         env: FxHashMap<String, String>,
     ) -> Self {
         Self {
             inner,
-            command_list: vec![],
             interactive,
             env,
         }
     }
 
-    /// Get the command at the specified index, or the current command if index is out of bounds
-    pub fn get_command_at_index(&self, index: usize) -> &str {
-        if self.command_list.is_empty() {
-            return self.inner.template_string();
-        }
-
-        if let Some(command) = self.command_list.get(index) {
-            command.as_str()
-        } else if let Some(first_command) = self.command_list.first() {
-            first_command.as_str()
-        } else {
-            self.inner.template_string()
-        }
-    }
-
-    /// Check if this command spec has multiple commands
-    pub fn has_multiple_commands(&self) -> bool {
-        self.command_list.len() > 1
-    }
-
-    /// Get the total number of commands
     pub fn command_count(&self) -> usize {
-        if self.command_list.is_empty() {
-            1
-        } else {
-            self.command_list.len()
-        }
+        self.inner.len()
+    }
+
+    pub fn has_multiple_commands(&self) -> bool {
+        self.inner.len() > 1
+    }
+
+    /// This wraps back to the first command in a circular manner.
+    ///
+    /// # Panics
+    /// If the command spec does not contain any commands.
+    pub fn get_nth(&self, index: usize) -> &MultiTemplate {
+        &self.inner[index % self.inner.len()]
     }
 }
 
-fn serialize_template<S>(
+fn serialize_command<S>(
     command: &MultiTemplate,
     serializer: S,
 ) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
 {
-    let raw = command.template_string();
-    serializer.serialize_str(raw)
+    serializer.serialize_str(command.template_string())
 }
 
 #[allow(clippy::ref_option)]
-fn serialize_maybe_template<S>(
+fn serialize_maybe_command<S>(
     command: &Option<MultiTemplate>,
     serializer: S,
 ) -> Result<S::Ok, S::Error>
@@ -146,19 +92,23 @@ where
     S: serde::Serializer,
 {
     match command {
-        Some(template) => serialize_template(template, serializer),
+        Some(cmd) => serialize_command(cmd, serializer),
         None => serializer.serialize_none(),
     }
 }
 
-#[derive(Debug, Clone, serde::Deserialize)]
-#[serde(untagged)]
-enum SerializedCommand {
-    Single(String),
-    Multiple(Vec<String>),
+#[allow(dead_code)]
+fn deserialize_command<'de, D>(
+    deserializer: D,
+) -> Result<MultiTemplate, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw: String = serde::Deserialize::deserialize(deserializer)?;
+    MultiTemplate::parse(&raw).map_err(serde::de::Error::custom)
 }
 
-fn deserialize_maybe_template<'de, D>(
+fn deserialize_maybe_command<'de, D>(
     deserializer: D,
 ) -> Result<Option<MultiTemplate>, D::Error>
 where
@@ -166,9 +116,99 @@ where
 {
     let raw: Option<String> = serde::Deserialize::deserialize(deserializer)?;
     match raw {
-        Some(template) => MultiTemplate::parse(&template)
+        Some(cmd) => MultiTemplate::parse(&cmd)
             .map(Some)
             .map_err(serde::de::Error::custom),
+        None => Ok(None),
+    }
+}
+
+fn serialize_commands<S>(
+    commands: &[MultiTemplate],
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    if commands.len() == 1 {
+        let raw = commands[0].template_string();
+        serializer.serialize_str(raw)
+    } else {
+        let raw: Vec<String> = commands
+            .iter()
+            .map(|c| c.template_string().to_string())
+            .collect();
+        let mut seq = serializer.serialize_seq(Some(raw.len()))?;
+        for item in raw {
+            seq.serialize_element(&item)?;
+        }
+        seq.end()
+    }
+}
+
+#[allow(clippy::ref_option, dead_code)]
+fn serialize_maybe_commands<S>(
+    commands: Option<&[MultiTemplate]>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    match commands {
+        Some(m) => serialize_commands(m, serializer),
+        None => serializer.serialize_none(),
+    }
+}
+
+fn deserialize_commands<'de, D>(
+    deserializer: D,
+) -> Result<Vec<MultiTemplate>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let res = match serde::Deserialize::deserialize(deserializer)? {
+        SerializedCommand::Single(cmd) => {
+            MultiTemplate::parse(&cmd).map(|m| vec![m])
+        }
+        SerializedCommand::Multiple(cmds) => cmds
+            .iter()
+            .map(|cmd| MultiTemplate::parse(cmd))
+            .collect::<Result<Vec<_>, _>>(),
+    }
+    .map_err(serde::de::Error::custom);
+
+    if let Ok(ref cmds) = res {
+        if cmds.is_empty() {
+            return Err(serde::de::Error::custom(
+                "Command list cannot be empty",
+            ));
+        }
+    }
+
+    res
+}
+
+#[allow(dead_code)]
+fn deserialize_maybe_commands<'de, D>(
+    deserializer: D,
+) -> Result<Option<Vec<MultiTemplate>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw: Option<SerializedCommand> =
+        serde::Deserialize::deserialize(deserializer)?;
+    match raw {
+        Some(template) => {
+            let cmd = match template {
+                SerializedCommand::Single(cmd) => {
+                    MultiTemplate::parse(&cmd).map(|m| vec![m])
+                }
+                SerializedCommand::Multiple(cmds) => {
+                    cmds.iter().map(|cmd| MultiTemplate::parse(cmd)).collect()
+                }
+            };
+            cmd.map_err(serde::de::Error::custom).map(Some)
+        }
         None => Ok(None),
     }
 }
@@ -188,20 +228,19 @@ pub struct ChannelPrototype {
 }
 
 impl ChannelPrototype {
-    // FIXME: is this really needed? maybe tests should use a toml spec directly
-    pub fn new(name: &str, source_command: &str) -> Self {
+    pub fn new(name: &str, command: &str) -> Self {
         Self {
             metadata: Metadata {
                 name: name.to_string(),
-                description: Some(String::new()),
+                description: None,
                 requirements: vec![],
             },
             source: SourceSpec {
                 command: CommandSpec {
-                    inner: MultiTemplate::parse(source_command).expect(
-                        "Failed to parse source command MultiTemplate",
-                    ),
-                    command_list: vec![source_command.to_string()],
+                    inner: vec![
+                        MultiTemplate::parse(command)
+                            .expect("Failed to parse command"),
+                    ],
                     interactive: false,
                     env: FxHashMap::default(),
                 },
@@ -225,8 +264,7 @@ impl ChannelPrototype {
             },
             source: SourceSpec {
                 command: CommandSpec {
-                    inner: MultiTemplate::parse("cat").unwrap(),
-                    command_list: vec!["cat".to_string()],
+                    inner: vec![MultiTemplate::parse("cat").unwrap()],
                     interactive: false,
                     env: FxHashMap::default(),
                 },
@@ -265,14 +303,14 @@ pub struct SourceSpec {
     pub command: CommandSpec,
     #[serde(
         default,
-        deserialize_with = "deserialize_maybe_template",
-        serialize_with = "serialize_maybe_template"
+        deserialize_with = "deserialize_maybe_command",
+        serialize_with = "serialize_maybe_command"
     )]
     pub display: Option<MultiTemplate>,
     #[serde(
         default,
-        deserialize_with = "deserialize_maybe_template",
-        serialize_with = "serialize_maybe_template"
+        deserialize_with = "deserialize_maybe_command",
+        serialize_with = "serialize_maybe_command"
     )]
     pub output: Option<MultiTemplate>,
 }
@@ -283,8 +321,8 @@ pub struct PreviewSpec {
     pub command: CommandSpec,
     #[serde(
         default,
-        deserialize_with = "deserialize_maybe_template",
-        serialize_with = "serialize_maybe_template"
+        deserialize_with = "deserialize_maybe_command",
+        serialize_with = "serialize_maybe_command"
     )]
     pub offset: Option<MultiTemplate>,
 }
@@ -297,9 +335,10 @@ impl PreviewSpec {
     pub fn from_str_command(command: &str) -> Self {
         Self {
             command: CommandSpec {
-                inner: MultiTemplate::parse(command)
-                    .expect("Failed to parse preview command"),
-                command_list: vec![command.to_string()],
+                inner: vec![
+                    MultiTemplate::parse(command)
+                        .expect("Failed to parse preview command"),
+                ],
                 interactive: false,
                 env: FxHashMap::default(),
             },
@@ -331,6 +370,24 @@ mod tests {
 
     use super::*;
     use toml::from_str;
+
+    #[test]
+    fn test_command_spec_get_nth() {
+        let command_spec = CommandSpec {
+            inner: vec![
+                MultiTemplate::parse("cmd1").unwrap(),
+                MultiTemplate::parse("cmd2").unwrap(),
+                MultiTemplate::parse("cmd3").unwrap(),
+            ],
+            interactive: false,
+            env: FxHashMap::default(),
+        };
+
+        assert_eq!(command_spec.get_nth(0).template_string(), "cmd1");
+        assert_eq!(command_spec.get_nth(1).template_string(), "cmd2");
+        assert_eq!(command_spec.get_nth(2).template_string(), "cmd3");
+        assert_eq!(command_spec.get_nth(3).template_string(), "cmd1"); // wraps around
+    }
 
     #[test]
     fn test_channel_prototype_deserialization() {
@@ -374,7 +431,10 @@ mod tests {
             prototype.metadata.description,
             Some("A channel to select files and directories".to_string())
         );
-        assert_eq!(format!("{}", prototype.source.command.inner), "fd -t f");
+        assert_eq!(
+            format!("{}", prototype.source.command.inner[0]),
+            "fd -t f"
+        );
         assert!(!prototype.source.command.interactive);
         assert_eq!(
             prototype.source.display.unwrap().template_string(),
@@ -382,7 +442,7 @@ mod tests {
         );
         assert_eq!(prototype.source.output.unwrap().template_string(), "{}");
         assert_eq!(
-            format!("{}", prototype.preview.unwrap().command.inner),
+            format!("{}", prototype.preview.unwrap().command.inner[0]),
             "bat -n --color=always {}"
         );
         let ui = prototype.ui.unwrap();
@@ -437,7 +497,10 @@ mod tests {
             prototype.metadata.description,
             Some("A channel to select files and directories".to_string())
         );
-        assert_eq!(format!("{}", prototype.source.command.inner), "fd -t f");
+        assert_eq!(
+            format!("{}", prototype.source.command.inner[0]),
+            "fd -t f"
+        );
         assert!(!prototype.source.command.interactive);
         assert!(prototype.source.command.env.is_empty());
         assert!(prototype.source.display.is_none());
@@ -470,7 +533,10 @@ mod tests {
             prototype.metadata.description,
             Some("A channel to select files and directories".to_string())
         );
-        assert_eq!(format!("{}", prototype.source.command.inner), "fd -t f");
+        assert_eq!(
+            format!("{}", prototype.source.command.inner[0]),
+            "fd -t f"
+        );
         assert!(!prototype.source.command.interactive);
         assert!(prototype.source.command.env.is_empty());
         assert!(prototype.source.display.is_none());

--- a/television/cli/mod.rs
+++ b/television/cli/mod.rs
@@ -68,11 +68,11 @@ pub fn post_process(cli: Cli) -> PostProcessedCli {
     // Parse the preview spec if provided
     let preview_spec = cli.preview.as_ref().map(|preview| {
         let command_spec = CommandSpec::new(
-            MultiTemplate::parse(preview).unwrap_or_else(|e| {
+            vec![MultiTemplate::parse(preview).unwrap_or_else(|e| {
                 cli_parsing_error_exit(&format!(
                     "Error parsing preview command: {e}"
                 ))
-            }),
+            })],
             false,
             FxHashMap::default(),
         );
@@ -280,7 +280,7 @@ mod tests {
                 .preview_spec
                 .unwrap()
                 .command
-                .inner
+                .get_nth(0)
                 .template_string(),
             "bat -n --color=always {}".to_string(),
         );

--- a/television/config/keybindings.rs
+++ b/television/config/keybindings.rs
@@ -8,6 +8,7 @@ use std::hash::Hash;
 use std::ops::{Deref, DerefMut};
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Hash)]
+#[serde(untagged)]
 pub enum Binding {
     SingleKey(Key),
     MultipleKeys(Vec<Key>),

--- a/television/draw.rs
+++ b/television/draw.rs
@@ -30,6 +30,7 @@ pub struct ChannelState {
     pub selected_entries: FxHashSet<Entry>,
     pub total_count: u32,
     pub running: bool,
+    pub current_command: String,
 }
 
 impl ChannelState {
@@ -38,12 +39,14 @@ impl ChannelState {
         selected_entries: FxHashSet<Entry>,
         total_count: u32,
         running: bool,
+        current_command: String,
     ) -> Self {
         Self {
             current_channel_name,
             selected_entries,
             total_count,
             running,
+            current_command,
         }
     }
 }
@@ -56,6 +59,7 @@ impl Hash for ChannelState {
             .for_each(|entry| entry.hash(state));
         self.total_count.hash(state);
         self.running.hash(state);
+        self.current_command.hash(state);
     }
 }
 
@@ -193,6 +197,7 @@ pub fn draw(ctx: &Ctx, f: &mut Frame<'_>, area: Rect) -> Result<Layout> {
         f,
         &layout.help_bar,
         &ctx.tv_state.channel_state.current_channel_name,
+        &ctx.tv_state.channel_state.current_command,
         build_keybindings_table(
             &ctx.config.keybindings.to_displayable(),
             ctx.tv_state.mode,

--- a/television/main.rs
+++ b/television/main.rs
@@ -319,7 +319,7 @@ mod tests {
     fn test_determine_channel_with_cli_preview() {
         let preview_spec = PreviewSpec::new(
             CommandSpec::new(
-                MultiTemplate::parse("echo hello").unwrap(),
+                vec![MultiTemplate::parse("echo hello").unwrap()],
                 false,
                 FxHashMap::default(),
             ),

--- a/television/matcher/mod.rs
+++ b/television/matcher/mod.rs
@@ -216,4 +216,16 @@ where
             }
         })
     }
+
+    /// Restart the matcher.
+    ///
+    /// This will reset the matcher to its initial state, clearing all
+    /// matched items and the last pattern.
+    pub fn restart(&mut self) {
+        self.inner.restart(true);
+        self.total_item_count = 0;
+        self.matched_item_count = 0;
+        self.status = Status::default();
+        self.last_pattern.clear();
+    }
 }

--- a/television/previewer/mod.rs
+++ b/television/previewer/mod.rs
@@ -221,7 +221,7 @@ pub fn try_preview(
 
     let child = shell_command(
         &command
-            .inner
+            .get_nth(0)
             .format(&entry.raw)
             .expect("Failed to format command"),
         command.interactive,

--- a/television/screen/help.rs
+++ b/television/screen/help.rs
@@ -37,6 +37,7 @@ fn draw_metadata_block(
     area: Rect,
     mode: Mode,
     current_channel_name: &str,
+    current_command: &str,
     app_metadata: &AppMetadata,
     colorscheme: &Colorscheme,
 ) {
@@ -53,6 +54,7 @@ fn draw_metadata_block(
     let metadata_table = build_metadata_table(
         mode,
         current_channel_name,
+        current_command,
         app_metadata,
         colorscheme,
     )
@@ -79,10 +81,12 @@ fn draw_keymaps_block(
     f.render_widget(table, area);
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn draw_help_bar(
     f: &mut Frame,
     layout: &Option<HelpBarLayout>,
     current_channel_name: &str,
+    current_command: &str,
     keymap_table: Table,
     mode: Mode,
     app_metadata: &AppMetadata,
@@ -94,6 +98,7 @@ pub fn draw_help_bar(
             help_bar.left,
             mode,
             current_channel_name,
+            current_command,
             app_metadata,
             colorscheme,
         );

--- a/television/screen/keybindings.rs
+++ b/television/screen/keybindings.rs
@@ -70,9 +70,9 @@ impl KeyBindings {
             ]);
 
         // Optional bindings only included if present in the configuration
-        if let Some(binding) = self.get(&Action::ToggleSource) {
+        if let Some(binding) = self.get(&Action::CycleThroughSources) {
             channel_bindings.insert(
-                DisplayableAction::ToggleSource,
+                DisplayableAction::CycleThroughSources,
                 vec![binding.to_string()],
             );
         }
@@ -151,7 +151,7 @@ pub enum DisplayableAction {
     Cancel,
     Quit,
     ToggleHelpBar,
-    ToggleSource,
+    CycleThroughSources,
     ReloadSource,
 }
 
@@ -168,7 +168,7 @@ impl Display for DisplayableAction {
             DisplayableAction::Cancel => "Cancel",
             DisplayableAction::Quit => "Quit",
             DisplayableAction::ToggleHelpBar => "Toggle help bar",
-            DisplayableAction::ToggleSource => "Toggle source",
+            DisplayableAction::CycleThroughSources => "Cycle through sources",
             DisplayableAction::ReloadSource => "Reload source",
         };
         write!(f, "{action}")
@@ -259,7 +259,7 @@ fn build_keybindings_table_for_channel<'a>(
     // Toggle source (optional)
     let toggle_source_row = keybindings
         .bindings
-        .get(&DisplayableAction::ToggleSource)
+        .get(&DisplayableAction::CycleThroughSources)
         .map(|toggle_source_keys| {
             Row::new(build_cells_for_group(
                 "Toggle source",

--- a/television/screen/keybindings.rs
+++ b/television/screen/keybindings.rs
@@ -14,7 +14,7 @@ use ratatui::{
 impl KeyBindings {
     pub fn to_displayable(&self) -> FxHashMap<Mode, DisplayableKeybindings> {
         // channel mode keybindings
-        let channel_bindings: FxHashMap<DisplayableAction, Vec<String>> =
+        let mut channel_bindings: FxHashMap<DisplayableAction, Vec<String>> =
             FxHashMap::from_iter(vec![
                 (
                     DisplayableAction::ResultsNavigation,
@@ -69,6 +69,21 @@ impl KeyBindings {
                 ),
             ]);
 
+        // Optional bindings only included if present in the configuration
+        if let Some(binding) = self.get(&Action::ToggleSource) {
+            channel_bindings.insert(
+                DisplayableAction::ToggleSource,
+                vec![binding.to_string()],
+            );
+        }
+
+        if let Some(binding) = self.get(&Action::ReloadSource) {
+            channel_bindings.insert(
+                DisplayableAction::ReloadSource,
+                vec![binding.to_string()],
+            );
+        }
+
         // remote control mode keybindings
         let remote_control_bindings: FxHashMap<
             DisplayableAction,
@@ -110,7 +125,8 @@ fn serialized_keys_for_actions(
 ) -> Vec<String> {
     actions
         .iter()
-        .map(|a| keybindings.get(a).unwrap().clone().to_string())
+        .filter_map(|a| keybindings.get(a).cloned())
+        .map(|binding| binding.to_string())
         .collect()
 }
 
@@ -135,6 +151,8 @@ pub enum DisplayableAction {
     Cancel,
     Quit,
     ToggleHelpBar,
+    ToggleSource,
+    ReloadSource,
 }
 
 impl Display for DisplayableAction {
@@ -150,6 +168,8 @@ impl Display for DisplayableAction {
             DisplayableAction::Cancel => "Cancel",
             DisplayableAction::Quit => "Quit",
             DisplayableAction::ToggleHelpBar => "Toggle help bar",
+            DisplayableAction::ToggleSource => "Toggle source",
+            DisplayableAction::ReloadSource => "Reload source",
         };
         write!(f, "{action}")
     }
@@ -236,18 +256,50 @@ fn build_keybindings_table_for_channel<'a>(
         colorscheme.mode.channel,
     ));
 
+    // Toggle source (optional)
+    let toggle_source_row = keybindings
+        .bindings
+        .get(&DisplayableAction::ToggleSource)
+        .map(|toggle_source_keys| {
+            Row::new(build_cells_for_group(
+                "Toggle source",
+                toggle_source_keys,
+                colorscheme.help.metadata_field_name_fg,
+                colorscheme.mode.channel,
+            ))
+        });
+
+    // Reload source (optional)
+    let reload_source_row = keybindings
+        .bindings
+        .get(&DisplayableAction::ReloadSource)
+        .map(|reload_source_keys| {
+            Row::new(build_cells_for_group(
+                "Reload source",
+                reload_source_keys,
+                colorscheme.help.metadata_field_name_fg,
+                colorscheme.mode.channel,
+            ))
+        });
+
     let widths = vec![Constraint::Fill(1), Constraint::Fill(2)];
 
-    Table::new(
-        vec![
-            results_row,
-            preview_row,
-            select_entry_row,
-            copy_entry_row,
-            switch_channels_row,
-        ],
-        widths,
-    )
+    let mut rows = vec![
+        results_row,
+        preview_row,
+        select_entry_row,
+        copy_entry_row,
+        switch_channels_row,
+    ];
+
+    if let Some(row) = toggle_source_row {
+        rows.push(row);
+    }
+    if let Some(row) = reload_source_row {
+        rows.push(row);
+    }
+
+    Table::new(rows, widths)
 }
 
 fn build_keybindings_table_for_channel_selection<'a>(

--- a/television/screen/metadata.rs
+++ b/television/screen/metadata.rs
@@ -22,6 +22,7 @@ impl Display for Mode {
 pub fn build_metadata_table<'a>(
     mode: Mode,
     current_channel_name: &'a str,
+    current_command: &'a str,
     app_metadata: &'a AppMetadata,
     colorscheme: &'a Colorscheme,
 ) -> Table<'a> {
@@ -61,6 +62,17 @@ pub fn build_metadata_table<'a>(
         )),
     ]);
 
+    let current_command_row = Row::new(vec![
+        Cell::from(Span::styled(
+            "current command: ",
+            Style::default().fg(colorscheme.help.metadata_field_name_fg),
+        )),
+        Cell::from(Span::styled(
+            current_command,
+            Style::default().fg(colorscheme.help.metadata_field_value_fg),
+        )),
+    ]);
+
     let current_mode_row = Row::new(vec![
         Cell::from(Span::styled(
             "current mode: ",
@@ -79,6 +91,7 @@ pub fn build_metadata_table<'a>(
             version_row,
             current_dir_row,
             current_channel_row,
+            current_command_row,
             current_mode_row,
         ],
         widths,

--- a/television/television.rs
+++ b/television/television.rs
@@ -220,32 +220,12 @@ impl Television {
     }
 
     pub fn dump_context(&self) -> Ctx {
-        let current_command = if self
-            .channel_prototype
-            .source
-            .command
-            .has_multiple_commands()
-        {
-            self.channel_prototype
-                .source
-                .command
-                .get_command_at_index(self.current_command_index)
-                .to_string()
-        } else {
-            self.channel_prototype
-                .source
-                .command
-                .inner
-                .template_string()
-                .to_string()
-        };
-
         let channel_state = ChannelState::new(
             self.channel.prototype.metadata.name.clone(),
             self.channel.selected_entries().clone(),
             self.channel.total_count(),
             self.channel.running(),
-            current_command,
+            self.channel.current_command().to_string(),
         );
         let tv_state = TvState::new(
             self.mode,

--- a/television/television.rs
+++ b/television/television.rs
@@ -220,11 +220,32 @@ impl Television {
     }
 
     pub fn dump_context(&self) -> Ctx {
+        let current_command = if self
+            .channel_prototype
+            .source
+            .command
+            .has_multiple_commands()
+        {
+            self.channel_prototype
+                .source
+                .command
+                .get_command_at_index(self.current_command_index)
+                .to_string()
+        } else {
+            self.channel_prototype
+                .source
+                .command
+                .inner
+                .template_string()
+                .to_string()
+        };
+
         let channel_state = ChannelState::new(
             self.channel.prototype.metadata.name.clone(),
             self.channel.selected_entries().clone(),
             self.channel.total_count(),
             self.channel.running(),
+            current_command,
         );
         let tv_state = TvState::new(
             self.mode,

--- a/television/television.rs
+++ b/television/television.rs
@@ -26,6 +26,7 @@ use crate::{
 use anyhow::Result;
 use rustc_hash::FxHashSet;
 use serde::{Deserialize, Serialize};
+use string_pipeline::MultiTemplate;
 use tokio::sync::mpsc::{
     UnboundedReceiver, UnboundedSender, unbounded_channel,
 };
@@ -66,6 +67,8 @@ pub struct Television {
     pub ui_state: UiState,
     pub no_help: bool,
     pub no_preview: bool,
+    pub current_command_index: usize,
+    pub channel_prototype: ChannelPrototype,
 }
 
 impl Television {
@@ -101,7 +104,7 @@ impl Television {
         // previewer
         let preview_handles = Self::setup_previewer(&channel_prototype);
 
-        let mut channel = CableChannel::new(channel_prototype);
+        let mut channel = CableChannel::new(channel_prototype.clone());
 
         let app_metadata = AppMetadata::new(
             env!("CARGO_PKG_VERSION").to_string(),
@@ -156,6 +159,8 @@ impl Television {
             ui_state: UiState::default(),
             no_help,
             no_preview,
+            current_command_index: 0,
+            channel_prototype,
         }
     }
 
@@ -269,6 +274,8 @@ impl Television {
             self.no_help,
             self.no_preview,
         );
+        self.channel_prototype = channel_prototype.clone();
+        self.current_command_index = 0;
         self.channel = CableChannel::new(channel_prototype);
     }
 
@@ -445,6 +452,8 @@ impl Television {
                     | Action::ToggleHelp
                     | Action::TogglePreview
                     | Action::CopyEntryToClipboard
+                    | Action::ToggleSource
+                    | Action::ReloadSource
             )
     }
 
@@ -619,6 +628,72 @@ impl Television {
         }
     }
 
+    pub fn handle_toggle_source(&mut self) {
+        // If single command, then reload
+        if !self
+            .channel_prototype
+            .source
+            .command
+            .has_multiple_commands()
+        {
+            self.reload_source_command();
+            return;
+        }
+
+        // Toggle to the next command
+        let command_count =
+            self.channel_prototype.source.command.command_count();
+        self.current_command_index =
+            (self.current_command_index + 1) % command_count;
+
+        // Execute the new command
+        self.reload_source_command();
+    }
+
+    pub fn handle_reload_source(&mut self) {
+        self.reload_source_command();
+    }
+
+    fn reload_source_command(&mut self) {
+        // Get the current command
+        let current_command = if self
+            .channel_prototype
+            .source
+            .command
+            .has_multiple_commands()
+        {
+            self.channel_prototype
+                .source
+                .command
+                .get_command_at_index(self.current_command_index)
+                .to_string()
+        } else {
+            self.channel_prototype
+                .source
+                .command
+                .inner
+                .template_string()
+                .to_string()
+        };
+
+        // Create a new channel prototype with the current command
+        let mut new_prototype = self.channel_prototype.clone();
+        new_prototype.source.command.inner =
+            MultiTemplate::parse(&current_command)
+                .expect("Failed to parse command");
+
+        // Update the channel with the new command
+        self.channel.shutdown();
+        self.channel = CableChannel::new(new_prototype);
+
+        // Preserve the current pattern and re-run the search
+        let current_pattern = self.current_pattern.clone();
+        self.find(&current_pattern);
+
+        // Reset selection
+        self.reset_picker_selection();
+    }
+
     pub fn handle_action(&mut self, action: &Action) -> Result<()> {
         // handle actions
         match action {
@@ -678,6 +753,12 @@ impl Television {
             }
             Action::CopyEntryToClipboard => {
                 self.handle_copy_entry_to_clipboard();
+            }
+            Action::ToggleSource => {
+                self.handle_toggle_source();
+            }
+            Action::ReloadSource => {
+                self.handle_reload_source();
             }
             Action::ToggleHelp => {
                 if self.no_help {


### PR DESCRIPTION
Add env channel
Add support to toggle between sources and reload them, this enables the following

```toml
[source]
command = ["fd -t f", "fd -t f -H"]

[keybindings]
toggle_source = "ctrl-t"
reload_source = "ctrl-r"
```

now you can have the same channel with two different representations, for example with and without hidden files

the change is backwards compatible, if you put a simple string nothing changes