### PR TITLE
fix(shell): redirect output to /dev/tty for autocomplete commands

### DIFF
--- a/television/utils/shell/completion.fish
+++ b/television/utils/shell/completion.fish
@@ -98,7 +98,7 @@ function tv_smart_autocomplete
     # move to the next line so that the prompt is not overwritten
     printf "\n"
 
-    if set -l result (tv $dir --autocomplete-prompt "$current_prompt" --input $tv_query --inline)
+    if set -l result (tv $dir --autocomplete-prompt "$current_prompt" --input $tv_query --inline >/dev/tty)
         # Remove last token from commandline.
         commandline -t ''
 
@@ -127,7 +127,7 @@ function tv_shell_history
     # move to the next line so that the prompt is not overwritten
     printf "\n"
 
-    set -l output (tv fish-history --input "$current_prompt" --inline)
+    set -l output (tv fish-history --input "$current_prompt" --inline >/dev/tty)
 
     if test -n "$output"
         commandline -r "$output"


### PR DESCRIPTION
## 📺 PR Description

Redirect output to /dev/tty for autocomplete commands
Fixes https://github.com/alexpasmantier/television/issues/697

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [ ] I have added a reasonable amount of documentation to the code where appropriate
