### PR TITLE
fix(channels): run reload source after kill_session action

### DIFF
--- a/cable/unix/sesh.toml
+++ b/cable/unix/sesh.toml
@@ -24,7 +24,7 @@ command = "sesh preview '{strip_ansi|split: :1}'"
 
 [keybindings]
 enter = "actions:connect"
-ctrl-d = "actions:kill_session"
+ctrl-d = [ "actions:kill_session", "reload_source" ]
 
 [actions.connect]
 description = "Connect to selected session"


### PR DESCRIPTION
## 📺 PR Description

This makes sure the source list is up-to-date after killing a tmux sesh session.

## Checklist

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [ ] I have added a reasonable amount of documentation to the code where appropriate
