### PR TITLE
fix(update-channels): channel configs not downloading

### DIFF
--- a/cable/unix/channels.toml
+++ b/cable/unix/channels.toml
@@ -7,7 +7,7 @@ requirements = ["tv", "bat"]
 command = ["tv list-channels"]
 
 [preview]
-command = "bat -pn --color always ${XDG_CONFIG_HOME:-$HOME/.config}/television/cable/{}.toml"
+command = "bat -pn --color always ${XDG_CONFIG_HOME:-$HOME/.config}/television/cable/**/{}.toml"
 
 [keybindings]
 enter = "actions:channel-enter"
@@ -16,4 +16,3 @@ enter = "actions:channel-enter"
 description = "Enter a television channel"
 command = "tv {}"
 mode = "execute"
-

--- a/scripts/update-channels.sh
+++ b/scripts/update-channels.sh
@@ -9,10 +9,7 @@ dest="${XDG_CONFIG_HOME:-$HOME/.config}/television"
 
 mkdir -p "$dest"
 
-auth_header=()
-[[ -n "${GITHUB_TOKEN:-}" ]] && auth_header=(-H "Authorization: Bearer $GITHUB_TOKEN")
-
-curl -sS -L "${auth_header[@]}" \
+curl -sS -L --fail \
   "https://api.github.com/repos/$owner/$repo/git/trees/$ref?recursive=1" \
 | jq -r --arg root "$root/" '
     .tree[]
@@ -28,4 +25,3 @@ curl -sS -L "${auth_header[@]}" \
   done
 
 echo "Done -> $dest"
-


### PR DESCRIPTION
## 📺 PR Description
Firstly let me just say what an amazing job you've done on this project. I recently switched from neovim to zed and needed a replacement for telescope, which is when I came across television, and personally I prefer this.

## ❗Problem

When I run `tv update-channels`, the logs say that channels were downloaded successfully and there’s no error code. However, nothing actually gets downloaded, even if I use the `--force` flag.

## 🔍 Root Cause

- I realised that the issue is that I haven't set the `$GITHUB_TOKEN` variable, which is used by the `update-channels.sh` script when defining the auth header for the first `curl` command.
- I'm not sure if we're supposed to set this variable but when I removed the auth header the `curl` command worked.
- The `jq` filter causes the subsequent while loop's `$relpath` variable to be in the format `$root/<channel-name>.toml`, e.g. `cable/unix/alias.toml`, and then the `curl` command uses this `$relpath` to form the destination path where the channel's `toml` file will be saved, e.g. `~/.config/television/cable/unix/alias.toml`.
- I've been using `~/.config/television/cable/` as the directory to save channel configurations, and not `~/.config/television/cable/unix/`, but channels can work whether they are saved in `cable/` or in `cable/unix/`.
- If there are two channels with the same name, one saved in `cable/` and one in `cable/unix/`, then the former will take precedence.
- The only issue with saving channels in `cable/unix/`, is that the `channels` channel's preview window uses `bat` to output the content of that channel's file found in the `cable/` directory, and therefore channels saved in `cable/unix/` cannot be previewed in the `channels` channel. That has to be a world record for the number of times the word "channel" was used in a sentence!

## 🎯 Intended Behaviour
The solution depends on what your desired behaviour is, namely:

1. **Should users be required to set a `GITHUB_TOKEN`?**
   - From my understanding the token serves two purposes:
     - Enable access to private repos
     - Allow up to 5000 requests/hour per user, as opposed to the standard 60 requests/hour per IP
   - In this case I think it would be safe allowing unauthenticated requests as it's a public repo and it's unlikely that a user will exceed 60 requests/hour
2. **Should channel configs be saved in `~/.config/television/cable/` or `~/.config/television/cable/unix/`?**
   - The documentation advises to save configs in `cable/`, however the `update-channels.sh` script saves configs in `cable/unix/`.
   - I think it's useful to keep the current behaviour, i.e. when calling `tv update-channels` save the default configs in `cable/unix/` but expect users to add custom channels to `cable/`, which always takes precedence. This way a user could implement their own version of an existing channel, e.g. `cable/alias.toml` and if they run an update then `cable/unix/alias.toml` will be updated, while their custom config will persist. 

## 💡 Proposal
If you agree with the points above then I'd like to suggest this PR as a potential fix:

1. **`scripts/update-channels.sh`**
   - Remove the Authorization header from `curl` to ensure that the script still works without a `GITHUB_TOKEN`
2. **`cable/unix/channels.toml`**
   - Preview the contents of a channel by checking for its config file either directly in `cable/` or any of its subdirectories

## ✅ Outcome

- Users don’t need to set a GitHub token to run `tv update-channels`
- Default configs stay in `cable/unix/`
- User customisations saved in `cable/` will always take precedence and survive updates
- `tv channels` previews a channel regardless of whether its config is saved in `cable/` or `cable/unix/`

---


## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [ ] I have added a reasonable amount of documentation to the code where appropriate
