### PR TITLE
docs: fix command option in README for tv preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ tv [channel]  # e.g. `tv files`, `tv env`, `tv git-repos`, `tv my-awesome-channe
 # pipe the output of your program into tv
 my_program | tv
 
-fd -t f . | tv --preview 'bat -n --color=always {}'
+fd -t f . | tv --preview-command 'bat -n --color=always {}'
 
 # or build your own channel on the fly
 tv --source-command 'fd -t f .' --preview-command 'bat -n --color=always {}' --preview-size 70


### PR DESCRIPTION
## 📺 PR Description

The command should be `fd -t f . | tv --preview-command 'bat -n --color=always {}'`, I think the `--preview` subcommand is outdated.

## Checklist

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [x] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [x] I have added a reasonable amount of documentation to the code where appropriate
