### PR TITLE
fix(shell): use $TTY for paste bracketing override

### DIFF
--- a/television/utils/shell/completion.zsh
+++ b/television/utils/shell/completion.zsh
@@ -4,14 +4,14 @@
 _disable_bracketed_paste() {
     # Check if bracketed paste is defined, for compatibility with older versions
     if [[ -n $zle_bracketed_paste ]]; then
-        print -nr ${zle_bracketed_paste[2]} >/dev/tty
+        print -nr ${zle_bracketed_paste[2]} >${TTY:-/dev/tty}
     fi
 }
 
 _enable_bracketed_paste() {
     # Check if bracketed paste is defined, for compatibility with older versions
     if [[ -n $zle_bracketed_paste ]]; then
-        print -nr ${zle_bracketed_paste[1]} >/dev/tty
+        print -nr ${zle_bracketed_paste[1]} >${TTY:-/dev/tty}
     fi
 }
 


### PR DESCRIPTION
## 📺 PR Description

use the $TTY var in the zsh integration so that the paste bracketing is disabled in the correct terminal.

See https://github.com/alexpasmantier/television/pull/512#pullrequestreview-3137810333

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] ~~if this is a new feature, I have added tests to consolidate the feature and prevent regressions~~
- [ ] ~~if this is a bug fix, I have added a test that reproduces the bug~~ N/A (if applicable) N/A
- [ ] ~~I have added a reasonable amount of documentation to the code where appropriate~~
