### PR TITLE
fix(website): Added gap between home page features on smaller screens

### DIFF
--- a/website/src/components/HomepageFeatures/index.tsx
+++ b/website/src/components/HomepageFeatures/index.tsx
@@ -15,8 +15,10 @@ const FeatureList: FeatureItem[] = [
     imgSrc: require("@site/static/img/files-toml.png").default,
     description: (
       <>
-        <a href="/docs/Users/channels">Create your own channels in a simple TOML file and search through
-        files, git repositories, environment variables, docker images, and more.
+        <a href="/docs/Users/channels">
+          Create your own channels in a simple TOML file and search through
+          files, git repositories, environment variables, docker images, and
+          more.
         </a>
       </>
     ),
@@ -27,8 +29,8 @@ const FeatureList: FeatureItem[] = [
     description: (
       <>
         <a href="/docs/Users/shell-integration">
-        Television integrates with your shell and provides autocompletion that is both
-          extensible and configurable to use your own channels.
+          Television integrates with your shell and provides autocompletion that
+          is both extensible and configurable to use your own channels.
         </a>
       </>
     ),
@@ -48,11 +50,11 @@ function Feature({ title, imgSrc, description }: FeatureItem) {
         <p>{description}</p>
       </div>
       <div className="featureImageContainer">
-        <img 
-          src={imgSrc} 
+        <img
+          src={imgSrc}
           alt={title}
-          className={styles.featureImage} 
-          role="img" 
+          className={styles.featureImage}
+          role="img"
         />
       </div>
     </div>
@@ -63,7 +65,7 @@ export default function HomepageFeatures(): ReactNode {
   return (
     <section className={styles.features}>
       <div className="container">
-        <div className="row">
+        <div className={clsx("row", styles.featuresRow)}>
           {FeatureList.map((props, idx) => (
             <Feature key={idx} {...props} />
           ))}

--- a/website/src/components/HomepageFeatures/styles.module.css
+++ b/website/src/components/HomepageFeatures/styles.module.css
@@ -40,3 +40,9 @@ html[data-theme='dark'] .featureSvg {
   flex-direction: column;
   align-items: center;
 }
+
+@media screen and (max-width: 996px) {
+  .featuresRow {
+    gap: 2rem;
+  }
+}


### PR DESCRIPTION
## 📺 PR Description

<!-- summary of the change + which issue is fixed if applicable. -->
Just added a gap for the home page features on smaller screens. Here's a before/after.

Before:

<img width="553" height="500" alt="image" src="https://github.com/user-attachments/assets/ea3d70cf-8eca-459f-8492-79c6845b277d" />


After:

<img width="557" height="500" alt="image" src="https://github.com/user-attachments/assets/a3c501d4-e85c-4dfc-acdd-39f423ea8652" />


## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [ ] I have added a reasonable amount of documentation to the code where appropriate
