### PR TITLE
feat(ui): add cycle_sources and cycle_previews tab indicators

### DIFF
--- a/television/channels/channel.rs
+++ b/television/channels/channel.rs
@@ -228,6 +228,14 @@ impl<P: EntryProcessor> Channel<P> {
     pub fn reloading(&self) -> bool {
         self.reloading.load(std::sync::atomic::Ordering::Relaxed)
     }
+
+    pub fn source_index(&self) -> usize {
+        self.current_source_index
+    }
+
+    pub fn source_count(&self) -> usize {
+        self.source_command.inner.len()
+    }
 }
 
 const DEFAULT_LINE_BUFFER_SIZE: usize = 256;
@@ -492,6 +500,8 @@ impl ChannelKind {
         shutdown() -> (),
         supports_preview() -> bool,
         reloading() -> bool,
+        source_index() -> usize,
+        source_count() -> usize,
     );
 }
 

--- a/television/draw.rs
+++ b/television/draw.rs
@@ -28,15 +28,20 @@ pub struct ChannelState {
     pub total_count: u32,
     pub running: bool,
     pub current_command: String,
+    pub source_index: usize,
+    pub source_count: usize,
 }
 
 impl ChannelState {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         current_channel_name: String,
         selected_entries: FxHashSet<Entry>,
         total_count: u32,
         running: bool,
         current_command: String,
+        source_index: usize,
+        source_count: usize,
     ) -> Self {
         Self {
             current_channel_name,
@@ -44,6 +49,8 @@ impl ChannelState {
             total_count,
             running,
             current_command,
+            source_index,
+            source_count,
         }
     }
 }
@@ -57,6 +64,8 @@ impl Hash for ChannelState {
         self.total_count.hash(state);
         self.running.hash(state);
         self.current_command.hash(state);
+        self.source_index.hash(state);
+        self.source_count.hash(state);
     }
 }
 
@@ -184,6 +193,8 @@ pub fn draw(ctx: Ctx, f: &mut Frame<'_>, area: Rect) -> Result<Layout> {
         &ctx.colorscheme,
         &ctx.config.results_panel_padding,
         &ctx.config.results_panel_border_type,
+        ctx.tv_state.channel_state.source_index,
+        ctx.tv_state.channel_state.source_count,
     )?;
 
     draw_input_box(

--- a/television/previewer/state.rs
+++ b/television/previewer/state.rs
@@ -77,6 +77,8 @@ impl PreviewState {
                 adjusted_line_number,
                 self.preview.total_lines,
                 self.preview.footer.clone(),
+                self.preview.preview_index,
+                self.preview.preview_count,
             ),
             self.scroll,
         )

--- a/television/screen/preview.rs
+++ b/television/screen/preview.rs
@@ -37,6 +37,8 @@ pub fn draw_preview_content_block(
         *padding,
         &preview_state.preview.title,
         preview_state.preview.footer,
+        preview_state.preview.preview_index,
+        preview_state.preview.preview_count,
     );
     let total_lines =
         preview_state.preview.total_lines.saturating_sub(1) as usize;
@@ -109,6 +111,7 @@ pub fn build_preview_paragraph(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn draw_content_outer_block(
     f: &mut Frame,
     rect: Rect,
@@ -117,7 +120,20 @@ fn draw_content_outer_block(
     padding: Padding,
     preview_title: &str,
     preview_footer: Option<String>,
+    preview_index: usize,
+    preview_count: usize,
 ) -> Rect {
+    let indicator = if preview_count > 1 {
+        let dots: String = (0..preview_count)
+            .map(|i| if i == preview_index { "●" } else { "○" })
+            .collect::<Vec<_>>()
+            .join(" ");
+        format!(" ⟨ {} ⟩", dots)
+    } else {
+        String::new()
+    };
+    let indicator_len = u16::try_from(indicator.chars().count()).unwrap_or(0);
+
     let mut preview_title_spans = vec![Span::from(SPACE)];
     // preview header
     preview_title_spans.push(Span::styled(
@@ -127,10 +143,17 @@ fn draw_content_outer_block(
                 &ReplaceNonPrintableConfig::default(),
             )
             .0,
-            rect.width.saturating_sub(4) as usize,
+            rect.width.saturating_sub(4 + indicator_len) as usize,
         ),
         Style::default().fg(colorscheme.preview.title_fg).bold(),
     ));
+
+    if preview_count > 1 {
+        preview_title_spans.push(Span::styled(
+            indicator,
+            Style::default().fg(colorscheme.input.results_count_fg),
+        ));
+    }
     preview_title_spans.push(Span::from(SPACE));
 
     let mut block = Block::default();

--- a/television/screen/results.rs
+++ b/television/screen/results.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use ratatui::{
     Frame,
     layout::{Alignment, Rect},
-    prelude::Style,
+    prelude::{Span, Style},
     text::Line,
     widgets::{Block, Borders, ListState, Padding as RatatuiPadding},
 };
@@ -24,9 +24,27 @@ pub fn draw_results_list(
     colorscheme: &Colorscheme,
     results_panel_padding: &Padding,
     results_panel_border_type: &BorderType,
+    source_index: usize,
+    source_count: usize,
 ) -> Result<()> {
+    let title = if source_count > 1 {
+        let mut spans = vec![Span::from(" Results ")];
+        let dots: String = (0..source_count)
+            .map(|i| if i == source_index { "●" } else { "○" })
+            .collect::<Vec<_>>()
+            .join(" ");
+        spans.push(Span::styled(
+            format!("⟨ {} ⟩", dots),
+            Style::default().fg(colorscheme.input.results_count_fg),
+        ));
+        spans.push(Span::from(" "));
+        Line::from(spans).alignment(Alignment::Center)
+    } else {
+        Line::from(" Results ").alignment(Alignment::Center)
+    };
+
     let mut results_block = Block::default()
-        .title_top(Line::from(" Results ").alignment(Alignment::Center))
+        .title_top(title)
         .style(
             Style::default()
                 .bg(colorscheme.general.background.unwrap_or_default()),

--- a/television/television.rs
+++ b/television/television.rs
@@ -246,6 +246,8 @@ impl Television {
             self.channel.total_count(),
             self.channel.running(),
             self.channel.current_command().to_string(),
+            self.channel.source_index(),
+            self.channel.source_count(),
         );
         let tv_state = TvState::new(
             self.mode,


### PR DESCRIPTION
<img width="2914" height="1687" alt="2026-01-25-161804_hyprshot" src="https://github.com/user-attachments/assets/9ea26e58-ac86-4e6e-b3cb-7e66f4d83867" />
