### PR TITLE
Default cable dir

### DIFF
--- a/docs/01-Users/09-cli.md
+++ b/docs/01-Users/09-cli.md
@@ -460,7 +460,8 @@ minimum height is ensured (set by default at 15 lines)
 **Purpose**: Uses a custom directory for channel definitions
 
 - **Both Modes**: Same behavior
-- **Default**: `~/.config/tv/cable/` (Linux/macOS) or `%APPDATA%\tv\cable\` (Windows)
+- **Default**: `~/.config/tv/cable/` (Linux/macOS) or `%APPDATA%\tv\cable\` (Windows),
+                or `$CABLE_DIR` if set and `.config/tv/cable` doesn't exist.
 - **Use Case**: Custom channel collections or shared team channels
 
 ### 📚 History Options


### PR DESCRIPTION
## 📺 PR Description

<!-- summary of the change + which issue is fixed if applicable. -->

Motivation: Packagers can set the environment variable for users so that television works when first downloaded without needing to download cables first.

Allow for `CABLE_DIR` to be set, which becomes the default cable_dir that is looked up. This can be overridden by setting the `--cable-dir` CLI flag. There is some logic to be done so that this isn't a breaking change:

1. If the .config cable directory already exists, use it.
2. If it doesn't exist, check if the environment variable is set
3. If it is set, use it
4. If it is not set, use the .config directory.

This ensures that is `CABLE_DIR` is used in packaging, it will not break users with their own custom cable directories.

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [x] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [x] I have added a reasonable amount of documentation to the code where appropriate
