### PR TITLE
perf(channel): batching + threadpool to significantly reduce loading times

### DIFF
--- a/benches/main/load_candidates.rs
+++ b/benches/main/load_candidates.rs
@@ -1,5 +1,8 @@
 use criterion::criterion_group;
 use criterion::{BenchmarkId, Criterion, Throughput, black_box};
+use television::channels::entry_processor::{
+    AnsiProcessor, DisplayProcessor, PlainProcessor,
+};
 use television::channels::prototypes::SourceSpec;
 use television::matcher::{Matcher, config::Config};
 use tokio::runtime::Runtime;
@@ -31,16 +34,15 @@ pub fn load_candidates_by_size(c: &mut Criterion) {
                     ))
                     .unwrap();
 
-                    let mut matcher =
-                        Matcher::<String>::new(&Config::default());
+                    // Plain mode uses Matcher<()> for memory efficiency
+                    let mut matcher = Matcher::<()>::new(&Config::default());
                     let injector = matcher.injector();
 
                     television::channels::channel::load_candidates(
                         black_box(source_spec.command),
                         black_box(source_spec.entry_delimiter),
                         black_box(0),
-                        black_box(source_spec.ansi),
-                        black_box(source_spec.display),
+                        black_box(PlainProcessor),
                         injector,
                     )
                     .await;
@@ -73,15 +75,15 @@ pub fn load_candidates_with_ansi(c: &mut Criterion) {
             ))
             .unwrap();
 
-            let mut matcher = Matcher::<String>::new(&Config::default());
+            // Plain mode uses Matcher<()>
+            let mut matcher = Matcher::<()>::new(&Config::default());
             let injector = matcher.injector();
 
             television::channels::channel::load_candidates(
                 black_box(source_spec.command),
                 black_box(source_spec.entry_delimiter),
                 black_box(0),
-                black_box(source_spec.ansi),
-                black_box(source_spec.display),
+                black_box(PlainProcessor),
                 injector,
             )
             .await;
@@ -102,6 +104,7 @@ pub fn load_candidates_with_ansi(c: &mut Criterion) {
             ))
             .unwrap();
 
+            // ANSI mode uses Matcher<String> to store original
             let mut matcher = Matcher::<String>::new(&Config::default());
             let injector = matcher.injector();
 
@@ -109,8 +112,7 @@ pub fn load_candidates_with_ansi(c: &mut Criterion) {
                 black_box(source_spec.command),
                 black_box(source_spec.entry_delimiter),
                 black_box(0),
-                black_box(source_spec.ansi),
-                black_box(source_spec.display),
+                black_box(AnsiProcessor),
                 injector,
             )
             .await;
@@ -139,15 +141,15 @@ pub fn load_candidates_with_display_template(c: &mut Criterion) {
             ))
             .unwrap();
 
-            let mut matcher = Matcher::<String>::new(&Config::default());
+            // Plain mode uses Matcher<()>
+            let mut matcher = Matcher::<()>::new(&Config::default());
             let injector = matcher.injector();
 
             television::channels::channel::load_candidates(
                 black_box(source_spec.command),
                 black_box(source_spec.entry_delimiter),
                 black_box(0),
-                black_box(source_spec.ansi),
-                black_box(source_spec.display),
+                black_box(PlainProcessor),
                 injector,
             )
             .await;
@@ -167,6 +169,7 @@ pub fn load_candidates_with_display_template(c: &mut Criterion) {
             ))
             .unwrap();
 
+            // Display mode uses Matcher<String> to store original
             let mut matcher = Matcher::<String>::new(&Config::default());
             let injector = matcher.injector();
 
@@ -174,8 +177,9 @@ pub fn load_candidates_with_display_template(c: &mut Criterion) {
                 black_box(source_spec.command),
                 black_box(source_spec.entry_delimiter),
                 black_box(0),
-                black_box(source_spec.ansi),
-                black_box(source_spec.display),
+                black_box(DisplayProcessor {
+                    template: source_spec.display.unwrap(),
+                }),
                 injector,
             )
             .await;

--- a/television/channels/channel.rs
+++ b/television/channels/channel.rs
@@ -1,12 +1,14 @@
 use crate::{
     channels::{
         entry::Entry,
+        entry_processor::{
+            AnsiProcessor, DisplayProcessor, EntryProcessor, PlainProcessor,
+        },
         prototypes::{CommandSpec, Template},
     },
     matcher::{Matcher, config::Config, injector::Injector},
     utils::command::shell_command,
 };
-use fast_strip_ansi::strip_ansi_string;
 use rustc_hash::{FxBuildHasher, FxHashSet};
 use std::collections::HashSet;
 use std::process::Stdio;
@@ -19,14 +21,13 @@ use tracing::debug;
 
 const RELOAD_RENDERING_DELAY: Duration = Duration::from_millis(200);
 
-pub struct Channel {
+pub struct Channel<P: EntryProcessor> {
     pub source_command: CommandSpec,
     pub source_entry_delimiter: Option<char>,
-    pub source_ansi: bool,
-    pub source_display: Option<Template>,
     pub source_output: Option<Template>,
     pub supports_preview: bool,
-    matcher: Matcher<String>,
+    processor: P,
+    matcher: Matcher<P::Data>,
     selected_entries: FxHashSet<Entry>,
     crawl_handle: Option<tokio::task::JoinHandle<()>>,
     current_source_index: usize,
@@ -35,14 +36,13 @@ pub struct Channel {
     pub reloading: Arc<AtomicBool>,
 }
 
-impl Channel {
+impl<P: EntryProcessor> Channel<P> {
     pub fn new(
         source_command: CommandSpec,
         source_entry_delimiter: Option<char>,
-        source_ansi: bool,
-        source_display: Option<Template>,
         source_output: Option<Template>,
         supports_preview: bool,
+        processor: P,
     ) -> Self {
         let config = Config::default().prefer_prefix(true);
         let matcher = Matcher::new(&config);
@@ -50,10 +50,9 @@ impl Channel {
         Self {
             source_command,
             source_entry_delimiter,
-            source_ansi,
-            source_display,
             source_output,
             supports_preview,
+            processor,
             matcher,
             selected_entries: HashSet::with_hasher(FxBuildHasher),
             crawl_handle: None,
@@ -64,12 +63,12 @@ impl Channel {
 
     pub fn load(&mut self) {
         let injector = self.matcher.injector();
+        let processor = self.processor.clone();
         let crawl_handle = tokio::spawn(load_candidates(
             self.source_command.clone(),
             self.source_entry_delimiter,
             self.current_source_index,
-            self.source_ansi,
-            self.source_display.clone(),
+            processor,
             injector,
         ));
         self.crawl_handle = Some(crawl_handle);
@@ -112,34 +111,22 @@ impl Channel {
 
         let results = self.matcher.results(num_entries, offset);
 
+        // PERF: this could be preallocated and reused by the caller
         let mut entries = Vec::with_capacity(results.len());
 
         for item in results {
-            let mut entry = Entry::new(item.inner)
-                .with_display(item.matched_string)
-                .with_match_indices(&item.match_indices)
-                .ansi(self.source_ansi);
-            if let Some(output) = &self.source_output {
-                entry = entry.with_output(output.clone());
-            }
-            entries.push(entry);
+            entries.push(
+                self.processor.make_entry(item, self.source_output.as_ref()),
+            );
         }
 
         entries
     }
 
     pub fn get_result(&mut self, index: u32) -> Option<Entry> {
-        if let Some(item) = self.matcher.get_result(index) {
-            let mut entry = Entry::new(item.inner.clone())
-                .with_display(item.matched_string)
-                .with_match_indices(&item.match_indices);
-            if let Some(output) = &self.source_output {
-                entry = entry.with_output(output.clone());
-            }
-            Some(entry)
-        } else {
-            None
-        }
+        self.matcher.get_result(index).map(|item| {
+            self.processor.make_entry(item, self.source_output.as_ref())
+        })
     }
 
     pub fn selected_entries(&self) -> &FxHashSet<Entry> {
@@ -170,7 +157,6 @@ impl Channel {
 
     pub fn shutdown(&self) {}
 
-    /// Cycles to the next source command
     pub fn cycle_sources(&mut self) {
         if self.source_command.inner.len() > 1 {
             self.current_source_index = (self.current_source_index + 1)
@@ -184,18 +170,37 @@ impl Channel {
             debug!("No other source commands to cycle through.");
         }
     }
+
+    pub fn supports_preview(&self) -> bool {
+        self.supports_preview
+    }
+
+    pub fn reloading(&self) -> bool {
+        self.reloading.load(std::sync::atomic::Ordering::Relaxed)
+    }
 }
 
-const DEFAULT_LINE_BUFFER_SIZE: usize = 512;
+// 8 MB
+const BUF_READER_CAPACITY: usize = 8 * 1024 * 1024;
+const DEFAULT_LINE_BUFFER_SIZE: usize = 256;
+// Batch size for pushing candidates to the injector
+// 50k * 100 bytes (avg line size) = ~5 MB per batch
+const BATCH_SIZE: usize = 50_000;
+// Maximum number of concurrent flush tasks to prevent unbounded memory growth
+// 64 * 100_000 * average line size (100 bytes) = ~640 MB max memory usage for buffering
+// This won't be reached in practice unless pushing tens of millions of lines very quickly
+// in which case this empirically seems like the optimal setting for speed vs memory usage.
+const MAX_CONCURRENT_FLUSHES: usize = 64;
+const DEFAULT_DELIMITER: u8 = b'\n';
 
+/// Collects entries before pushing them to the injector.
 #[allow(clippy::unused_async)]
-pub async fn load_candidates(
+pub async fn load_candidates<P: EntryProcessor>(
     command: CommandSpec,
     entry_delimiter: Option<char>,
     command_index: usize,
-    ansi: bool,
-    display: Option<Template>,
-    injector: Injector<String>,
+    processor: P,
+    injector: Injector<P::Data>,
 ) {
     debug!("Loading candidates from command: {:?}", command);
     let mut std_command = shell_command(
@@ -210,75 +215,245 @@ pub async fn load_candidates(
 
     if let Some(out) = child.stdout.take() {
         let mut produced_output = false;
-        let mut reader = BufReader::new(out);
+        let mut reader = BufReader::with_capacity(BUF_READER_CAPACITY, out);
         let mut buf = Vec::with_capacity(DEFAULT_LINE_BUFFER_SIZE);
+        let mut batch = Vec::with_capacity(BATCH_SIZE);
+        let mut flush_handles = Vec::with_capacity(MAX_CONCURRENT_FLUSHES);
 
-        let delimiter =
-            entry_delimiter.as_ref().map(|d| *d as u8).unwrap_or(b'\n');
+        let delimiter = entry_delimiter
+            .as_ref()
+            .map(|d| *d as u8)
+            .unwrap_or(DEFAULT_DELIMITER);
 
         while {
             buf.clear();
             let n = reader.read_until(delimiter, &mut buf).await.unwrap_or(0);
             n > 0
         } {
-            // Remove trailing delimiter
-            if buf.last() == Some(&delimiter) {
-                buf.pop();
-            }
+            batch.push(buf.clone());
 
-            if buf.is_empty() || buf.iter().all(u8::is_ascii_whitespace) {
-                continue;
-            }
-
-            if let Ok(line) = std::str::from_utf8(&buf) {
-                if !ansi && display.is_none() {
-                    let () = injector.push(line.to_string(), |e, cols| {
-                        cols[0] = e.as_str().into();
-                    });
-                    produced_output = true;
-                    continue;
+            // Flush batch when it reaches the target size
+            if batch.len() >= BATCH_SIZE {
+                // Apply backpressure: if we're at max concurrent tasks, wait for one to complete
+                if flush_handles.len() >= MAX_CONCURRENT_FLUSHES {
+                    // wait for any one to complete
+                    let handle = flush_handles.remove(0);
+                    let _ = handle.await;
                 }
 
-                let () = injector.push(line.to_string(), |e, cols| {
-                    if ansi {
-                        cols[0] = strip_ansi_string(line).into();
-                    } else if let Some(display) = &display {
-                        let formatted = display.format(e).unwrap_or_else(|_| {
-                            panic!(
-                                "Failed to format display expression '{}' with entry '{}'",
-                                display.raw(),
-                                e
-                            );
-                        });
-                        cols[0] = formatted.into();
-                    } else {
-                        cols[0] = e.clone().into();
-                    }
-                });
+                let batch_to_flush = std::mem::replace(
+                    &mut batch,
+                    Vec::with_capacity(BATCH_SIZE),
+                );
+                let handle = spawn_flush_batch(
+                    batch_to_flush,
+                    injector.clone(),
+                    processor.clone(),
+                    delimiter,
+                );
+                flush_handles.push(handle);
                 produced_output = true;
             }
+        }
+
+        debug!("Finished reading command output.");
+
+        // Flush any remaining entries in the batch
+        if !batch.is_empty() {
+            // Wait for room if needed
+            if flush_handles.len() >= MAX_CONCURRENT_FLUSHES {
+                let handle = flush_handles.remove(0);
+                let _ = handle.await;
+            }
+
+            let handle = spawn_flush_batch(
+                batch,
+                injector.clone(),
+                processor.clone(),
+                delimiter,
+            );
+            flush_handles.push(handle);
+            produced_output = true;
+        }
+
+        // Wait for all remaining flush tasks to complete
+        for handle in flush_handles {
+            let _ = handle.await;
         }
 
         // if the command didn't produce any output, check stderr and display that instead
         if !produced_output {
             let tv_message =
                 "Command produced no output on stdout, checking stderr...";
-            injector.push(tv_message.to_string(), |e, cols| {
-                cols[0] = e.clone().into();
-            });
+            processor.push_to_injector(tv_message.to_string(), &injector);
             let stderr = child.stderr.take().unwrap();
             let mut reader = BufReader::new(stderr).lines();
             while let Ok(Some(line)) = reader.next_line().await {
                 if line.trim().is_empty() {
                     continue;
                 }
-                let () = injector.push(line, |e, cols| {
-                    cols[0] = e.clone().into();
-                });
+                processor.push_to_injector(line, &injector);
             }
         }
     }
     let _ = child.wait().await;
+}
+
+/// Spawns a task to flush a batch of entries to the injector on a separate threadpool.
+/// This allows the main reader thread to continue reading while batches are being processed.
+fn spawn_flush_batch<P: EntryProcessor>(
+    batch: Vec<Vec<u8>>,
+    injector: Injector<P::Data>,
+    processor: P,
+    delimiter: u8,
+) -> tokio::task::JoinHandle<()> {
+    tokio::task::spawn_blocking(move || {
+        // decode utf8 and filter empty/whitespace-only lines
+        for mut bytes in batch {
+            if bytes.is_empty() || bytes.iter().all(u8::is_ascii_whitespace) {
+                continue;
+            }
+            if bytes.last() == Some(&delimiter) {
+                bytes.pop();
+            }
+            if let Ok(line) = String::from_utf8(bytes) {
+                processor.push_to_injector(line, &injector);
+            }
+        }
+    })
+}
+
+/// Channels can be in one of several modes depending on the source configuration.
+///
+/// - Plain: no ANSI processing, no display template (uses Matcher<()> for memory efficiency)
+/// - Ansi: strips ANSI codes for matching (uses Matcher<String>)
+/// - Display: applies custom display template for matching (uses Matcher<String>)
+pub enum ChannelKind {
+    Plain(Channel<PlainProcessor>),
+    Ansi(Channel<AnsiProcessor>),
+    Display(Channel<DisplayProcessor>),
+}
+
+/// This reduces the boilerplate you'd have to write to have the wrapping enum delegate same
+/// implementation methods to the inner channel variants.
+///
+/// e.g. instead of writing:
+/// ```ignore
+/// pub fn load(&mut self) {
+///     match self {
+///         ChannelKind::Plain(ch) => ch.load(),
+///         ChannelKind::Ansi(ch) => ch.load(),
+///         ChannelKind::Display(ch) => ch.load(),
+///     }
+/// }
+///
+/// pub fn current_command(&self) -> &str {
+///     match self {
+///         ChannelKind::Plain(ch) => ch.current_command(),
+///         ChannelKind::Ansi(ch) => ch.current_command(),
+///         ChannelKind::Display(ch) => ch.current_command(),
+///     }
+/// }
+/// ```
+/// You can just write:
+/// ```ignore
+/// delegate_to_channel!(mut
+///     load() -> (),
+/// );
+/// delegate_to_channel!(ref
+///     current_command() -> &str,
+/// );
+/// ```
+///
+/// The `mut` and `ref` keywords indicate whether the method takes `&mut self` or `&self`.
+macro_rules! delegate_to_channel {
+    // Mutable methods
+    (mut $($method:ident($($arg:ident: $arg_ty:ty),*) -> $ret:ty),* $(,)?) => {
+        $(
+            pub fn $method(&mut self $(, $arg: $arg_ty)*) -> $ret {
+                match self {
+                    ChannelKind::Plain(ch) => ch.$method($($arg),*),
+                    ChannelKind::Ansi(ch) => ch.$method($($arg),*),
+                    ChannelKind::Display(ch) => ch.$method($($arg),*),
+                }
+            }
+        )*
+    };
+
+    // Immutable methods
+    (ref $($method:ident($($arg:ident: $arg_ty:ty),*) -> $ret:ty),* $(,)?) => {
+        $(
+            pub fn $method(&self $(, $arg: $arg_ty)*) -> $ret {
+                match self {
+                    ChannelKind::Plain(ch) => ch.$method($($arg),*),
+                    ChannelKind::Ansi(ch) => ch.$method($($arg),*),
+                    ChannelKind::Display(ch) => ch.$method($($arg),*),
+                }
+            }
+        )*
+    };
+}
+
+impl ChannelKind {
+    /// Creates the appropriate `ChannelKind` variant based on the source configuration.
+    ///
+    /// This mainly enables us to make some memory savings for the common case of no ANSI processing
+    /// and no display template by using `Matcher<()>` instead of `Matcher<String>`.
+    pub fn new(
+        source_command: CommandSpec,
+        source_entry_delimiter: Option<char>,
+        source_ansi: bool,
+        source_display: Option<Template>,
+        source_output: Option<Template>,
+        supports_preview: bool,
+    ) -> Self {
+        match (source_ansi, source_display) {
+            (false, None) => ChannelKind::Plain(Channel::new(
+                source_command,
+                source_entry_delimiter,
+                source_output,
+                supports_preview,
+                PlainProcessor,
+            )),
+            (true, None) => ChannelKind::Ansi(Channel::new(
+                source_command,
+                source_entry_delimiter,
+                source_output,
+                supports_preview,
+                AnsiProcessor,
+            )),
+            (_, Some(template)) => ChannelKind::Display(Channel::new(
+                source_command,
+                source_entry_delimiter,
+                source_output,
+                supports_preview,
+                DisplayProcessor { template },
+            )),
+        }
+    }
+
+    // Generate all mutable delegation methods
+    delegate_to_channel!(mut
+        load() -> (),
+        reload() -> (),
+        find(pattern: &str) -> (),
+        results(num_entries: u32, offset: u32) -> Vec<Entry>,
+        get_result(index: u32) -> Option<Entry>,
+        toggle_selection(entry: &Entry) -> (),
+        cycle_sources() -> (),
+    );
+
+    // Generate all immutable delegation methods
+    delegate_to_channel!(ref
+        current_command() -> &str,
+        selected_entries() -> &FxHashSet<Entry>,
+        result_count() -> u32,
+        total_count() -> u32,
+        running() -> bool,
+        shutdown() -> (),
+        supports_preview() -> bool,
+        reloading() -> bool,
+    );
 }
 
 #[cfg(test)]
@@ -295,15 +470,15 @@ mod tests {
         )
         .unwrap();
 
-        let mut matcher = Matcher::<String>::new(&Config::default());
+        // Use PlainProcessor for no ansi, no display
+        let mut matcher = Matcher::<()>::new(&Config::default());
         let injector = matcher.injector();
 
         load_candidates(
             source_spec.command,
             source_spec.entry_delimiter,
             0,
-            source_spec.ansi,
-            source_spec.display,
+            PlainProcessor,
             injector,
         )
         .await;
@@ -313,9 +488,9 @@ mod tests {
         matcher.tick();
         let results = matcher.results(10, 0);
         assert_eq!(results.len(), 3);
-        assert_eq!(results[0].inner, "test1");
-        assert_eq!(results[1].inner, "test2");
-        assert_eq!(results[2].inner, "test3");
+        assert_eq!(results[0].matched_string, "test1");
+        assert_eq!(results[1].matched_string, "test2");
+        assert_eq!(results[2].matched_string, "test3");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
@@ -326,15 +501,14 @@ mod tests {
         )
         .unwrap();
 
-        let mut matcher = Matcher::<String>::new(&Config::default());
+        let mut matcher = Matcher::<()>::new(&Config::default());
         let injector = matcher.injector();
 
         load_candidates(
             source_spec.command,
             source_spec.entry_delimiter,
             0,
-            source_spec.ansi,
-            source_spec.display,
+            PlainProcessor,
             injector,
         )
         .await;
@@ -344,9 +518,9 @@ mod tests {
         matcher.tick();
         let results = matcher.results(10, 0);
         assert_eq!(results.len(), 3);
-        assert_eq!(results[0].inner, "test1");
-        assert_eq!(results[1].inner, "test2");
-        assert_eq!(results[2].inner, "test3");
+        assert_eq!(results[0].matched_string, "test1");
+        assert_eq!(results[1].matched_string, "test2");
+        assert_eq!(results[2].matched_string, "test3");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
@@ -357,15 +531,14 @@ mod tests {
         )
         .unwrap();
 
-        let mut matcher = Matcher::<String>::new(&Config::default());
+        let mut matcher = Matcher::<()>::new(&Config::default());
         let injector = matcher.injector();
 
         load_candidates(
             source_spec.command,
             source_spec.entry_delimiter,
             0,
-            source_spec.ansi,
-            source_spec.display,
+            PlainProcessor,
             injector,
         )
         .await;
@@ -375,7 +548,70 @@ mod tests {
         matcher.tick();
         let results = matcher.results(10, 0);
         assert_eq!(results.len(), 2);
-        assert_eq!(results[0].inner, "test1");
-        assert_eq!(results[1].inner, "test2\ntest3");
+        assert_eq!(results[0].matched_string, "test1");
+        assert_eq!(results[1].matched_string, "test2\ntest3");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+    async fn test_load_candidates_large_input() {
+        // Test with more entries than the batch size
+        let source_spec: SourceSpec = toml::from_str(
+            r#"
+            command = "seq 1 1000"
+            "#,
+        )
+        .unwrap();
+
+        let mut matcher = Matcher::<()>::new(&Config::default());
+        let injector = matcher.injector();
+
+        load_candidates(
+            source_spec.command,
+            source_spec.entry_delimiter,
+            0,
+            PlainProcessor,
+            injector,
+        )
+        .await;
+
+        // Check if the matcher has the expected results
+        matcher.find("");
+        matcher.tick();
+        let results = matcher.results(1000, 0);
+        assert_eq!(results.len(), 1000);
+        assert_eq!(results[0].matched_string, "1");
+        assert_eq!(results[999].matched_string, "1000");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+    async fn test_load_candidates_with_ansi() {
+        let source_spec: SourceSpec = toml::from_str(
+            r#"
+            command = "printf '\\x1b[31mtest1\\x1b[0m\\n\\x1b[32mtest2\\x1b[0m\\n\\x1b[33mtest3\\x1b[0m\\n'"
+            ansi = true
+            "#,
+        )
+        .unwrap();
+
+        let mut matcher = Matcher::<String>::new(&Config::default());
+        let injector = matcher.injector();
+
+        load_candidates(
+            source_spec.command,
+            source_spec.entry_delimiter,
+            0,
+            AnsiProcessor,
+            injector,
+        )
+        .await;
+
+        // Check if the matcher has the expected results (ANSI codes should be stripped)
+        matcher.find("test");
+        matcher.tick();
+        let results = matcher.results(10, 0);
+        assert_eq!(results.len(), 3);
+        assert_eq!(results[0].matched_string, "test1");
+        assert_eq!(results[1].matched_string, "test2");
+        assert_eq!(results[2].matched_string, "test3");
     }
 }

--- a/television/channels/entry_processor.rs
+++ b/television/channels/entry_processor.rs
@@ -1,0 +1,129 @@
+use crate::{
+    channels::{entry::Entry, prototypes::Template},
+    matcher::{injector::Injector, matched_item::MatchedItem},
+};
+use fast_strip_ansi::strip_ansi_string;
+
+pub trait EntryProcessor: Send + Sync + Clone + 'static {
+    type Data: Send + Sync + Clone + 'static;
+
+    fn push_to_injector(&self, line: String, injector: &Injector<Self::Data>);
+
+    fn make_entry(
+        &self,
+        item: MatchedItem<Self::Data>,
+        source_output: Option<&Template>,
+    ) -> Entry;
+
+    fn has_ansi(&self) -> bool;
+}
+
+/// no transformation: matches the raw line as-is
+#[derive(Clone, Debug)]
+pub struct PlainProcessor;
+
+impl EntryProcessor for PlainProcessor {
+    type Data = ();
+
+    fn push_to_injector(&self, line: String, injector: &Injector<()>) {
+        injector.push((), |(), cols| {
+            cols[0] = line.into();
+        });
+    }
+
+    fn make_entry(
+        &self,
+        item: MatchedItem<()>,
+        source_output: Option<&Template>,
+    ) -> Entry {
+        let mut entry = Entry::new(item.matched_string.clone())
+            .with_match_indices(&item.match_indices);
+        if let Some(output) = source_output {
+            entry = entry.with_output(output.clone());
+        }
+        entry
+    }
+
+    fn has_ansi(&self) -> bool {
+        false
+    }
+}
+
+/// ANSI mode: strips ANSI codes for matching
+/// Uses Matcher<String> to store original with ANSI codes
+#[derive(Clone, Debug)]
+pub struct AnsiProcessor;
+
+impl EntryProcessor for AnsiProcessor {
+    type Data = String;
+
+    fn push_to_injector(&self, line: String, injector: &Injector<String>) {
+        injector.push(line, |original, cols| {
+            cols[0] = strip_ansi_string(original).into();
+        });
+    }
+
+    fn make_entry(
+        &self,
+        item: MatchedItem<String>,
+        source_output: Option<&Template>,
+    ) -> Entry {
+        let mut entry = Entry::new(item.inner)
+            .with_display(item.matched_string)
+            .with_match_indices(&item.match_indices)
+            .ansi(true);
+        if let Some(output) = source_output {
+            entry = entry.with_output(output.clone());
+        }
+        entry
+    }
+
+    fn has_ansi(&self) -> bool {
+        true
+    }
+}
+
+/// Display mode: applies custom template for matching
+/// Uses Matcher<String> to store original
+#[derive(Clone, Debug)]
+pub struct DisplayProcessor {
+    pub template: Template,
+}
+
+impl EntryProcessor for DisplayProcessor {
+    type Data = String;
+
+    fn push_to_injector(&self, line: String, injector: &Injector<String>) {
+        let template = self.template.clone();
+        injector.push(line, move |original, cols| {
+            cols[0] = template.format(original)
+                .unwrap_or_else(|_| {
+                    panic!(
+                        "Failed to format display expression '{}' with entry '{}'",
+                        template.raw(),
+                        original
+                    )
+                })
+                .into();
+        });
+    }
+
+    fn make_entry(
+        &self,
+        item: MatchedItem<String>,
+        source_output: Option<&Template>,
+    ) -> Entry {
+        let mut entry = Entry::new(item.inner)
+            .with_display(item.matched_string)
+            .with_match_indices(&item.match_indices)
+            .ansi(false);
+        if let Some(output) = source_output {
+            entry = entry.with_output(output.clone());
+        }
+        entry
+    }
+
+    fn has_ansi(&self) -> bool {
+        false
+    }
+}

--- a/television/channels/mod.rs
+++ b/television/channels/mod.rs
@@ -1,4 +1,5 @@
 pub mod channel;
 pub mod entry;
+pub mod entry_processor;
 pub mod prototypes;
 pub mod remote_control;

--- a/television/television.rs
+++ b/television/television.rs
@@ -2,7 +2,7 @@ use crate::{
     action::Action,
     cable::Cable,
     channels::{
-        channel::Channel as CableChannel,
+        channel::ChannelKind as CableChannel,
         entry::Entry,
         prototypes::{ChannelPrototype, CommandSpec, Template},
         remote_control::{CableEntry, RemoteControl},
@@ -160,8 +160,11 @@ impl Television {
         channel.find(&pattern);
         let spinner = Spinner::default();
 
-        let preview_state =
-            PreviewState::new(channel.supports_preview, Preview::default(), 0);
+        let preview_state = PreviewState::new(
+            channel.supports_preview(),
+            Preview::default(),
+            0,
+        );
 
         let remote_control = if merged_config.remote_disabled {
             None
@@ -519,8 +522,7 @@ impl Television {
             // to prevent UI flickering.
             && !self
                 .channel
-                .reloading
-                .load(std::sync::atomic::Ordering::Relaxed)
+                .reloading()
     }
 
     pub fn update_preview_state(


### PR DESCRIPTION
Testing this out on approx. 15 million rows of rg output text using a fixed corpora and the `--take-1` flag in association with a query that isolates a single result to get a reproducible baseline.

The new implementation gives a bit more than a 2 times speedup when compared to 0.13.12.

| Command | Mean  s  | Min  s  | Max  s  | Relative |
|:---|---:|---:|---:|---:|
|  `rg . --no-heading --line-number ~ \| tv -i "'15438 26qwertyq" --take-1`  | 4.056 ± 0.201 | 3.955 | 4.619 | 2.08 ± 0.13 |
| `rg . --no-heading --line-number ~ \| ./target/release/tv -i "'15438 26qwertyq" --take-1` | **1.954** ± 0.073 | 1.866 | 2.106 | 1.00 |

Speedup is comparable when tested against ansi formatted strings:

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
|  `rg . --no-heading --line-number --color=always ~ \| tv -i "'15438 26qwertyq" --take-1 --ansi`  | 7.151 ± 0.316 | 6.996 | 8.044 | 2.14 ± 0.12 |
|  `rg . --no-heading --line-number --color=always ~ \| ./target/release/tv -i "'15438 26qwertyq" --take-1 --ansi`  | **3.338** ± 0.114 | 3.181 | 3.538 | 1.00 |

For reference, here is fzf with the same command:

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
|  `rg . --no-heading --line-number --color=always ~ \| fzf -q "'15438 26qwertyq" --select-1 --ansi`  | 10.324 ± 0.784 | 9.478 | 12.069 | 3.07 ± 0.25 |
|  `rg . --no-heading --line-number --color=always ~ \| ./target/release/tv -i "'15438 26qwertyq" --take-1 --ansi`  | **3.368** ± 0.092 | 3.240 | 3.485 | 1.00 |down ~/test-1.md
