### PR TITLE
perf: update channels concurrently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1469,9 +1469,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -1479,9 +1479,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -2012,6 +2012,7 @@ dependencies = [
  "parking_lot",
  "portable-pty",
  "ratatui",
+ "rayon",
  "rustc-hash",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ colored = "3.0.0"
 serde_with = "3.13.0"
 which = "8.0.0"
 clap_complete = "4.5.55"
+rayon = "1.11.0"
 
 
 # target specific dependencies

--- a/television/gh.rs
+++ b/television/gh.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use colored::Colorize;
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use std::path::Path;
 use tracing::debug;
 use ureq::get;
@@ -97,7 +98,7 @@ fn get_default_prototypes_from_repo() -> Result<Vec<DownloadedPrototype>> {
         );
     }
     Ok(nodes
-        .iter()
+        .par_iter()
         .filter_map(|node| {
             if node.is_file() {
                 node.download_url.clone()


### PR DESCRIPTION
This adds rayon as a dependency and uses its iterator adapter to make `update-channels` fetch prototypes concurrently.