### PR TITLE
perf: optimization of the hot paths

### DIFF
--- a/television/channels/channel.rs
+++ b/television/channels/channel.rs
@@ -84,25 +84,24 @@ impl Channel {
         entries
     }
 
-    pub fn get_result(&self, index: u32) -> Option<Entry> {
-        self.matcher.get_result(index).map(|item| {
-            let mut entry = Entry::new(item.inner.clone())
-                .with_display(item.matched_string)
-                .with_match_indices(&item.match_indices);
-            if let Some(p) = &self.prototype.preview {
-                // FIXME: this should be done by the previewer instead
-                if let Some(offset_expr) = &p.offset {
-                    let offset_str = offset_expr
-                        .format(&item.inner)
-                        .unwrap_or_else(|_| panic!("Failed to format offset expression '{}' with name '{}'", offset_expr.raw(), item.inner));
+    pub fn get_result(&self, index: u32) -> Entry {
+        let item = self.matcher.get_result(index).expect("Invalid index");
+        let mut entry = Entry::new(item.inner.clone())
+            .with_display(item.matched_string)
+            .with_match_indices(&item.match_indices);
+        if let Some(p) = &self.prototype.preview {
+            // FIXME: this should be done by the previewer instead
+            if let Some(offset_expr) = &p.offset {
+                let offset_str = offset_expr
+                    .format(&item.inner)
+                    .unwrap_or_else(|_| panic!("Failed to format offset expression '{}' with name '{}'", offset_expr.raw(), item.inner));
 
-                    entry = entry.with_line_number(
-                        offset_str.parse::<usize>().unwrap_or(0),
-                    );
-                }
+                entry = entry.with_line_number(
+                    offset_str.parse::<usize>().unwrap_or(0),
+                );
             }
-            entry
-        })
+        }
+        entry
     }
 
     pub fn selected_entries(&self) -> &FxHashSet<Entry> {

--- a/television/channels/channel.rs
+++ b/television/channels/channel.rs
@@ -21,9 +21,7 @@ pub struct Channel {
 
 impl Channel {
     pub fn new(prototype: ChannelPrototype) -> Self {
-        let config = Config::default()
-            .prefer_prefix(true)
-            .optimize_for_paths(true);
+        let config = Config::default().prefer_prefix(true);
         let matcher = Matcher::new(&config);
         let current_source_index = 0;
         Self {

--- a/television/channels/remote_control.rs
+++ b/television/channels/remote_control.rs
@@ -106,15 +106,14 @@ impl RemoteControl {
             .collect()
     }
 
-    pub fn get_result(&self, index: u32) -> Option<CableEntry> {
-        self.matcher.get_result(index).map(|item| {
-            CableEntry::new(
-                item.matched_string.clone(),
-                self.cable_channels
-                    .get_channel_shortcut(&item.matched_string),
-            )
-            .with_match_indices(&item.match_indices)
-        })
+    pub fn get_result(&self, index: u32) -> CableEntry {
+        let item = self.matcher.get_result(index).expect("Invalid index");
+        CableEntry::new(
+            item.matched_string.clone(),
+            self.cable_channels
+                .get_channel_shortcut(&item.matched_string),
+        )
+        .with_match_indices(&item.match_indices)
     }
 
     pub fn result_count(&self) -> u32 {

--- a/television/channels/remote_control.rs
+++ b/television/channels/remote_control.rs
@@ -57,7 +57,8 @@ const NUM_THREADS: usize = 1;
 
 impl RemoteControl {
     pub fn new(cable_channels: Cable) -> Self {
-        let matcher = Matcher::new(Config::default().n_threads(NUM_THREADS));
+        let matcher =
+            Matcher::new(&Config::default().n_threads(Some(NUM_THREADS)));
         let injector = matcher.injector();
         for c in cable_channels.keys() {
             let () = injector.push(c.clone(), |e, cols| {

--- a/television/matcher/config.rs
+++ b/television/matcher/config.rs
@@ -12,8 +12,6 @@
 pub struct Config {
     /// Whether to prefer prefix matches.
     pub prefer_prefix: bool,
-    /// Whether to optimize for matching paths.
-    pub optimize_for_paths: bool,
     /// The number of threads to use for matching.
     pub n_threads: Option<usize>,
 }
@@ -22,7 +20,6 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             prefer_prefix: true,
-            optimize_for_paths: true,
             n_threads: Some(
                 std::thread::available_parallelism()
                     .map(std::num::NonZeroUsize::get)
@@ -42,12 +39,6 @@ impl Config {
     /// Set whether to prefer prefix matches.
     pub fn prefer_prefix(mut self, prefer_prefix: bool) -> Self {
         self.prefer_prefix = prefer_prefix;
-        self
-    }
-
-    /// Set whether to optimize for matching paths.
-    pub fn optimize_for_paths(mut self, optimize_for_paths: bool) -> Self {
-        self.optimize_for_paths = optimize_for_paths;
         self
     }
 

--- a/television/matcher/config.rs
+++ b/television/matcher/config.rs
@@ -8,41 +8,35 @@
 /// matches, and no optimization for matching paths as well as using the
 /// default number of threads (which corresponds to the number of available logical
 /// cores on the current machine).
-#[derive(Copy, Clone, Debug)]
-#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone)]
 pub struct Config {
-    /// The number of threads to use for the fuzzy matcher.
-    pub n_threads: Option<usize>,
-    /// Whether to ignore case when matching.
-    pub ignore_case: bool,
     /// Whether to prefer prefix matches.
     pub prefer_prefix: bool,
     /// Whether to optimize for matching paths.
-    pub match_paths: bool,
+    pub optimize_for_paths: bool,
+    /// The number of threads to use for matching.
+    pub n_threads: Option<usize>,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
-            n_threads: None,
-            ignore_case: true,
-            prefer_prefix: false,
-            match_paths: false,
+            prefer_prefix: true,
+            optimize_for_paths: true,
+            n_threads: Some(
+                std::thread::available_parallelism()
+                    .map(std::num::NonZeroUsize::get)
+                    .unwrap_or(4)
+                    .min(8),
+            ),
         }
     }
 }
 
 impl Config {
-    /// Set the number of threads to use.
-    pub fn n_threads(mut self, n_threads: usize) -> Self {
-        self.n_threads = Some(n_threads);
-        self
-    }
-
-    /// Set whether to ignore case.
-    pub fn ignore_case(mut self, ignore_case: bool) -> Self {
-        self.ignore_case = ignore_case;
-        self
+    /// Create a new configuration with the default values.
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// Set whether to prefer prefix matches.
@@ -52,20 +46,22 @@ impl Config {
     }
 
     /// Set whether to optimize for matching paths.
-    pub fn match_paths(mut self, match_paths: bool) -> Self {
-        self.match_paths = match_paths;
+    pub fn optimize_for_paths(mut self, optimize_for_paths: bool) -> Self {
+        self.optimize_for_paths = optimize_for_paths;
+        self
+    }
+
+    /// Set the number of threads to use for matching.
+    pub fn n_threads(mut self, n_threads: Option<usize>) -> Self {
+        self.n_threads = n_threads;
         self
     }
 }
 
 impl From<&Config> for nucleo::Config {
     fn from(config: &Config) -> Self {
-        let mut matcher_config = nucleo::Config::DEFAULT;
-        matcher_config.ignore_case = config.ignore_case;
-        matcher_config.prefer_prefix = config.prefer_prefix;
-        if config.match_paths {
-            matcher_config = matcher_config.match_paths();
-        }
-        matcher_config
+        let mut nucleo_config = nucleo::Config::DEFAULT;
+        nucleo_config.prefer_prefix = config.prefer_prefix;
+        nucleo_config
     }
 }

--- a/television/matcher/injector.rs
+++ b/television/matcher/injector.rs
@@ -31,7 +31,7 @@ where
     /// use television::matcher::{config::Config, Matcher};
     ///
     /// let config = Config::default();
-    /// let matcher = Matcher::new(config);
+    /// let matcher = Matcher::new(&config);
     ///
     /// let injector = matcher.injector();
     /// injector.push(

--- a/television/matcher/mod.rs
+++ b/television/matcher/mod.rs
@@ -50,7 +50,8 @@ where
     pub status: Status,
     /// The last pattern that was matched against.
     pub last_pattern: String,
-    /// Ephemeral vector to reduce allocations
+    /// A pre-allocated buffer used to collect match indices when fetching the results
+    /// from the matcher. This avoids having to re-allocate on each pass.
     col_indices_buffer: Vec<u32>,
 }
 
@@ -162,7 +163,7 @@ where
         self.total_item_count = snapshot.item_count();
         self.matched_item_count = snapshot.matched_item_count();
 
-        // Clear ephemeral vector for reuse
+        // Clear the pre-allocated match indices buffer for safety
         self.col_indices_buffer.clear();
         let mut matcher = lazy::MATCHER.lock();
         let mut results = Vec::new();

--- a/television/matcher/mod.rs
+++ b/television/matcher/mod.rs
@@ -50,6 +50,8 @@ where
     pub status: Status,
     /// The last pattern that was matched against.
     pub last_pattern: String,
+    /// Cache for reused vectors to reduce allocations
+    col_indices_cache: Vec<u32>,
 }
 
 impl<I> Matcher<I>
@@ -57,10 +59,10 @@ where
     I: Sync + Send + Clone + 'static,
 {
     /// Create a new fuzzy matcher with the given configuration.
-    pub fn new(config: config::Config) -> Self {
+    pub fn new(config: &config::Config) -> Self {
         Self {
             inner: nucleo::Nucleo::new(
-                (&config).into(),
+                config.into(),
                 Arc::new(|| {}),
                 config.n_threads,
                 1,
@@ -69,6 +71,7 @@ where
             matched_item_count: 0,
             status: Status::default(),
             last_pattern: String::new(),
+            col_indices_cache: Vec::with_capacity(64), // Pre-allocate for performance
         }
     }
 
@@ -88,7 +91,7 @@ where
     /// use television::matcher::{config::Config, Matcher};
     ///
     /// let config = Config::default();
-    /// let matcher = Matcher::new(config);
+    /// let matcher = Matcher::new(&config);
     /// let injector = matcher.injector();
     ///
     /// injector.push(
@@ -138,7 +141,7 @@ where
     /// use television::matcher::{config::Config, Matcher};
     ///
     /// let config = Config::default();
-    /// let mut matcher: Matcher<String> = Matcher::new(config);
+    /// let mut matcher: Matcher<String> = Matcher::new(&config);
     /// matcher.find("some pattern");
     ///
     /// let results = matcher.results(10, 0);
@@ -159,32 +162,40 @@ where
         self.total_item_count = snapshot.item_count();
         self.matched_item_count = snapshot.matched_item_count();
 
-        let mut col_indices = Vec::new();
+        // Clear cached vector for reuse
+        self.col_indices_cache.clear();
         let mut matcher = lazy::MATCHER.lock();
+        let mut results = Vec::new();
 
-        snapshot
-            .matched_items(
-                offset..(num_entries + offset).min(self.matched_item_count),
-            )
-            .map(move |item| {
-                snapshot.pattern().column_pattern(0).indices(
-                    item.matcher_columns[0].slice(..),
-                    &mut matcher,
-                    &mut col_indices,
-                );
-                col_indices.sort_unstable();
-                col_indices.dedup();
+        for item in snapshot.matched_items(
+            offset..(num_entries + offset).min(self.matched_item_count),
+        ) {
+            snapshot.pattern().column_pattern(0).indices(
+                item.matcher_columns[0].slice(..),
+                &mut matcher,
+                &mut self.col_indices_cache,
+            );
 
-                let indices = col_indices.drain(..);
+            // PERF: Avoid unnecessary sorting if already sorted or small
+            if self.col_indices_cache.len() > 1 {
+                self.col_indices_cache.sort_unstable();
+                self.col_indices_cache.dedup();
+            }
 
-                let matched_string = item.matcher_columns[0].to_string();
-                matched_item::MatchedItem {
-                    inner: item.data.clone(),
-                    matched_string,
-                    match_indices: indices.collect(),
-                }
-            })
-            .collect()
+            let indices: Vec<u32> = self.col_indices_cache.drain(..).collect();
+            let matched_string = item.matcher_columns[0].to_string();
+
+            results.push(matched_item::MatchedItem {
+                inner: item.data.clone(),
+                matched_string,
+                match_indices: indices,
+            });
+
+            // Clear for next iteration
+            self.col_indices_cache.clear();
+        }
+
+        results
     }
 
     /// Get a single matched item.
@@ -194,7 +205,7 @@ where
     /// use television::matcher::{config::Config, Matcher};
     ///
     /// let config = Config::default();
-    /// let mut matcher: Matcher<String> = Matcher::new(config);
+    /// let mut matcher: Matcher<String> = Matcher::new(&config);
     /// matcher.find("some pattern");
     ///
     /// if let Some(item) = matcher.get_result(0) {
@@ -207,12 +218,25 @@ where
         index: u32,
     ) -> Option<matched_item::MatchedItem<I>> {
         let snapshot = self.inner.snapshot();
-        snapshot.get_matched_item(index).map(|item| {
+        let mut col_indices = Vec::new();
+        let mut matcher = lazy::MATCHER.lock();
+
+        snapshot.matched_items(index..=index).next().map(|item| {
+            snapshot.pattern().column_pattern(0).indices(
+                item.matcher_columns[0].slice(..),
+                &mut matcher,
+                &mut col_indices,
+            );
+            col_indices.sort_unstable();
+            col_indices.dedup();
+
+            let indices = col_indices.drain(..);
             let matched_string = item.matcher_columns[0].to_string();
+
             matched_item::MatchedItem {
                 inner: item.data.clone(),
                 matched_string,
-                match_indices: Vec::new(),
+                match_indices: indices.collect(),
             }
         })
     }
@@ -227,5 +251,6 @@ where
         self.matched_item_count = 0;
         self.status = Status::default();
         self.last_pattern.clear();
+        self.col_indices_cache.clear();
     }
 }

--- a/television/picker.rs
+++ b/television/picker.rs
@@ -86,23 +86,33 @@ impl<T> Picker<T> {
     fn inner_next(&mut self, total_items: usize, height: usize) {
         let selected = self.selected().unwrap_or(0);
         let relative_selected = self.relative_selected().unwrap_or(0);
-        self.select(Some(selected.saturating_add(1) % total_items));
-        self.relative_select(Some((relative_selected + 1).min(height - 1)));
-        if self.selected().unwrap() == 0 {
+
+        let new_selected = selected.wrapping_add(1) % total_items;
+        self.select(Some(new_selected));
+
+        if new_selected == 0 {
             self.relative_select(Some(0));
+        } else {
+            self.relative_select(Some(
+                (relative_selected + 1).min(height - 1),
+            ));
         }
     }
 
     fn inner_prev(&mut self, total_items: usize, height: usize) {
         let selected = self.selected().unwrap_or(0);
         let relative_selected = self.relative_selected().unwrap_or(0);
-        self.select(Some((selected + (total_items - 1)) % total_items));
-        self.relative_select(Some(relative_selected.saturating_sub(1)));
-        if self.selected().unwrap() == total_items - 1 {
+
+        let new_selected =
+            selected.wrapping_add(total_items - 1) % total_items;
+        self.select(Some(new_selected));
+
+        if new_selected == total_items - 1 {
             self.relative_select(Some((height - 1).min(total_items - 1)));
+        } else {
+            self.relative_select(Some(relative_selected.saturating_sub(1)));
         }
     }
-
     /// Generic cursor movement helper.
     pub fn move_cursor(
         &mut self,
@@ -111,6 +121,11 @@ impl<T> Picker<T> {
         total_items: usize,
         viewport_height: usize,
     ) {
+        // Early return for empty collections
+        if total_items == 0 {
+            return;
+        }
+
         match movement {
             Movement::Next => {
                 self.select_next(step, total_items, viewport_height);

--- a/television/screen/result_item.rs
+++ b/television/screen/result_item.rs
@@ -39,7 +39,8 @@ pub fn build_result_line<'a, T: ResultItem + ?Sized>(
     area_width: u16,
     prefix: Option<bool>, // Some(true)=selected ●, Some(false)=unselected, None=no prefix
 ) -> Line<'a> {
-    let mut spans = Vec::<Span<'a>>::new();
+    // PERF: Pre-allocate spans vector with estimated capacity
+    let mut spans = Vec::<Span<'a>>::with_capacity(8);
 
     // Optional selection prefix
     if let Some(selected) = prefix {
@@ -102,32 +103,62 @@ pub fn build_result_line<'a, T: ResultItem + ?Sized>(
         match_ranges = ranges;
     }
 
-    // Build highlighted spans.
-    let mut last_end = 0;
-    let chars = entry_name.chars();
-    let name_len = UnicodeWidthStr::width(entry_name.as_str());
+    // PERF: Early return for empty match ranges
+    if match_ranges.is_empty() {
+        spans.push(Span::styled(
+            entry_name,
+            Style::default().fg(colorscheme.result_name_fg),
+        ));
+    } else {
+        // Build highlighted spans
+        let mut last_end = 0;
 
-    for (s, e) in match_ranges.iter().map(|(s, e)| (*s as usize, *e as usize))
-    {
-        spans.push(Span::styled(
-            chars
-                .clone()
-                .skip(last_end)
-                .take(s - last_end)
-                .collect::<String>(),
-            Style::default().fg(colorscheme.result_name_fg),
-        ));
-        spans.push(Span::styled(
-            chars.clone().skip(s).take(e - s).collect::<String>(),
-            Style::default().fg(colorscheme.match_foreground_color),
-        ));
-        last_end = e;
-    }
-    if last_end < name_len {
-        spans.push(Span::styled(
-            chars.skip(last_end).collect::<String>(),
-            Style::default().fg(colorscheme.result_name_fg),
-        ));
+        // PERF: Use byte indices for better performance, convert to chars only when needed
+        for (start, end) in
+            match_ranges.iter().map(|(s, e)| (*s as usize, *e as usize))
+        {
+            // Add unhighlighted text before match
+            if start > last_end {
+                let chars: String = entry_name
+                    .chars()
+                    .skip(last_end)
+                    .take(start - last_end)
+                    .collect();
+                if !chars.is_empty() {
+                    spans.push(Span::styled(
+                        chars,
+                        Style::default().fg(colorscheme.result_name_fg),
+                    ));
+                }
+            }
+
+            // Add highlighted match
+            if end > start {
+                let chars: String =
+                    entry_name.chars().skip(start).take(end - start).collect();
+                if !chars.is_empty() {
+                    spans.push(Span::styled(
+                        chars,
+                        Style::default()
+                            .fg(colorscheme.match_foreground_color),
+                    ));
+                }
+            }
+
+            last_end = end;
+        }
+
+        // Add remaining unhighlighted text
+        let name_len = entry_name.chars().count();
+        if last_end < name_len {
+            let chars: String = entry_name.chars().skip(last_end).collect();
+            if !chars.is_empty() {
+                spans.push(Span::styled(
+                    chars,
+                    Style::default().fg(colorscheme.result_name_fg),
+                ));
+            }
+        }
     }
 
     // Show shortcut if present.

--- a/television/television.rs
+++ b/television/television.rs
@@ -358,14 +358,20 @@ impl Television {
             return None;
         }
         self.selected_index()
-            .and_then(|idx| self.channel.get_result(idx))
+            .map(|idx| self.channel.get_result(idx))
     }
 
     pub fn get_selected_cable_entry(&self) -> Option<CableEntry> {
+        if self
+            .remote_control
+            .as_ref()
+            .map_or(0, RemoteControl::result_count)
+            == 0
+        {
+            return None;
+        }
         self.selected_index().and_then(|idx| {
-            self.remote_control
-                .as_ref()
-                .and_then(|rc| rc.get_result(idx))
+            self.remote_control.as_ref().map(|rc| rc.get_result(idx))
         })
     }
 


### PR DESCRIPTION
before

```
on   ➜ cargo bench --bench main -- --save-baseline before
    Finished `bench` profile [optimized] target(s) in 0.13s
     Running benches/main.rs (target/release/deps/main-8151fda9d09b6257)
results_list            time:   [16.002 µs 16.095 µs 16.190 µs]
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild

Benchmarking draw: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.6s, or reduce sample count to 80.
draw                    time:   [2.0829 ms 2.2517 ms 2.4277 ms]
```

after

```
on   ➜ cargo bench --bench main -- --baseline before
    Finished `bench` profile [optimized] target(s) in 0.08s
     Running benches/main.rs (target/release/deps/main-8151fda9d09b6257)
results_list            time:   [8.2873 µs 8.3418 µs 8.3963 µs]
                        change: [-49.407% -48.880% -48.360%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) low mild

Benchmarking draw: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.4s, or reduce sample count to 90.
draw                    time:   [1.3345 ms 1.4388 ms 1.5460 ms]
                        change: [-42.872% -36.105% -29.053%] (p = 0.00 < 0.05)
                        Performance has improved.
```