### PR TITLE
fix(nix): set meta.mainProgram field

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,9 @@
       in {
         packages.default = naersk'.buildPackage {
           src = ./.;
+          meta = {
+            mainProgram = "tv";
+          };
         };
         apps = {
           default = flake-utils.lib.mkApp {


### PR DESCRIPTION
`meta.mainProgram` must be set otherwise `lib.getExe` assumes that the package name is `television` and home manager shell integrations are broken

## 📺 PR Description

<!-- summary of the change + which issue is fixed if applicable. -->

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [ ] I have added a reasonable amount of documentation to the code where appropriate
