### PR TITLE
Accept Braille Unicode characters in the preview

### DIFF
--- a/television/utils/strings.rs
+++ b/television/utils/strings.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use lazy_regex::{Lazy, Regex, regex};
+use lazy_regex::{regex, Lazy, Regex};
 
 use crate::screen::result_item::ResultItem;
 
@@ -485,7 +485,7 @@ pub fn replace_non_printable_bulk<'a>(
                     // Braille Unicode characters
                     c if ('\u{2800}'..='\u{28FF}').contains(&c) => {
                         output.push(c);
-                    },
+                    }
                     // Unicode characters above 0x0700 seem unstable with ratatui
                     c if c > '\u{0700}' => {
                         output.push(NULL_SYMBOL);
@@ -949,6 +949,14 @@ mod tests {
         let (output, offsets) = replace_non_printable_bulk(input, &config);
         assert_eq!(output, "안녕하세요!");
         assert_eq!(offsets, vec![0, 0, 0, 0, 0, 0]);
+    }
+    #[test]
+    fn test_braille_characters() {
+        let input = "⠓⠑⠇⠇⠕⠀⠺⠕⠗⠇⠙";
+        let config = ReplaceNonPrintableConfig::default();
+        let (output, offsets) = replace_non_printable_bulk(input, &config);
+        assert_eq!(output, "⠓⠑⠇⠇⠕⠀⠺⠕⠗⠇⠙");
+        assert_eq!(offsets, vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
     }
     #[test]
     fn test_replace_non_printable_no_range_changes() {


### PR DESCRIPTION
Several plotting CLIs leverage Braille characters to render plots in the terminal.

[https://github.com/tammoippen/plotille](https://github.com/tammoippen/plotille)
[https://github.com/loony-bean/textplots-rs](https://github.com/loony-bean/textplots-rs)

This PR adds Braille character support for the preview window.

On another note, I see rustfmt shuffling the use statement, which brings to mind this discussion on syntax formatting in the linux kernel [https://lkml.org/lkml/2025/10/2/1004](https://lkml.org/lkml/2025/10/2/1004)

Cheers