### PR TITLE
feat: add support for NetBSD installation

### DIFF
--- a/docs/01-Users/01-installation.md
+++ b/docs/01-Users/01-installation.md
@@ -73,6 +73,12 @@ sudo dpkg -i tv-$VER-x86_64-unknown-linux-musl.deb
 pixi global install television
 ```
 
+## NetBSD (pkgsrc)
+
+```bash
+pkgin install television
+```
+
 ## Pre-compiled Binary
 
 From the [latest release](https://github.com/alexpasmantier/television/releases/latest) page:


### PR DESCRIPTION
## 📺 PR Description

Add NetBSD install instructions

I've just packaged `television` for NetBSD and merged the package into pkgsrc main branch.
Commit log for reference, https://mail-index.netbsd.org/pkgsrc-changes/2025/08/07/msg328025.html

Could you please consider adding this to the supported platforms?
Thanks!

Regards