### PR TITLE
feat(actions): improve actions behavior and add support for `exec`

### DIFF
--- a/cable/unix/files.toml
+++ b/cable/unix/files.toml
@@ -12,9 +12,10 @@ env = { BAT_THEME = "ansi" }
 
 [keybindings]
 shortcut = "f1"
-# ctrl-f12 = "actions:edit"
+f12 = "actions:edit"
 
-# [actions.edit]
-# description = "Opens the selected entries with Neovim"
-# command = "nvim {}"
-# mode = "execute"
+[actions.edit]
+description = "Opens the selected entries with the default editor (falls back to vim)"
+command = "${EDITOR:-vim} '{}'"
+# use `mode = "fork"` if you want to return to tv afterwards
+mode = "execute"

--- a/docs/01-Users/07-channels.md
+++ b/docs/01-Users/07-channels.md
@@ -278,7 +278,6 @@ separator = "\n"
 description = "View files with less"
 command = "less {}"
 mode = "fork"
-output_mode = "discard"
 separator = " "
 # example: inputs "file1" and "file 2" will generate the command
 # less file1 file 2
@@ -290,11 +289,8 @@ separator = " "
 - `description` - Optional description of what the action does
 - `command` - Command template to execute (supports [templating syntax](#templating-syntax))
 - `mode` - Execution mode:
-  - `execute` - Run command and wait for completion (inherits terminal)
-  - `fork` - Run command in background (**not yet implemented**)
-- `output_mode` - How to handle command output (when `mode = "fork"`, **not yet implemented**):
-  - `capture` - Capture output for processing
-  - `discard` - Discard output silently
+  - `execute` - Run command and become the new process
+  - `fork` - Run command in a subprocess, allowing you to return to tv upon completion
 - `separator` - Character(s) to use when joining **multiple selected entries** when using complex template processing,
 depending on the entries content it might be beneficial to change to another
 one (default: `" "` - space)

--- a/television/channels/prototypes.rs
+++ b/television/channels/prototypes.rs
@@ -177,19 +177,6 @@ pub enum ExecutionMode {
     Execute,
 }
 
-/// Output handling mode for external actions
-#[derive(
-    Debug, Clone, Default, serde::Deserialize, serde::Serialize, PartialEq,
-)]
-#[serde(rename_all = "lowercase")]
-pub enum OutputMode {
-    /// Capture output for processing
-    Capture,
-    /// Discard output silently
-    #[default]
-    Discard,
-}
-
 fn default_separator() -> String {
     " ".to_string()
 }
@@ -203,10 +190,9 @@ pub struct ActionSpec {
     /// How to execute the command
     #[serde(default)]
     pub mode: ExecutionMode,
-    /// How to handle command output
-    #[serde(default)]
-    pub output_mode: OutputMode,
-    /// Separator to use when joining multiple selected entries
+    /// Separator to use when formatting multiple entries into the command
+    ///
+    /// Example: `rm file1+SEPARATOR+file2+SEPARATOR+file3`
     #[serde(default = "default_separator")]
     pub separator: String,
     // TODO: add `requirements` (see `prototypes::BinaryRequirement`)

--- a/television/main.rs
+++ b/television/main.rs
@@ -20,7 +20,6 @@ use television::{
     gh::update_local_channels,
     television::Mode,
     utils::clipboard::CLIPBOARD,
-    utils::command::execute_action,
     utils::{
         shell::{
             Shell, completion_script, render_autocomplete_script_template,
@@ -99,22 +98,6 @@ async fn main() -> Result<()> {
     debug!("Running application...");
     let output = app.run(stdout().is_terminal(), false).await?;
     info!("App output: {:?}", output);
-
-    // Handle external action execution after terminal cleanup
-    if let Some((action_spec, entries)) = output.external_action {
-        debug!("Executing external action command after terminal cleanup");
-
-        let status = execute_action(&action_spec, &entries)?;
-        if !status.success() {
-            eprintln!(
-                "External command failed with exit code: {:?}",
-                status.code()
-            );
-            exit(1);
-        }
-
-        exit(0);
-    }
 
     let stdout_handle = stdout().lock();
     let mut bufwriter = BufWriter::new(stdout_handle);


### PR DESCRIPTION
## 📺 PR Description

This improves support for `fork` and adds the logic for the `exec` feature.

I'm dropping the `OutputMode` logic for now as it doesn't seem that useful and kind of gets in the way right now. We might add that back later on.

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [ ] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [ ] I have added a reasonable amount of documentation to the code where appropriate
