### PR TITLE
feat(ui): add cycle_x keybinding hint next to tab indicator when cycling is enabled

### DIFF
--- a/television/draw.rs
+++ b/television/draw.rs
@@ -1,4 +1,5 @@
 use crate::{
+    action::Action,
     channels::{entry::Entry, remote_control::CableEntry},
     config::layers::MergedConfig,
     picker::Picker,
@@ -187,6 +188,10 @@ pub fn draw(ctx: Ctx, f: &mut Frame<'_>, area: Rect) -> Result<Layout> {
         Layout::build(area, &ctx.config, ctx.tv_state.mode, &ctx.colorscheme);
 
     // results list
+    let cycle_sources_key = ctx
+        .config
+        .input_map
+        .get_key_for_action(&Action::CycleSources);
     draw_results_list(
         f,
         layout.results,
@@ -199,6 +204,7 @@ pub fn draw(ctx: Ctx, f: &mut Frame<'_>, area: Rect) -> Result<Layout> {
         &ctx.config.results_panel_border_type,
         ctx.tv_state.channel_state.source_index,
         ctx.tv_state.channel_state.source_count,
+        cycle_sources_key,
     )?;
 
     draw_input_box(
@@ -225,6 +231,10 @@ pub fn draw(ctx: Ctx, f: &mut Frame<'_>, area: Rect) -> Result<Layout> {
     }
 
     if let Some(preview_rect) = layout.preview_window {
+        let cycle_previews_key = ctx
+            .config
+            .input_map
+            .get_key_for_action(&Action::CyclePreviews);
         draw_preview_content_block(
             f,
             preview_rect,
@@ -234,6 +244,7 @@ pub fn draw(ctx: Ctx, f: &mut Frame<'_>, area: Rect) -> Result<Layout> {
             &ctx.config.preview_panel_padding,
             ctx.config.preview_panel_scrollbar,
             ctx.config.preview_panel_word_wrap,
+            cycle_previews_key,
         )?;
     }
 

--- a/television/screen/preview.rs
+++ b/television/screen/preview.rs
@@ -1,5 +1,6 @@
 use crate::{
     config::ui::{BorderType, Padding},
+    event::Key,
     previewer::state::PreviewState,
     screen::colors::Colorscheme,
     utils::strings::{
@@ -28,6 +29,7 @@ pub fn draw_preview_content_block(
     padding: &Padding,
     scrollbar: bool,
     word_wrap: bool,
+    cycle_key: Option<Key>,
 ) -> Result<()> {
     let inner = draw_content_outer_block(
         f,
@@ -39,6 +41,7 @@ pub fn draw_preview_content_block(
         preview_state.preview.footer,
         preview_state.preview.preview_index,
         preview_state.preview.preview_count,
+        cycle_key,
     );
     let total_lines =
         preview_state.preview.total_lines.saturating_sub(1) as usize;
@@ -122,17 +125,20 @@ fn draw_content_outer_block(
     preview_footer: Option<String>,
     preview_index: usize,
     preview_count: usize,
+    cycle_key: Option<Key>,
 ) -> Rect {
-    let indicator = if preview_count > 1 {
+    let (indicator, key_hint) = if preview_count > 1 {
         let dots: String = (0..preview_count)
             .map(|i| if i == preview_index { "●" } else { "○" })
             .collect::<Vec<_>>()
             .join(" ");
-        format!(" ⟨ {} ⟩", dots)
+        let hint = cycle_key.map(|k| format!(" {}", k)).unwrap_or_default();
+        (format!(" ⟨ {} ⟩", dots), hint)
     } else {
-        String::new()
+        (String::new(), String::new())
     };
     let indicator_len = u16::try_from(indicator.chars().count()).unwrap_or(0);
+    let key_hint_len = u16::try_from(key_hint.chars().count()).unwrap_or(0);
 
     let mut preview_title_spans = vec![Span::from(SPACE)];
     // preview header
@@ -143,7 +149,8 @@ fn draw_content_outer_block(
                 &ReplaceNonPrintableConfig::default(),
             )
             .0,
-            rect.width.saturating_sub(4 + indicator_len) as usize,
+            rect.width.saturating_sub(4 + indicator_len + key_hint_len)
+                as usize,
         ),
         Style::default().fg(colorscheme.preview.title_fg).bold(),
     ));
@@ -153,6 +160,12 @@ fn draw_content_outer_block(
             indicator,
             Style::default().fg(colorscheme.input.results_count_fg),
         ));
+        if !key_hint.is_empty() {
+            preview_title_spans.push(Span::styled(
+                key_hint,
+                Style::default().fg(colorscheme.general.border_fg),
+            ));
+        }
     }
     preview_title_spans.push(Span::from(SPACE));
 

--- a/television/screen/results.rs
+++ b/television/screen/results.rs
@@ -1,6 +1,7 @@
 use crate::{
     channels::entry::Entry,
     config::ui::{BorderType, Padding},
+    event::Key,
     screen::{colors::Colorscheme, layout::InputPosition, result_item},
 };
 use anyhow::Result;
@@ -26,6 +27,7 @@ pub fn draw_results_list(
     results_panel_border_type: &BorderType,
     source_index: usize,
     source_count: usize,
+    cycle_key: Option<Key>,
 ) -> Result<()> {
     let title = if source_count > 1 {
         let mut spans = vec![Span::from(" Results ")];
@@ -37,6 +39,12 @@ pub fn draw_results_list(
             format!("⟨ {} ⟩", dots),
             Style::default().fg(colorscheme.input.results_count_fg),
         ));
+        if let Some(key) = cycle_key {
+            spans.push(Span::styled(
+                format!(" {}", key),
+                Style::default().fg(colorscheme.general.border_fg),
+            ));
+        }
         spans.push(Span::from(" "));
         Line::from(spans).alignment(Alignment::Center)
     } else {


### PR DESCRIPTION

<img width="2914" height="1687" alt="kbd-indicator" src="https://github.com/user-attachments/assets/99c45e32-02d5-494f-9689-dc2241af5901" />
