### PR TITLE
fix(update-channels): prevent overwriting user configs

### DIFF
--- a/scripts/update-channels.sh
+++ b/scripts/update-channels.sh
@@ -1,18 +1,26 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+case "$OSTYPE" in
+  linux-gnu* | darwin*) OS="unix" ;;
+  msys* | cygwin*) OS="windows" ;;
+  *) echo "Unsupported OS: $OSTYPE" && exit 1 ;;
+esac
+
 owner="alexpasmantier"
 repo="television"
-root="cable/unix"
+root="cable/$OS"
 ref="main"
 dest="${XDG_CONFIG_HOME:-$HOME/.config}/television"
 
 mkdir -p "$dest"
 
-auth_header=()
-[[ -n "${GITHUB_TOKEN:-}" ]] && auth_header=(-H "Authorization: Bearer $GITHUB_TOKEN")
+case " $* " in
+*" --force "*) force_update=true ;;
+*) force_update=false ;;
+esac
 
-curl -sS -L "${auth_header[@]}" \
+curl -sS -L ${GITHUB_TOKEN:+-H "Authorization: Bearer $GITHUB_TOKEN"} \
   "https://api.github.com/repos/$owner/$repo/git/trees/$ref?recursive=1" \
 | jq -r --arg root "$root/" '
     .tree[]
@@ -20,12 +28,17 @@ curl -sS -L "${auth_header[@]}" \
     | .path
 ' \
 | while IFS= read -r relpath; do
-    echo "Downloading $relpath"
-    mkdir -p "$dest/$(dirname "$relpath")"
+    channel_name="$(basename "${relpath%.*}")"
+    target="$dest/$relpath"
+    if [ -e "$target" ] && ! $force_update; then
+        echo "Channel $channel_name already exists at $target, SKIPPING..."
+        continue
+    fi
+    mkdir -p "$dest/$root"
     curl -sS -L --fail \
       "https://raw.githubusercontent.com/$owner/$repo/$ref/$relpath" \
-      -o "$dest/$relpath"
+      -o "$target"
+    echo "Saved $channel_name to $target"
   done
 
 echo "Done -> $dest"
-


### PR DESCRIPTION
## 📺 PR Description
This PR prevents the `update-channels.sh` script from overwriting existing user configs unless explicitly requested.   

- Added logic to skip downloading a channel config if it already exists locally, unless the `--force` flag is set.   

- Introduced OS detection to set `root="cable/$OS"` instead of the previous hardcoded `root="cable/unix"`, allowing support for both Windows and Unix cables.   

- Simplified the curl authentication logic by replacing the `auth_header` array (which failed under `set -euo pipefail` when `GITHUB_TOKEN` was unset) with inline conditional expansion:   

  ```bash 

  curl -sS -L ${GITHUB_TOKEN:+-H "Authorization: Bearer $GITHUB_TOKEN"} … 

  ``` 

- After filtering config paths from `jq`, each path is checked locally. If it exists, the download is skipped unless the `--force` flag is set. 

- This ensures user configs are preserved by default, while still allowing explicit overwrites when needed. 

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [ ] I have added a reasonable amount of documentation to the code where appropriate
