### PR TITLE
feat(channels): add sesh session manager channel

### DIFF
--- a/cable/unix/sesh.toml
+++ b/cable/unix/sesh.toml
@@ -1,0 +1,37 @@
+# Television channel for sesh session management
+# https://github.com/joshmedeski/sesh
+
+[metadata]
+name = "sesh"
+description = "Session manager integrating tmux sessions, zoxide directories, and config paths"
+requirements = ["sesh", "fd"]
+
+[source]
+# Multiple source commands for cycling through different modes
+# Press Ctrl+S to cycle between sources
+command = [
+  "sesh list --icons",                          # all sessions (default)
+  "sesh list -t --icons",                       # tmux sessions only
+  "sesh list -c --icons",                       # config directories
+  "sesh list -z --icons",                       # zoxide directories
+  "fd -H -d 2 -t d -E .Trash . ~"               # find directories
+]
+ansi = true
+output = "{strip_ansi|split: :1}"
+
+[preview]
+command = "sesh preview '{strip_ansi|split: :1}'"
+
+[keybindings]
+enter = "actions:connect"
+ctrl-d = "actions:kill_session"
+
+[actions.connect]
+description = "Connect to selected session"
+command = "sesh connect '{strip_ansi|split: :1}'"
+mode = "execute"
+
+[actions.kill_session]
+description = "Kill selected tmux session (press Ctrl+r to reload)"
+command = "tmux kill-session -t '{strip_ansi|split: :1}'"
+mode = "fork"


### PR DESCRIPTION
## 📺 PR Description

Adds channel for [sesh](https://github.com/joshmedeski/sesh), a smart session manager that handles tmux sessions, zoxide directories, and config paths in one place. Supports filtering by source type and includes actions to connect or kill sessions.

![IMG_0520](https://github.com/user-attachments/assets/1aea1259-7c29-4b4d-af28-61b5e3377701)

## Checklist

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [ ] I have added a reasonable amount of documentation to the code where appropriate
