### PR TITLE
feat(config): add `z` (Zoxide) to `dirs` channel triggers

### DIFF
--- a/.config/config.toml
+++ b/.config/config.toml
@@ -215,7 +215,7 @@ fallback_channel = "files"
 # ```
 "alias" = ["alias", "unalias"]
 "env" = ["export", "unset"]
-"dirs" = ["cd", "ls", "rmdir"]
+"dirs" = ["cd", "ls", "rmdir", "z"]
 "files" = [
   "cat",
   "less",


### PR DESCRIPTION
## 📺 PR Description

This will set the `dirs` channel with `z` ([Zoxide](https://github.com/ajeetdsouza/zoxide)) upon `Ctrl` + `T`.

Note that this PR might be extended with other jumping tools like Autojump, and others.

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [ ] I have added a reasonable amount of documentation to the code where appropriate
