### PR TITLE
fix(channel): add forgotten quote in preview command

### DIFF
--- a/cable/unix/gh-issues.toml
+++ b/cable/unix/gh-issues.toml
@@ -26,6 +26,6 @@ command = '''gh issue view '{strip_ansi|split:#:1|split:   :0}' --json number,ti
 "",
 "  \u001b[90m────────────────────────────────────────────────────────────\u001b[39m",
 "",
-(.body // "")
+(.body // "")'
 '''
 

--- a/cable/unix/gh-prs.toml
+++ b/cable/unix/gh-prs.toml
@@ -25,5 +25,5 @@ command = '''gh pr view '{strip_ansi|split:#:1|split:   :0}' --json number,title
 "",
 "  \u001b[90m────────────────────────────────────────────────────────────\u001b[39m",
 "",
-(.body // "")
+(.body // "")'
 '''


### PR DESCRIPTION
## 📺 PR Description

The preview of the gh-issues and gh-prs channels didn't work due to a forgotten `'`.

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [ ] I have added a reasonable amount of documentation to the code where appropriate
