### PR TITLE
UI: Optional scrollbar and mouse support for the preview panel

### DIFF
--- a/.config/config.toml
+++ b/.config/config.toml
@@ -80,6 +80,7 @@ separator_close = ""
 size = 50
 #header = "{}"
 #footer = ""
+scrollbar = false
 
 [ui.remote_control]
 # Whether to show channel descriptions in remote control mode

--- a/.config/config.toml
+++ b/.config/config.toml
@@ -88,28 +88,55 @@ show_channel_descriptions = true
 # Whether to sort channels alphabetically
 sort_alphabetically = true
 
+
 # Keybindings
 # ----------------------------------------------------------------------------
 #
-# Channel mode
-# ------------------------
+# HARDCODED KEYBINDINGS (cannot be changed via config):
+# Input field actions (always active):
+#   Backspace          - Delete previous character
+#   Ctrl+w             - Delete previous word
+#   Ctrl+u             - Delete entire line
+#   Delete             - Delete next character
+#   Left/Right         - Move cursor left/right
+#   Home / Ctrl+a      - Go to input start
+#   End / Ctrl+e       - Go to input end
+#
+# CONFIGURABLE KEYBINDINGS (can be customized below):
+# --------------------------------------------------
 [keybindings]
+# Application control
+# ------------------
 # Quit the application
 quit = ["esc", "ctrl-c"]
+
+# Navigation and selection
+# -----------------------
 # Scrolling through entries
 select_next_entry = ["down", "ctrl-n", "ctrl-j"]
 select_prev_entry = ["up", "ctrl-p", "ctrl-k"]
 select_next_page = "pagedown"
 select_prev_page = "pageup"
-# Scrolling the preview pane
-scroll_preview_half_page_down = "ctrl-d"
-scroll_preview_half_page_up = "ctrl-u"
+
+# Multi-selection
+# --------------
 # Add entry to selection and move to the next entry
 toggle_selection_down = "tab"
 # Add entry to selection and move to the previous entry
 toggle_selection_up = "backtab"
 # Confirm selection
 confirm_selection = "enter"
+
+# Preview panel control
+# --------------------
+# Scrolling the preview pane
+scroll_preview_half_page_down = ["ctrl-d"]
+scroll_preview_half_page_up = ["ctrl-u"]  # CONFLICT: Ctrl+u is hardcoded for delete line
+#scroll_preview_half_page_down = ["ctrl-d", "mousescrolldown"]  # Optional mouse support
+#scroll_preview_half_page_up = ["ctrl-u", "mousescrollup"]  # Optional mouse support
+
+# Data operations
+# --------------
 # Copy the selected entry to the clipboard
 copy_entry_to_clipboard = "ctrl-y"
 # Reload the current source
@@ -118,6 +145,7 @@ reload_source = "ctrl-r"
 cycle_sources = "ctrl-s"
 
 # UI Features
+# ----------
 toggle_remote_control = "ctrl-t"
 toggle_preview = "ctrl-o"
 toggle_help = "ctrl-h"

--- a/.config/config.toml
+++ b/.config/config.toml
@@ -80,7 +80,7 @@ separator_close = ""
 size = 50
 #header = "{}"
 #footer = ""
-scrollbar = false
+scrollbar = true
 
 [ui.remote_control]
 # Whether to show channel descriptions in remote control mode
@@ -115,8 +115,8 @@ quit = ["esc", "ctrl-c"]
 # Scrolling through entries
 select_next_entry = ["down", "ctrl-n", "ctrl-j"]
 select_prev_entry = ["up", "ctrl-p", "ctrl-k"]
-select_next_page = "pagedown"
-select_prev_page = "pageup"
+#select_next_page = "pagedown"
+#select_prev_page = "pageup"
 
 # Multi-selection
 # --------------
@@ -130,10 +130,8 @@ confirm_selection = "enter"
 # Preview panel control
 # --------------------
 # Scrolling the preview pane
-scroll_preview_half_page_down = ["ctrl-d"]
-scroll_preview_half_page_up = ["ctrl-u"]  # CONFLICT: Ctrl+u is hardcoded for delete line
-#scroll_preview_half_page_down = ["ctrl-d", "mousescrolldown"]  # Optional mouse support
-#scroll_preview_half_page_up = ["ctrl-u", "mousescrollup"]  # Optional mouse support
+scroll_preview_half_page_down = ["pagedown", "mousescrolldown"]
+scroll_preview_half_page_up = ["pageup", "mousescrollup"]
 
 # Data operations
 # --------------

--- a/television/app.rs
+++ b/television/app.rs
@@ -10,6 +10,7 @@ use crate::{
     television::{Mode, Television},
 };
 use anyhow::Result;
+use crossterm::event::MouseEventKind;
 use rustc_hash::FxHashSet;
 use tokio::sync::mpsc;
 use tracing::{debug, trace};
@@ -428,6 +429,35 @@ impl App {
                         Key::Char(c) => Action::AddInputChar(c),
                         _ => Action::NoOp,
                     }
+                }
+            }
+            Event::Mouse(mouse_event) => {
+                // Handle mouse scroll events for preview panel, if keybindings are configured
+                // Only works in channel mode, regardless of mouse position
+                if self.television.mode == Mode::Channel {
+                    match mouse_event.kind {
+                        MouseEventKind::ScrollUp => {
+                            if let Some(action) =
+                                self.keymap.get(&Key::MouseScrollUp)
+                            {
+                                action.clone()
+                            } else {
+                                Action::NoOp
+                            }
+                        }
+                        MouseEventKind::ScrollDown => {
+                            if let Some(action) =
+                                self.keymap.get(&Key::MouseScrollDown)
+                            {
+                                action.clone()
+                            } else {
+                                Action::NoOp
+                            }
+                        }
+                        _ => Action::NoOp,
+                    }
+                } else {
+                    Action::NoOp
                 }
             }
             // terminal events

--- a/television/config/keybindings.rs
+++ b/television/config/keybindings.rs
@@ -242,6 +242,14 @@ pub fn parse_key(raw: &str) -> anyhow::Result<Key, String> {
         let raw = raw.strip_prefix('<').unwrap_or(raw);
         raw.strip_suffix('>').unwrap_or(raw)
     };
+
+    // Handle mouse scroll keys as special cases
+    match raw.to_ascii_lowercase().as_str() {
+        "mousescrollup" => return Ok(Key::MouseScrollUp),
+        "mousescrolldown" => return Ok(Key::MouseScrollDown),
+        _ => {}
+    }
+
     let key_event = parse_key_event(raw)?;
     Ok(convert_raw_event_to_key(key_event))
 }

--- a/television/config/mod.rs
+++ b/television/config/mod.rs
@@ -256,6 +256,7 @@ impl Config {
             if let Some(footer) = &preview_panel.footer {
                 self.ui.preview_panel.footer = Some(footer.clone());
             }
+            self.ui.preview_panel.scrollbar = preview_panel.scrollbar;
         }
 
         if let Some(help_panel) = &ui_spec.help_panel {

--- a/television/config/ui.rs
+++ b/television/config/ui.rs
@@ -31,7 +31,7 @@ impl Default for PreviewPanelConfig {
             size: DEFAULT_PREVIEW_SIZE,
             header: None,
             footer: None,
-            scrollbar: false,
+            scrollbar: true,
         }
     }
 }

--- a/television/config/ui.rs
+++ b/television/config/ui.rs
@@ -22,6 +22,7 @@ pub struct PreviewPanelConfig {
     pub size: u16,
     pub header: Option<Template>,
     pub footer: Option<Template>,
+    pub scrollbar: bool,
 }
 
 impl Default for PreviewPanelConfig {
@@ -30,6 +31,7 @@ impl Default for PreviewPanelConfig {
             size: DEFAULT_PREVIEW_SIZE,
             header: None,
             footer: None,
+            scrollbar: false,
         }
     }
 }

--- a/television/draw.rs
+++ b/television/draw.rs
@@ -219,6 +219,7 @@ pub fn draw(ctx: &Ctx, f: &mut Frame<'_>, area: Rect) -> Result<Layout> {
             &ctx.tv_state.preview_state,
             ctx.config.ui.use_nerd_font_icons,
             &ctx.colorscheme,
+            ctx.config.ui.preview_panel.scrollbar,
         )?;
     }
 

--- a/television/screen/preview.rs
+++ b/television/screen/preview.rs
@@ -13,7 +13,10 @@ use ratatui::{
     Frame,
     layout::{Alignment, Rect},
     prelude::{Color, Line, Span, Style, Stylize, Text},
-    widgets::{Block, BorderType, Borders, Padding, Paragraph},
+    widgets::{
+        Block, BorderType, Borders, Padding, Paragraph, Scrollbar,
+        ScrollbarOrientation, ScrollbarState, StatefulWidget,
+    },
 };
 use std::str::FromStr;
 
@@ -24,6 +27,7 @@ pub fn draw_preview_content_block(
     preview_state: &PreviewState,
     use_nerd_font_icons: bool,
     colorscheme: &Colorscheme,
+    scrollbar_enabled: bool,
 ) -> Result<()> {
     let inner = draw_content_outer_block(
         f,
@@ -40,6 +44,27 @@ pub fn draw_preview_content_block(
         colorscheme.preview.highlight_bg,
     );
     f.render_widget(rp, inner);
+
+    // render scrollbar if enabled
+    if scrollbar_enabled {
+        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+            .style(Style::default().fg(colorscheme.general.border_fg));
+
+        let mut scrollbar_state = ScrollbarState::new(
+            preview_state.preview.total_lines.saturating_sub(1) as usize,
+        )
+        .position(preview_state.scroll as usize);
+
+        // Create a separate area for the scrollbar that accounts for text padding
+        let scrollbar_rect = Rect {
+            x: inner.x + inner.width,
+            y: inner.y,
+            width: 1, // Scrollbar width
+            height: inner.height,
+        };
+
+        scrollbar.render(scrollbar_rect, f.buffer_mut(), &mut scrollbar_state);
+    }
 
     Ok(())
 }

--- a/television/tui.rs
+++ b/television/tui.rs
@@ -6,7 +6,7 @@ use std::{
 use anyhow::Result;
 use crossterm::{
     cursor,
-    event::DisableMouseCapture,
+    event::{DisableMouseCapture, EnableMouseCapture},
     execute,
     terminal::{
         EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode,
@@ -43,10 +43,8 @@ where
         enable_raw_mode()?;
         let mut buffered_stderr = LineWriter::new(stderr());
         execute!(buffered_stderr, EnterAlternateScreen)?;
+        execute!(buffered_stderr, EnableMouseCapture)?;
         self.terminal.clear()?;
-        if cfg!(not(windows)) {
-            execute!(buffered_stderr, DisableMouseCapture)?;
-        }
         Ok(())
     }
 
@@ -57,6 +55,7 @@ where
             disable_raw_mode()?;
             let mut buffered_stderr = LineWriter::new(stderr());
             execute!(buffered_stderr, cursor::Show)?;
+            execute!(buffered_stderr, DisableMouseCapture)?;
             execute!(buffered_stderr, LeaveAlternateScreen)?;
         }
 


### PR DESCRIPTION
cleaned up keybinding section from config

@alexpasmantier you had this code before, perhaps there was a reason for it?

```rust
        if cfg!(not(windows)) {
            execute!(buffered_stderr, DisableMouseCapture)?;
        }
```