### PR TITLE
fix(channels-preview): preview configs in cable subdirectories

### DIFF
--- a/cable/unix/channels.toml
+++ b/cable/unix/channels.toml
@@ -7,7 +7,7 @@ requirements = ["tv", "bat"]
 command = ["tv list-channels"]
 
 [preview]
-command = "bat -pn --color always ${XDG_CONFIG_HOME:-$HOME/.config}/television/cable/{}.toml"
+command = "bat -pn --color always ${XDG_CONFIG_HOME:-$HOME/.config}/television/cable/**/{}.toml"
 
 [keybindings]
 enter = "actions:channel-enter"
@@ -16,4 +16,3 @@ enter = "actions:channel-enter"
 description = "Enter a television channel"
 command = "tv {}"
 mode = "execute"
-


### PR DESCRIPTION
## 📺 PR Description
This PR ensures that the `tv channels` preview works correctly for configuration files stored in `cable/` or any of its subdirectories. Previously, previews only worked for configs directly under `cable/`.   

- Updated the search path to `${XDG_CONFIG_HOME:-$HOME/.config}/television/cable/**/{}.toml` instead of `${XDG_CONFIG_HOME:-$HOME/.config}/television/cable/{}.toml`.   

- This change aligns the preview logic with the location where `tv update-channels` saves configs, ensuring consistency and proper handling of nested directories. 

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [ ] I have added a reasonable amount of documentation to the code where appropriate
