### PR TITLE
fix(cli): fix parsing of arguments for autocomplete-prompt

### DIFF
--- a/television/cli/args.rs
+++ b/television/cli/args.rs
@@ -33,12 +33,7 @@ pub struct Cli {
     /// A list of the available channels can be displayed using the
     /// `list-channels` command. The channel can also be changed from within
     /// the application.
-    #[arg(
-        value_enum,
-        index = 1,
-        verbatim_doc_comment,
-        conflicts_with = "autocomplete_prompt"
-    )]
+    #[arg(value_enum, index = 1, verbatim_doc_comment)]
     pub channel: Option<String>,
 
     /// A preview line number offset template to use to scroll the preview to for each
@@ -265,12 +260,7 @@ pub struct Cli {
     /// This can be used to automatically select a channel based on the input
     /// prompt by using the `shell_integration` mapping in the configuration
     /// file.
-    #[arg(
-        long,
-        value_name = "STRING",
-        verbatim_doc_comment,
-        conflicts_with = "channel"
-    )]
+    #[arg(long, value_name = "STRING", verbatim_doc_comment)]
     pub autocomplete_prompt: Option<String>,
 
     /// Use substring matching instead of fuzzy matching.

--- a/television/cli/mod.rs
+++ b/television/cli/mod.rs
@@ -11,6 +11,9 @@ use crate::{
     utils::paths::expand_tilde,
 };
 use anyhow::{Result, anyhow};
+use clap::CommandFactory;
+use clap::error::ErrorKind;
+use colored::Colorize;
 use rustc_hash::FxHashMap;
 use std::path::{Path, PathBuf};
 use tracing::debug;
@@ -205,6 +208,21 @@ pub fn post_process(cli: Cli) -> PostProcessedCli {
                 ))
             })
         });
+
+    if cli.autocomplete_prompt.is_some() {
+        if let Some(ch) = &cli.channel {
+            if !Path::new(ch).exists() {
+                let mut cmd = Cli::command();
+                let arg1 = "'--autocomplete-prompt <STRING>'".yellow();
+                let arg2 = "'[CHANNEL]'".yellow();
+                let msg = format!(
+                    "The argument {} cannot be used with {}",
+                    arg1, arg2
+                );
+                cmd.error(ErrorKind::ArgumentConflict, msg).exit();
+            }
+        }
+    }
 
     // Validate interdependent flags for ad-hoc mode (when no channel is specified)
     // This ensures ad-hoc channels have all necessary components to function properly

--- a/tests/cli/cli_special.rs
+++ b/tests/cli/cli_special.rs
@@ -43,6 +43,24 @@ fn test_autocomplete_prompt_and_channel_argument_conflict_errors() {
     tester.assert_raw_output_contains("cannot be used with");
 }
 
+/// Tests that --autocomplete-prompt works with a working directory path argument.
+#[test]
+fn test_autocomplete_prompt_with_working_directory() {
+    let mut tester = PtyTester::new();
+
+    // This should work: --autocomplete-prompt with a path argument
+    let cmd = tv_local_config_and_cable_with_args(&[
+        "--autocomplete-prompt",
+        "ls",
+        "/etc",
+    ]);
+    let mut child = tester.spawn_command_tui(cmd);
+
+    // Send Ctrl+C to exit (the test is mainly to ensure no CLI parsing error)
+    tester.send(&ctrl('c'));
+    PtyTester::assert_exit_ok(&mut child, DEFAULT_DELAY);
+}
+
 /// Tests that the `list-channels` subcommand lists available channels.
 #[test]
 fn test_list_channels_subcommand_lists_channels() {


### PR DESCRIPTION
the new clap restrictions introduced a regression with `--autocomplete-prompt` causing the following command to fail

```
tv --autocomplete-prompt "nvim" /etc
```

it incorrectly interpreted that `/etc/` was a channel and triggered the channel|autocomplete-prompt restriction