### PR TITLE
fix(fish): more robust string escaping

### DIFF
--- a/television/utils/shell/completion.fish
+++ b/television/utils/shell/completion.fish
@@ -109,9 +109,9 @@ function tv_smart_autocomplete
         end
 
         for i in $result
-            commandline -it -- $dir(string escape -- $i)' '
+            commandline -t -- (string escape -- "$dir$i")' '
             # optional, if you want to replace '/home/foo/' with '~/', comment out above and uncomment below
-            # commandline -it -- (string replace --all $HOME '~' $dir(string escape -- $i))' '
+            # commandline -t -- (string replace --all $HOME '~' -- (string escape -- "$dir$i"))' '
         end
     end
 


### PR DESCRIPTION
fixes #653 

> https://github.com/alexpasmantier/television/blob/28f58e0641e3e4a56f02c39e165642024da430df/television/utils/shell/completion.fish#L112
> 
> This line should be
> 
> ```
> commandline -t -- (string escape -- "$dir$i")' '
> ```
> 
> This is a bug in the fish completion. Bash seems to be fine.
> 
> Testing with:
> 
> ```
> ❯ fish --version
> fish, version 4.0.2
> 
> ❯ mkdir -p "a/with whitespace"
> 
> ❯ cd a<ctrl-t>
> ```
> 
> Result:
> 
> ```
> ❯ cd a/'with whitespace/'
> ```
> 
> Expected result:
> 
> ```
> ❯ cd 'a/with whitespace/'
> ```
> 
> The fix on top gets this result.