### PR TITLE
test(cli): fix some flaky tests, reinstate exact mode testing

### DIFF
--- a/tests/cli/cli_input.rs
+++ b/tests/cli/cli_input.rs
@@ -96,20 +96,22 @@ fn test_exact_matching_enabled() {
     PtyTester::assert_exit_ok(&mut child, DEFAULT_DELAY);
 }
 
-// #[test]
-// TODO: This test is failing because the matcher is not correctly handling the exact matching mode. REGRESSION
-// fn test_exact_matching_enabled_fails() {
-//     let mut tester = PtyTester::new();
+#[test]
+fn test_exact_matching_enabled_fails() {
+    let mut tester = PtyTester::new();
 
-//     // This enables exact substring matching instead of the default fuzzy matching
-//     let cmd = tv_local_config_and_cable_with_args(&["files", "--exact", "--input", "fl1"]);
-//     let mut child = tester.spawn_command_tui(cmd);
+    // This enables exact substring matching instead of the default fuzzy matching
+    let cmd = tv_local_config_and_cable_with_args(&[
+        "files", "--exact", "--input", "fl1",
+    ]);
+    let mut child = tester.spawn_command_tui(cmd);
 
-//     // Verify the TUI started successfully with exact matching enabled and no results
-//     tester.assert_tui_frame_contains("│> fl1                                               0 / 0 │");
-//     tester.assert_not_tui_frame_contains("file1.txt");
+    // Verify the TUI started successfully with exact matching enabled and no results
+    tester.assert_tui_frame_contains("│> fl1");
+    tester.assert_tui_frame_contains("0 / 0");
+    tester.assert_not_tui_frame_contains("file1.txt");
 
-//     // Send Ctrl+C to exit the application
-//     tester.send(&ctrl('c'));
-//     PtyTester::assert_exit_ok(&mut child, DEFAULT_DELAY);
-// }
+    // Send Ctrl+C to exit the application
+    tester.send(&ctrl('c'));
+    PtyTester::assert_exit_ok(&mut child, DEFAULT_DELAY);
+}

--- a/tests/cli/cli_ui.rs
+++ b/tests/cli/cli_ui.rs
@@ -3,12 +3,7 @@
 //! These tests verify Television's user interface customization capabilities,
 //! ensuring users can adapt the layout and appearance to their preferences and needs.
 
-use std::fs;
-use television::{
-    config::{Config, ConfigEnv},
-    tui::TESTING_ENV_VAR,
-};
-use tempfile::tempdir;
+use television::tui::TESTING_ENV_VAR;
 
 use super::common::*;
 
@@ -440,7 +435,7 @@ fn test_tui_with_height_and_width() {
 
 #[test]
 // FIXME: needs https://github.com/crossterm-rs/crossterm/pull/957
-#[ignore]
+#[ignore = "needs https://github.com/crossterm-rs/crossterm/pull/957"]
 fn test_tui_with_height_only() {
     unsafe { std::env::set_var(TESTING_ENV_VAR, "1") };
     let mut tester = PtyTester::new();

--- a/tests/cli/cli_ui_behavior.rs
+++ b/tests/cli/cli_ui_behavior.rs
@@ -102,7 +102,11 @@ fn test_scroll_preview_keybindings() {
     let mut tester = PtyTester::new();
 
     // Start with the files channel which has preview enabled
-    let cmd = tv_local_config_and_cable_with_args(&["files"]);
+    let cmd = tv_local_config_and_cable_with_args(&[
+        "files",
+        "--input",
+        "CHANGELOG.md",
+    ]);
     let mut child = tester.spawn_command_tui(cmd);
 
     // Send Page Down to scroll preview down
@@ -136,6 +140,8 @@ fn test_reload_source_keybinding() {
     // Start with the files channel
     let cmd = tv_local_config_and_cable_with_args(&[
         "files",
+        "--input",
+        ".txt",
         tmp_dir.to_str().unwrap(),
     ]);
     let mut child = tester.spawn_command_tui(cmd);


### PR DESCRIPTION
## 📺 PR Description

Fixes #631 
Added constraints to make either mitigate or remove "flakiness" for some tests

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [ ] I have added a reasonable amount of documentation to the code where appropriate
