### PR TITLE
fix(channels): deduplicate history command in nu-history channel

### DIFF
--- a/cable/unix/nu-history.toml
+++ b/cable/unix/nu-history.toml
@@ -4,4 +4,4 @@ name = "nu-history"
 description = "A channel to select from your nu history"
 
 [source]
-command = "nu -c 'open $nu.history-path | lines | reverse | to text'"
+command = "nu -c 'open $nu.history-path | lines | uniq | reverse | to text'"


### PR DESCRIPTION
…tory channel

## 📺 PR Description

When I use the nu-history channel to find historical commands, there are many duplicate entries, which are unnecessary for me. Therefore, I tried to modify the channel's source and use uniq to deduplicate commands.

The left one is the origin version and right one is modified version

<img width="3420" height="2148" alt="image" src="https://github.com/user-attachments/assets/08c1c6c2-a9b7-44c4-94e5-8f862b4fb417" />


## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [ ] I have added a reasonable amount of documentation to the code where appropriate
