### PR TITLE
Fix install binary

### DIFF
--- a/docs/01-Users/01-installation.md
+++ b/docs/01-Users/01-installation.md
@@ -83,7 +83,7 @@ pkgin install television
 
 From the [latest release](https://github.com/alexpasmantier/television/releases/latest) page:
 
-- Download the latest release asset for your platform (e.g. `tv-vX.X.X-linux-x86_64.tar.gz` if you're on a linux x86 machine)
+- Download the latest release asset for your platform (e.g. `tv-vX.X.X-x86_64-unknown-linux-musl.tar.gz` if you're on a linux x86 machine)
 - Unpack and copy to the relevant location on your system (e.g. `/usr/local/bin` on macos and linux for a global installation)
 
 ## Crates.io

--- a/install.sh
+++ b/install.sh
@@ -153,10 +153,10 @@ install_binary() {
     
     # Map architecture to release naming
     case "$OS-$ARCH" in
-        linux-x86_64) BINARY_TARGET="linux-x86_64" ;;
-        linux-aarch64) BINARY_TARGET="linux-aarch64" ;;
-        macos-x86_64) BINARY_TARGET="darwin-x86_64" ;;
-        macos-aarch64) BINARY_TARGET="darwin-aarch64" ;;
+        linux-x86_64) BINARY_TARGET="x86_64-unknown-linux-musl" ;;
+        linux-aarch64) BINARY_TARGET="aarch64-unknown-linux-gnu" ;;
+        macos-x86_64) BINARY_TARGET="x86_64-apple-darwin" ;;
+        macos-aarch64) BINARY_TARGET="aarch64-apple-darwin" ;;
         *) error "No pre-compiled binary available for $OS-$ARCH" ;;
     esac
     
@@ -167,10 +167,11 @@ install_binary() {
         error "Failed to fetch latest version. Please check your internet connection."
     fi
     
-    TARBALL="tv-$VER-$BINARY_TARGET.tar.gz"
+    DIRNAME="tv-$VER-$BINARY_TARGET"
+    TARBALL="$DIRNAME.tar.gz"
     URL="https://github.com/alexpasmantier/television/releases/download/$VER/$TARBALL"
     
-    info "Downloading Television $VER for $BINARY_TARGET..."
+    info "Downloading Television $VER for $OS-$ARCH..."
     if ! curl -LO "$URL"; then
         error "Failed to download binary package"
     fi
@@ -187,11 +188,11 @@ install_binary() {
     
     info "Installing to $INSTALL_DIR..."
     sudo mkdir -p "$INSTALL_DIR"
-    sudo mv tv "$INSTALL_DIR/tv"
+    sudo mv "$DIRNAME/tv" "$INSTALL_DIR/tv"
     sudo chmod +x "$INSTALL_DIR/tv"
     
     # Clean up
-    rm -f "$TARBALL"
+    rm -rf $DIRNAME*
     
     success "Television $VER installed successfully to $INSTALL_DIR/tv!"
 }


### PR DESCRIPTION
## 📺 PR Description

In versions [0.11.1 - 0.11.3](https://github.com/alexpasmantier/television/compare/0.11.0...0.11.3#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18) the names of pre-compiled binary tarballs have been changed. Commit updates BINARY_TARGET in install.sh to use new tarball names

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [x] I have added a reasonable amount of documentation to the code where appropriate
