### PR TITLE
test: support passing tv binary path

### DIFF
--- a/tests/cli/special.rs
+++ b/tests/cli/special.rs
@@ -113,7 +113,7 @@ fn test_tv_pipes_correctly() -> io::Result<()> {
         dbg!("Skipping test_tv_pipes_correctly in CI environment");
         return Ok(());
     }
-    let mut tv_command = Command::new(TV_BIN_PATH)
+    let mut tv_command = Command::new(*TV_BIN_PATH)
         .args(LOCAL_CONFIG_AND_CABLE)
         .args(["--input", "Cargo.toml"])
         .arg("--take-1")

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+use std::cell::LazyCell;
 use std::path::PathBuf;
 use std::time::Duration;
 use std::{fs, io};
@@ -364,7 +365,9 @@ pub fn f(c: u8) -> String {
 pub const ENTER: &str = "\r";
 pub const ESC: &str = "\x1b";
 
-pub const TV_BIN_PATH: &str = "./target/debug/tv";
+pub const TV_BIN_PATH: LazyCell<&str> = LazyCell::new(|| {
+    option_env!("TV_BIN_PATH").unwrap_or("./target/debug/tv")
+});
 pub const LOCAL_CONFIG_AND_CABLE: &[&str] = &[
     "--cable-dir",
     DEFAULT_CABLE_DIR,
@@ -374,7 +377,7 @@ pub const LOCAL_CONFIG_AND_CABLE: &[&str] = &[
 
 /// A command builder initialized with the tv binary path.
 pub fn tv() -> CommandBuilder {
-    CommandBuilder::new(TV_BIN_PATH)
+    CommandBuilder::new(*TV_BIN_PATH)
 }
 
 /// A command builder initialized with the tv binary path and the provided arguments.


### PR DESCRIPTION
## 📺 PR Description

Add a compile time env var override for the path to the `tv` binary. The tests that run `tv` expect the path to be `./target/debug/tv`, but if you pass a target to cargo, or if you run tests with `--release`, that path doesn't work anymore.

This came up for the FreeBSD people (see https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=288915#c5), and also for me while updating the Chimera Linux package.

For an example of how this can be used, see https://github.com/jcgruenhage/cports/blob/a1dd86b5d24de91f1f2b72afa4c371753d074e1d/user/television/template.py#L5-L7.

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [x] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [x] I have added a reasonable amount of documentation to the code where appropriate
