### PR TITLE
fix: set fish keybinds for both default and insert modes

### DIFF
--- a/television/utils/shell/completion.fish
+++ b/television/utils/shell/completion.fish
@@ -126,5 +126,7 @@ function tv_shell_history
     end
 end
 
-bind {tv_smart_autocomplete_keybinding} tv_smart_autocomplete
-bind {tv_shell_history_keybinding} tv_shell_history
+for mode in default insert
+    bind --mode $mode {tv_smart_autocomplete_keybinding} tv_smart_autocomplete
+    bind --mode $mode {tv_shell_history_keybinding} tv_shell_history
+end


### PR DESCRIPTION
When I set up the keybinds for my fish, I couldn't configure them. After a while, I realized that there are two modes for fish. Whenever vim mode is set up for fish with `fish_vi_key_bindings`.

Based on how the keybinds are set in [fzf.fish](https://github.com/PatrickF1/fzf.fish/blob/8920367cf85eee5218cc25a11e209d46e2591e7a/functions/fzf_configure_bindings.fish#L32), I managed to fix it.

Let me know what you think 🤞