### PR TITLE
fix(tui): account for cursor position when determining the size

### DIFF
--- a/television/tui.rs
+++ b/television/tui.rs
@@ -143,6 +143,9 @@ where
             terminal_size.height, available_height, cursor_position.y
         );
 
+        // We need to add one to the required height to account for the cursor position.
+        let required_height = required_height + 1;
+
         // If we don't have enough space for the required height we need to scroll up.
         if available_height < required_height {
             // Minus one to account for the cursor position.


### PR DESCRIPTION
## 📺 PR Description

Fixes #615 

When we want to draw a viewport of `required_height` lines, we need
- required_height -> the lines that belong to the TUI
- 1 -> the cursor’s own line (top border of the viewport)

A few lines later we compute how many rows to scroll:
The extra - 1 deliberately discounts the cursor’s current line (we don’t want to scroll past it), so the earlier + 1 is needed to keep the math balanced.

In short: the + 1 compensates for the later - 1, making sure we always create one full blank line of space for the status bar/prompt and preventing the overlap when the terminal doesn’t have enough free lines left.

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [x] I have added a reasonable amount of documentation to the code where appropriate
