### PR TITLE
perf: pre-allocate result vectors, and reuse picker entries to avoid reallocations

### DIFF
--- a/television/app.rs
+++ b/television/app.rs
@@ -276,7 +276,7 @@ impl App {
             {
                 for event in event_buf.drain(..) {
                     if let Some(action) = self.convert_event_to_action(event) {
-                        if !matches!(action, Action::Tick) {
+                        if action != Action::Tick {
                             debug!("Queuing new action: {action:?}");
                         }
                         action_tx.send(action)?;
@@ -363,11 +363,11 @@ impl App {
             Event::Closed => Action::NoOp,
         };
 
-        if !matches!(action, Action::Tick) {
+        if action != Action::Tick {
             trace!("Converted event to action: {action:?}");
         }
 
-        if matches!(action, Action::NoOp) {
+        if action == Action::NoOp {
             None
         } else {
             Some(action)
@@ -395,7 +395,7 @@ impl App {
         }
         if self.action_rx.recv_many(buf, ACTION_BUF_SIZE).await > 0 {
             for action in buf.drain(..) {
-                if !matches!(action, Action::Tick) {
+                if action != Action::Tick {
                     trace!("{action:?}");
                 }
                 match action {

--- a/television/app.rs
+++ b/television/app.rs
@@ -276,7 +276,7 @@ impl App {
             {
                 for event in event_buf.drain(..) {
                     if let Some(action) = self.convert_event_to_action(event) {
-                        if action != Action::Tick {
+                        if !matches!(action, Action::Tick) {
                             debug!("Queuing new action: {action:?}");
                         }
                         action_tx.send(action)?;
@@ -363,11 +363,11 @@ impl App {
             Event::Closed => Action::NoOp,
         };
 
-        if action != Action::Tick {
+        if !matches!(action, Action::Tick) {
             trace!("Converted event to action: {action:?}");
         }
 
-        if action == Action::NoOp {
+        if matches!(action, Action::NoOp) {
             None
         } else {
             Some(action)
@@ -395,7 +395,7 @@ impl App {
         }
         if self.action_rx.recv_many(buf, ACTION_BUF_SIZE).await > 0 {
             for action in buf.drain(..) {
-                if action != Action::Tick {
+                if !matches!(action, Action::Tick) {
                     trace!("{action:?}");
                 }
                 match action {

--- a/television/cable.rs
+++ b/television/cable.rs
@@ -81,9 +81,9 @@ impl Cable {
     /// E.g. if the channel is "files" and the shortcut is "F1",
     /// this will return `Some(Binding::SingleKey("F1"))`.
     pub fn get_channel_shortcut(&self, channel_name: &str) -> Option<Binding> {
-        self.get_channel(channel_name)
-            .keybindings
-            .as_ref()
+        // Get only what we need, clone at the end
+        self.get(channel_name)
+            .and_then(|prototype| prototype.keybindings.as_ref())
             .and_then(|keybindings| keybindings.shortcut.as_ref())
             .cloned()
     }

--- a/television/matcher/mod.rs
+++ b/television/matcher/mod.rs
@@ -166,7 +166,9 @@ where
         // Clear the pre-allocated match indices buffer for safety
         self.col_indices_buffer.clear();
         let mut matcher = lazy::MATCHER.lock();
-        let mut results = Vec::new();
+
+        // PERF: Pre-allocate the results Vec so we avoid repeated reallocations
+        let mut results = Vec::with_capacity(num_entries as usize);
 
         for item in snapshot.matched_items(
             offset..(num_entries + offset).min(self.matched_item_count),


### PR DESCRIPTION
before
![flamegraph-before](https://github.com/user-attachments/assets/92f30f0f-51da-4d96-b22b-11de99f27c86)

after
![flamegraph-after](https://github.com/user-attachments/assets/39fda567-e7fd-4e17-9c42-9d088a853974)

ran with this command
```
cargo flamegraph --no-inline -c 'record -F 997 --call-graph dwarf --no-inherit' --profile=profiling -- --cable-dir ./cable --config-file ./.config/config.toml files ~/
```