### PR TITLE
refactor(zsh): use the dedicated channel for the zsh history shell integration

### DIFF
--- a/television/utils/shell/completion.zsh
+++ b/television/utils/shell/completion.zsh
@@ -93,7 +93,7 @@ _tv_shell_history() {
 
     local output
 
-    output=$(history -n -1 0 | tv --no-status-bar --input "$current_prompt" --inline $*)
+    output=$(tv zsh-history --no-status-bar --input "$current_prompt" --inline $*)
 
     zle reset-prompt
     if [[ -n $output ]]; then


### PR DESCRIPTION
fixes #829