### PR TITLE
feat: allow disabling automatic sorting of matcher results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1409,8 +1409,7 @@ dependencies = [
 [[package]]
 name = "nucleo"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5262af4c94921c2646c5ac6ff7900c2af9cbb08dc26a797e18130a7019c039d4"
+source = "git+https://github.com/alexpasmantier/nucleo.git?branch=television#7d1e62bdb32c838fba936b4bc75bbf2fe5a19749"
 dependencies = [
  "nucleo-matcher",
  "parking_lot",
@@ -1420,8 +1419,7 @@ dependencies = [
 [[package]]
 name = "nucleo-matcher"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf33f538733d1a5a3494b836ba913207f14d9d4a1d3cd67030c5061bdd2cac85"
+source = "git+https://github.com/alexpasmantier/nucleo.git?branch=television#7d1e62bdb32c838fba936b4bc75bbf2fe5a19749"
 dependencies = [
  "memchr",
  "unicode-segmentation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ better-panic = "0.3"
 signal-hook = "0.4"
 human-panic = "2.0"
 parking_lot = "0.12"
-nucleo = "0.5"
+nucleo = { git = "https://github.com/alexpasmantier/nucleo.git", branch = "television" }
 toml = "0.9"
 lazy-regex = { version = "3.4", features = ["lite"], default-features = false }
 ansi-to-tui = "8.0"

--- a/cable/unix/bash-history.toml
+++ b/cable/unix/bash-history.toml
@@ -6,3 +6,4 @@ requirements = ["bash"]
 
 [source]
 command = "sed '1!G;h;$!d' ${HISTFILE:-${HOME}/.bash_history}"
+sort_results = false

--- a/cable/unix/fish-history.toml
+++ b/cable/unix/fish-history.toml
@@ -6,3 +6,4 @@ requirements = ["fish"]
 
 [source]
 command = "fish -c 'history'"
+sort_results = false

--- a/cable/unix/git-log.toml
+++ b/cable/unix/git-log.toml
@@ -7,6 +7,7 @@ requirements = ["git"]
 command = "git log --graph --pretty=format:'%C(yellow)%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --color=always"
 output = "{strip_ansi|split: :1}"
 ansi = true
+sort_results = false
 
 [preview]
 command = "git show -p --stat --pretty=fuller --color=always '{strip_ansi|split: :1}' | head -n 1000"

--- a/cable/unix/git-reflog.toml
+++ b/cable/unix/git-reflog.toml
@@ -7,6 +7,7 @@ requirements = ["git"]
 command = "git reflog --decorate --color=always"
 output = "{0|strip_ansi}"
 ansi = true
+sort_results = false
 
 [preview]
 command = "git show -p --stat --pretty=fuller --color=always '{0|strip_ansi}'"

--- a/cable/unix/nu-history.toml
+++ b/cable/unix/nu-history.toml
@@ -5,3 +5,4 @@ description = "A channel to select from your nu history"
 
 [source]
 command = "nu -c 'open $nu.history-path | lines | uniq | reverse | to text'"
+sort_results = false

--- a/cable/unix/zsh-history.toml
+++ b/cable/unix/zsh-history.toml
@@ -7,3 +7,4 @@ requirements = ["zsh"]
 command = "sed '1!G;h;$!d' ${HISTFILE:-${HOME}/.zsh_history}"
 display = "{split:;:1..}"
 output = "{split:;:1..}"
+sort_results = false

--- a/television/channels/channel.rs
+++ b/television/channels/channel.rs
@@ -42,9 +42,12 @@ impl<P: EntryProcessor> Channel<P> {
         source_entry_delimiter: Option<char>,
         source_output: Option<Template>,
         supports_preview: bool,
+        sort_results: bool,
         processor: P,
     ) -> Self {
-        let config = Config::default().prefer_prefix(true);
+        let config = Config::default()
+            .prefer_prefix(true)
+            .sort_results(sort_results);
         let matcher = Matcher::new(&config);
         let current_source_index = 0;
         Self {
@@ -386,6 +389,7 @@ impl ChannelKind {
         source_display: Option<Template>,
         source_output: Option<Template>,
         supports_preview: bool,
+        sort_results: bool,
     ) -> Self {
         match (source_ansi, source_display) {
             (false, None) => ChannelKind::Plain(Channel::new(
@@ -393,6 +397,7 @@ impl ChannelKind {
                 source_entry_delimiter,
                 source_output,
                 supports_preview,
+                sort_results,
                 PlainProcessor,
             )),
             (true, None) => ChannelKind::Ansi(Channel::new(
@@ -400,6 +405,7 @@ impl ChannelKind {
                 source_entry_delimiter,
                 source_output,
                 supports_preview,
+                sort_results,
                 AnsiProcessor,
             )),
             (_, Some(template)) => ChannelKind::Display(Channel::new(
@@ -407,6 +413,7 @@ impl ChannelKind {
                 source_entry_delimiter,
                 source_output,
                 supports_preview,
+                sort_results,
                 DisplayProcessor { template },
             )),
         }

--- a/television/channels/prototypes.rs
+++ b/television/channels/prototypes.rs
@@ -263,6 +263,7 @@ impl ChannelPrototype {
                 ansi: false,
                 display: None,
                 output: None,
+                sort_results: true,
             },
             preview: None,
             ui: None,
@@ -362,6 +363,12 @@ pub struct SourceSpec {
     pub display: Option<Template>,
     #[serde(default)]
     pub output: Option<Template>,
+    #[serde(default = "default_sort_results")]
+    pub sort_results: bool,
+}
+
+const fn default_sort_results() -> bool {
+    true
 }
 
 /// Just a helper function to adapt cli parsing to serde deserialization.

--- a/television/cli/args.rs
+++ b/television/cli/args.rs
@@ -57,6 +57,18 @@ pub struct Cli {
     )]
     pub ansi: bool,
 
+    /// Disable automatic sorting of entries based on match quality.
+    ///
+    /// This is useful when you want to preserve the original order of entries
+    /// as provided by the source command.
+    #[arg(
+        long,
+        default_value = "false",
+        verbatim_doc_comment,
+        help_heading = "Source"
+    )]
+    pub no_sort: bool,
+
     /// Source display template to use for the current channel.
     ///
     /// When a channel is specified: This overrides the display template defined in the channel prototype.

--- a/television/cli/mod.rs
+++ b/television/cli/mod.rs
@@ -70,6 +70,7 @@ pub struct ChannelCli {
     pub source_entry_delimiter: Option<char>,
     pub autocomplete_prompt: Option<String>,
     pub ansi: bool,
+    pub no_sort: bool,
 
     // Preview configuration
     pub preview_command: Option<Template>,
@@ -311,6 +312,7 @@ pub fn post_process(cli: Cli, readable_stdin: bool) -> PostProcessedCli {
             source_display,
             source_output,
             source_entry_delimiter,
+            no_sort: cli.no_sort,
 
             // Autocomplete and ANSI configuration
             autocomplete_prompt: cli.autocomplete_prompt,

--- a/television/config/layers.rs
+++ b/television/config/layers.rs
@@ -99,6 +99,9 @@ impl ConfigLayers {
             .channel_cli
             .watch_interval
             .unwrap_or(self.channel.watch);
+        // only sort results if --no-sort is not set and channel config has it enabled
+        let sort_results =
+            !self.channel_cli.no_sort && self.channel.source.sort_results;
         let channel_name = self
             .channel_cli
             .channel
@@ -471,6 +474,7 @@ impl ConfigLayers {
             take_1,
             take_1_fast,
             input,
+            sort_results,
 
             // Bindings
             input_map,
@@ -565,6 +569,7 @@ pub struct MergedConfig {
     pub take_1: bool,
     pub take_1_fast: bool,
     pub input: Option<String>,
+    pub sort_results: bool,
 
     // Bindings
     pub input_map: InputMap,

--- a/television/matcher/config.rs
+++ b/television/matcher/config.rs
@@ -14,6 +14,8 @@ pub struct Config {
     pub prefer_prefix: bool,
     /// The number of threads to use for matching.
     pub n_threads: Option<usize>,
+    /// Whether to sort results based on score.
+    pub sort_results: bool,
 }
 
 impl Default for Config {
@@ -26,6 +28,7 @@ impl Default for Config {
                     .unwrap_or(4)
                     .min(8),
             ),
+            sort_results: true,
         }
     }
 }
@@ -47,12 +50,19 @@ impl Config {
         self.n_threads = n_threads;
         self
     }
+
+    /// Set whether or not to sort results based on matching score
+    pub fn sort_results(mut self, sort_results: bool) -> Self {
+        self.sort_results = sort_results;
+        self
+    }
 }
 
 impl From<&Config> for nucleo::Config {
     fn from(config: &Config) -> Self {
         let mut nucleo_config = nucleo::Config::DEFAULT;
         nucleo_config.prefer_prefix = config.prefer_prefix;
+        nucleo_config.sort_results = config.sort_results;
         nucleo_config
     }
 }

--- a/television/television.rs
+++ b/television/television.rs
@@ -135,6 +135,7 @@ impl Television {
             merged_config.channel_source_display,
             merged_config.channel_source_output,
             merged_config.channel_preview_command.is_some(),
+            merged_config.sort_results,
         );
         let app_metadata = AppMetadata::new(
             env!("CARGO_PKG_VERSION").to_string(),
@@ -311,6 +312,7 @@ impl Television {
             self.merged_config.channel_source_display.clone(),
             self.merged_config.channel_source_output.clone(),
             self.merged_config.channel_preview_command.is_some(),
+            self.merged_config.sort_results,
         );
         self.channel.load();
     }

--- a/tests/cli/input.rs
+++ b/tests/cli/input.rs
@@ -133,3 +133,28 @@ fn test_exact_matching_enabled_fails() {
     tester.send(&ctrl('c'));
     PtyTester::assert_exit_ok(&mut child, DEFAULT_DELAY);
 }
+
+/// Tests that --no-sort keeps results in the source order for selection.
+#[test]
+fn test_no_sort_preserves_source_order() {
+    let mut tester = PtyTester::new();
+
+    // The second entry is a stronger fuzzy match for "ab".
+    let cmd = tv_local_config_and_cable_with_args(&[
+        "--source-command",
+        "echo 'a-weak-b'; echo 'ab-strong'",
+        "--input",
+        "ab",
+        "--no-sort",
+        "--take-1",
+    ]);
+    let mut child = tester.spawn_command(cmd);
+
+    let output = tester.read_raw_output();
+    assert!(
+        output.contains("a-weak-b"),
+        "Expected output to contain 'a-weak-b', but got:\n{:?}",
+        output
+    );
+    PtyTester::assert_exit_ok(&mut child, DEFAULT_DELAY);
+}


### PR DESCRIPTION
partially solves #194

This makes interacting with chronologically sorted sources more intuitive by preserving the original ordering when matching. Examples: shell history, log entries, etc.

```
tv my_channel --no-sort
```
```toml
[source]
command = "..."  # produces some sorted list
sort_results = false  # preserve original order
```
