### PR TITLE
feat: better handling external action's arguments

### DIFF
--- a/benches/main/ui.rs
+++ b/benches/main/ui.rs
@@ -31,6 +31,7 @@ pub fn draw_results_list(c: &mut Criterion) {
     let entries = [
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/LICENSE".to_string(),
             match_ranges: Some(into_ranges(&[0, 1, 2, 3])),
             icon: Some(FileIcon {
@@ -42,6 +43,7 @@ pub fn draw_results_list(c: &mut Criterion) {
         },
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/README.md".to_string(),
             match_ranges: Some(into_ranges(&[0, 1, 2, 3])),
             icon: Some(FileIcon {
@@ -53,6 +55,7 @@ pub fn draw_results_list(c: &mut Criterion) {
         },
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/stdlib/re.pyi".to_string(),
             match_ranges: Some(into_ranges(&[0, 1, 2, 3])),
             icon: Some(FileIcon {
@@ -64,6 +67,7 @@ pub fn draw_results_list(c: &mut Criterion) {
         },
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/stdlib/io.pyi".to_string(),
             match_ranges: Some(into_ranges(&[0, 1, 2, 3])),
             icon: Some(FileIcon {
@@ -75,6 +79,7 @@ pub fn draw_results_list(c: &mut Criterion) {
         },
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/stdlib/gc.pyi".to_string(),
             match_ranges: Some(into_ranges(&[0, 1, 2, 3])),
             icon: Some(FileIcon {
@@ -86,6 +91,7 @@ pub fn draw_results_list(c: &mut Criterion) {
         },
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/stdlib/uu.pyi".to_string(),
             match_ranges: Some(into_ranges(&[0, 1, 2, 3])),
             icon: Some(FileIcon {
@@ -97,6 +103,7 @@ pub fn draw_results_list(c: &mut Criterion) {
         },
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/stdlib/nt.pyi".to_string(),
             match_ranges: Some(into_ranges(&[0, 1, 2, 3])),
             icon: Some(FileIcon {
@@ -108,6 +115,7 @@ pub fn draw_results_list(c: &mut Criterion) {
         },
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/stdlib/dis.pyi".to_string(),
             match_ranges: Some(into_ranges(&[0, 1, 2, 3])),
             icon: Some(FileIcon {
@@ -119,6 +127,7 @@ pub fn draw_results_list(c: &mut Criterion) {
         },
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/stdlib/imp.pyi".to_string(),
             match_ranges: Some(into_ranges(&[0, 1, 2, 3])),
             icon: Some(FileIcon {
@@ -130,6 +139,7 @@ pub fn draw_results_list(c: &mut Criterion) {
         },
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/stdlib/bdb.pyi".to_string(),
             match_ranges: Some(into_ranges(&[0, 1, 2, 3])),
             icon: Some(FileIcon {
@@ -141,6 +151,7 @@ pub fn draw_results_list(c: &mut Criterion) {
         },
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/stdlib/abc.pyi".to_string(),
             match_ranges: Some(into_ranges(&[0, 1, 2, 3])),
             icon: Some(FileIcon {
@@ -152,6 +163,7 @@ pub fn draw_results_list(c: &mut Criterion) {
         },
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/stdlib/cgi.pyi".to_string(),
             match_ranges: Some(into_ranges(&[0, 1, 2, 3])),
             icon: Some(FileIcon {
@@ -163,6 +175,7 @@ pub fn draw_results_list(c: &mut Criterion) {
         },
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/stdlib/bz2.pyi".to_string(),
             match_ranges: Some(into_ranges(&[0, 1, 2, 3])),
             icon: Some(FileIcon {
@@ -174,6 +187,7 @@ pub fn draw_results_list(c: &mut Criterion) {
         },
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/stdlib/grp.pyi".to_string(),
             match_ranges: Some(into_ranges(&[0, 1, 2, 3])),
             icon: Some(FileIcon {
@@ -185,6 +199,7 @@ pub fn draw_results_list(c: &mut Criterion) {
         },
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/stdlib/ast.pyi".to_string(),
             match_ranges: Some(into_ranges(&[0, 1, 2, 3])),
             icon: Some(FileIcon {
@@ -196,6 +211,7 @@ pub fn draw_results_list(c: &mut Criterion) {
         },
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/stdlib/csv.pyi".to_string(),
             match_ranges: Some(into_ranges(&[0, 1, 2, 3])),
             icon: Some(FileIcon {
@@ -207,6 +223,7 @@ pub fn draw_results_list(c: &mut Criterion) {
         },
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/stdlib/pdb.pyi".to_string(),
             match_ranges: Some(into_ranges(&[0, 1, 2, 3])),
             icon: Some(FileIcon {
@@ -218,6 +235,7 @@ pub fn draw_results_list(c: &mut Criterion) {
         },
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/stdlib/pwd.pyi".to_string(),
             match_ranges: Some(into_ranges(&[0, 1, 2, 3])),
             icon: Some(FileIcon {
@@ -229,6 +247,7 @@ pub fn draw_results_list(c: &mut Criterion) {
         },
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/stdlib/ssl.pyi".to_string(),
             match_ranges: Some(into_ranges(&[0, 1, 2, 3])),
             icon: Some(FileIcon {
@@ -240,6 +259,7 @@ pub fn draw_results_list(c: &mut Criterion) {
         },
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/stdlib/tty.pyi".to_string(),
             match_ranges: Some(into_ranges(&[0, 1, 2, 3])),
             icon: Some(FileIcon {
@@ -251,6 +271,7 @@ pub fn draw_results_list(c: &mut Criterion) {
         },
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/stdlib/nis.pyi".to_string(),
             match_ranges: Some(into_ranges(&[0, 1, 2, 3])),
             icon: Some(FileIcon {
@@ -262,6 +283,7 @@ pub fn draw_results_list(c: &mut Criterion) {
         },
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/stdlib/pty.pyi".to_string(),
             match_ranges: Some(into_ranges(&[0, 1, 2, 3])),
             icon: Some(FileIcon {
@@ -273,6 +295,7 @@ pub fn draw_results_list(c: &mut Criterion) {
         },
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/stdlib/cmd.pyi".to_string(),
             match_ranges: Some(into_ranges(&[0, 1, 2, 3])),
             icon: Some(FileIcon {
@@ -284,6 +307,7 @@ pub fn draw_results_list(c: &mut Criterion) {
         },
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/tests/utils.py".to_string(),
             match_ranges: Some(into_ranges(&[0, 1, 2, 3])),
             icon: Some(FileIcon {
@@ -295,6 +319,7 @@ pub fn draw_results_list(c: &mut Criterion) {
         },
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/pyproject.toml".to_string(),
             match_ranges: Some(into_ranges(&[0, 1, 2, 3])),
             icon: Some(FileIcon {
@@ -306,6 +331,7 @@ pub fn draw_results_list(c: &mut Criterion) {
         },
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/MAINTAINERS.md".to_string(),
             match_ranges: Some(into_ranges(&[0, 1, 2, 3])),
             icon: Some(FileIcon {
@@ -317,6 +343,7 @@ pub fn draw_results_list(c: &mut Criterion) {
         },
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/stdlib/enum.pyi".to_string(),
             match_ranges: Some(into_ranges(&[0, 1, 2, 3])),
             icon: Some(FileIcon {
@@ -328,6 +355,7 @@ pub fn draw_results_list(c: &mut Criterion) {
         },
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/stdlib/hmac.pyi".to_string(),
             match_ranges: Some(into_ranges(&[0, 1, 2, 3])),
             icon: Some(FileIcon {
@@ -339,6 +367,7 @@ pub fn draw_results_list(c: &mut Criterion) {
         },
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/stdlib/uuid.pyi".to_string(),
             match_ranges: Some(into_ranges(&[0, 1, 2, 3])),
             icon: Some(FileIcon {
@@ -350,6 +379,7 @@ pub fn draw_results_list(c: &mut Criterion) {
         },
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/stdlib/glob.pyi".to_string(),
             match_ranges: Some(into_ranges(&[0, 1, 2, 3])),
             icon: Some(FileIcon {
@@ -361,6 +391,7 @@ pub fn draw_results_list(c: &mut Criterion) {
         },
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/stdlib/_ast.pyi".to_string(),
             match_ranges: Some(into_ranges(&[0, 1, 2, 3])),
             icon: Some(FileIcon {
@@ -372,6 +403,7 @@ pub fn draw_results_list(c: &mut Criterion) {
         },
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/stdlib/_csv.pyi".to_string(),
             match_ranges: Some(into_ranges(&[0, 1, 2, 3])),
             icon: Some(FileIcon {
@@ -383,6 +415,7 @@ pub fn draw_results_list(c: &mut Criterion) {
         },
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/stdlib/code.pyi".to_string(),
             match_ranges: Some(into_ranges(&[0, 1, 2, 3])),
             icon: Some(FileIcon {
@@ -394,6 +427,7 @@ pub fn draw_results_list(c: &mut Criterion) {
         },
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/stdlib/spwd.pyi".to_string(),
             match_ranges: Some(into_ranges(&[0, 1, 2, 3])),
             icon: Some(FileIcon {
@@ -405,6 +439,7 @@ pub fn draw_results_list(c: &mut Criterion) {
         },
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/stdlib/_msi.pyi".to_string(),
             match_ranges: Some(into_ranges(&[0, 1, 2, 3])),
             icon: Some(FileIcon {
@@ -416,6 +451,7 @@ pub fn draw_results_list(c: &mut Criterion) {
         },
         Entry {
             display: None,
+            output: None,
             raw: "typeshed/stdlib/time.pyi".to_string(),
 
             icon: Some(FileIcon {

--- a/cable/unix/files.toml
+++ b/cable/unix/files.toml
@@ -16,5 +16,5 @@ shortcut = "f1"
 
 # [actions.edit]
 # description = "Opens the selected entries with Neovim"
-# command = "nvim {split:\\n:..|map:{append:'|prepend:'}|join: }"
+# command = "nvim {}"
 # mode = "execute"

--- a/docs/01-Users/07-channels.md
+++ b/docs/01-Users/07-channels.md
@@ -228,3 +228,48 @@ confirm_selection = "ctrl-y"
 ```
 
 See [actions.rs](https://github.com/alexpasmantier/television/blob/main/television/action.rs) for a list of available actions.
+
+#### `[actions]`
+
+External actions allow you to define custom commands that can be executed on
+selected entries. Actions are triggered via keybindings using the
+`actions:<action_name>` syntax.
+
+```toml
+[keybindings]
+ctrl-e = "actions:edit"
+f2 = "actions:view"
+
+[actions.edit]
+description = "Open selected files in editor"
+command = "nvim {split:\\n:..|map:{append:'|prepend:'}|join: }"
+mode = "execute"
+separator = "\n"
+# example: inputs "file1" and "file 2" will generate the command
+# nvim 'file1' 'file 2'
+# Note: we added quotes at command level to avoid shell artifacts
+
+[actions.view]
+description = "View files with less"
+command = "less {}"
+mode = "fork"
+output_mode = "discard"
+separator = " "
+# example: inputs "file1" and "file 2" will generate the command
+# less file1 file 2
+# Note: 3 args here, instead of 2
+```
+
+**Action specification:**
+
+- `description` - Optional description of what the action does
+- `command` - Command template to execute (supports [templating syntax](#templating-syntax))
+- `mode` - Execution mode:
+  - `execute` - Run command and wait for completion (inherits terminal)
+  - `fork` - Run command in background (**not yet implemented**)
+- `output_mode` - How to handle command output (when `mode = "fork"`, **not yet implemented**):
+  - `capture` - Capture output for processing
+  - `discard` - Discard output silently
+- `separator` - Character(s) to use when joining **multiple selected entries**,
+depending on the entries content it might be beneficial to change to another
+one (default: `"\n"`)

--- a/docs/01-Users/07-channels.md
+++ b/docs/01-Users/07-channels.md
@@ -288,6 +288,6 @@ separator = " "
 - `output_mode` - How to handle command output (when `mode = "fork"`, **not yet implemented**):
   - `capture` - Capture output for processing
   - `discard` - Discard output silently
-- `separator` - Character(s) to use when joining **multiple selected entries**,
+- `separator` - Character(s) to use when joining **multiple selected entries** when using complex template processing,
 depending on the entries content it might be beneficial to change to another
-one (default: `"\n"`)
+one (default: `" "` - space)

--- a/docs/01-Users/07-channels.md
+++ b/docs/01-Users/07-channels.md
@@ -235,6 +235,24 @@ External actions allow you to define custom commands that can be executed on
 selected entries. Actions are triggered via keybindings using the
 `actions:<action_name>` syntax.
 
+**Simple Braces Syntactic Sugar:**
+
+For most use cases, you can use simple `{}` braces which automatically handle
+quoting and multiple entries:
+
+```toml
+[actions.edit]
+description = "Open selected files in editor"
+command = "nvim {}"
+# Single file: nvim 'file1.txt'
+# Multiple files: nvim 'file1.txt' 'file2.txt'
+# Files with quotes: nvim 'file\'s name.txt'
+```
+
+**Advanced Template Processing:**
+
+For complex formatting needs, use the full [templating syntax](#templating-syntax):
+
 ```toml
 [keybindings]
 ctrl-e = "actions:edit"

--- a/television/channels/channel.rs
+++ b/television/channels/channel.rs
@@ -97,10 +97,13 @@ impl Channel {
         let mut entries = Vec::with_capacity(results.len());
 
         for item in results {
-            let entry = Entry::new(item.inner)
+            let mut entry = Entry::new(item.inner)
                 .with_display(item.matched_string)
                 .with_match_indices(&item.match_indices)
                 .ansi(self.prototype.source.ansi);
+            if let Some(output) = &self.prototype.source.output {
+                entry = entry.with_output(output.clone());
+            }
             entries.push(entry);
         }
 
@@ -112,6 +115,9 @@ impl Channel {
             let mut entry = Entry::new(item.inner.clone())
                 .with_display(item.matched_string)
                 .with_match_indices(&item.match_indices);
+            if let Some(output) = &self.prototype.source.output {
+                entry = entry.with_output(output.clone());
+            }
             if let Some(p) = &self.prototype.preview {
                 // FIXME: this should be done by the previewer instead
                 if let Some(offset_expr) = &p.offset {

--- a/television/channels/prototypes.rs
+++ b/television/channels/prototypes.rs
@@ -186,7 +186,7 @@ pub enum OutputMode {
 }
 
 fn default_separator() -> String {
-    "\n".to_string()
+    " ".to_string()
 }
 
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize, PartialEq)]

--- a/television/channels/prototypes.rs
+++ b/television/channels/prototypes.rs
@@ -185,6 +185,10 @@ pub enum OutputMode {
     Discard,
 }
 
+fn default_separator() -> String {
+    "\n".to_string()
+}
+
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize, PartialEq)]
 pub struct ActionSpec {
     #[serde(default)]
@@ -197,6 +201,9 @@ pub struct ActionSpec {
     /// How to handle command output
     #[serde(default)]
     pub output_mode: OutputMode,
+    /// Separator to use when joining multiple selected entries
+    #[serde(default = "default_separator")]
+    pub separator: String,
     // TODO: add `requirements` (see `prototypes::BinaryRequirement`)
 }
 

--- a/television/channels/remote_control.rs
+++ b/television/channels/remote_control.rs
@@ -9,6 +9,7 @@ use crate::{
     matcher::{Matcher, config::Config},
     screen::result_item::ResultItem,
 };
+use anyhow::Result;
 use devicons::FileIcon;
 
 #[derive(Debug, Clone)]
@@ -62,6 +63,10 @@ impl ResultItem for CableEntry {
 
     fn display(&self) -> &str {
         &self.channel_name
+    }
+
+    fn output(&self) -> Result<String> {
+        Ok(self.channel_name.clone())
     }
 
     fn match_ranges(&self) -> Option<&[(u32, u32)]> {

--- a/television/main.rs
+++ b/television/main.rs
@@ -136,11 +136,7 @@ async fn main() -> Result<()> {
     }
     if let Some(entries) = output.selected_entries {
         for entry in &entries {
-            writeln!(
-                bufwriter,
-                "{}",
-                entry.output(&app.television.channel.prototype.source.output)
-            )?;
+            writeln!(bufwriter, "{}", entry.output()?)?;
         }
     }
     bufwriter.flush()?;

--- a/television/screen/result_item.rs
+++ b/television/screen/result_item.rs
@@ -10,6 +10,7 @@ use crate::{
     },
 };
 use ansi_to_tui::IntoText;
+use anyhow::Result;
 use devicons::FileIcon;
 use ratatui::{
     prelude::{Color, Line, Span, Style},
@@ -31,6 +32,9 @@ pub trait ResultItem {
 
     /// The main text representing the item.
     fn display(&self) -> &str;
+
+    /// The output string that will be used when the item is selected.
+    fn output(&self) -> Result<String>;
 
     /// Highlight match ranges (char based indices) within `display()`.
     ///


### PR DESCRIPTION
## 📺 PR Description

Add the possibility to change the separator when multiple items are selected and we're executing and external action.

```toml
[actions.edit]
description = "Open selected files in editor"
command = "nvim {split:\\n:..|map:{append:'|prepend:'}|join: }"
mode = "execute"
separator = "\n"
# example: inputs "file1" and "file 2" will generate the command
# nvim 'file1' 'file 2'
```

Default value is the newline, but depending on the actual entries it might be beneficial to use another one

Add external actions documentation

Add support for common use case where we only want to escape every selection, allowing a short syntax like:

```toml
command = 'nvim {}'
# for inputs "file1.txt" and "file2.txt" produces
# nvim 'file1.txt' 'file2.txt
# for inputs "file1's.txt" and "file2.txt" produces
# nvim 'file1\'s.txt' 'file2.txt
```

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [x] I have added a reasonable amount of documentation to the code where appropriate
