### PR TITLE
docs: fix link to community-maintained channels page

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Start searching:
 tv tldr
 ```
 
-Switch channels using the remote control and pick from a large choice of [community-maintained channels](./10-community-channels-unix.md):
+Switch channels using the remote control and pick from a large choice of [community-maintained channels](./docs/01-Users/10-community-channels-unix.md):
 
 ![tv remote](./assets/tv-files-remote.png)
 


### PR DESCRIPTION
## 📺 PR Description

Fix a broken \[link\] in this sentence from `README.md`:

> Switch channels using the remote control and pick from a large choice of \[community-maintained channels\]:

The current link points to `./10-community-channels-unix.md`, but this file is under `./docs/01-Users/`.

This PR changes the link to point to [this file](https://github.com/alexpasmantier/television/blob/e48bd3dcc9f9a4a8998297c78a85428a83bd9459/docs/01-Users/10-community-channels-unix.md): same name, correct path.

## Cause

The broken link ([demo](https://github.com/alexpasmantier/television/blob/main/10-community-channels-unix.md)) was introduced in 9d45e57a, [here](https://github.com/alexpasmantier/television/commit/9d45e57a#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L62-R109).

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [X] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [ ] I have added a reasonable amount of documentation to the code where appropriate
