### PR TITLE
feat(update-channels): skip channels with unmet requirements by default

### DIFF
--- a/television/cli/args.rs
+++ b/television/cli/args.rs
@@ -676,7 +676,7 @@ pub enum Command {
     /// Downloads the latest collection of channel prototypes from github
     /// and saves them to the local configuration directory.
     UpdateChannels {
-        /// Force update on already existing channels.
+        /// Force update on unsupported and already existing channels.
         #[arg(long, default_value = "false")]
         force: bool,
     },


### PR DESCRIPTION

## 📺 PR Description

<!-- summary of the change + which issue is fixed if applicable. -->
This PR adds a new flag `--skip-unmet-requirements` to skip channels with unmet requirements during channel update.

This is useful to avoid updating or displaying channels that are not usable in the current environment.

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [x] I have added a reasonable amount of documentation to the code where appropriate
