### PR TITLE
feat(channels): add procs channel to manage running processes

### DIFF
--- a/.github/workflows/generate-cable-docs.yml
+++ b/.github/workflows/generate-cable-docs.yml
@@ -8,7 +8,6 @@
 name: Generate Cable Docs
 permissions:
   contents: write
-  pull-requests: write
 on:
   push:
     paths:


### PR DESCRIPTION
## 📺 PR Description

This channel list running processes via the `ps` command. I've added the following line to my `config.toml` to enable completion for `kill, proc. caffeinate` commands:

```diff
[shell_integration.channel_triggers]
+ "procs" = ["kill", "procs", "caffeinate"]
```

Here is a demo, first I run `sleep 60m`. Then use `tv procs` to search for the process and press `Ctrl-K` to send a `SIGKILL` signal and terminate the process.

https://github.com/user-attachments/assets/98abae48-887b-410a-9bcf-cdc94e840630

<!-- summary of the change + which issue is fixed if applicable. -->

## Limitation

- [x] ~~When a command is too long, the remaining part will be truncated. Currently, i have no solution for this.~~

<img width="1710" height="810" alt="image" src="https://github.com/user-attachments/assets/1ca590ad-2359-4bc5-8eb7-10ea9545b69e" />


## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [ ] I have added a reasonable amount of documentation to the code where appropriate
