### PR TITLE
perf(frecency): avoid string allocations in sort comparisons

### DIFF
--- a/television/frecency.rs
+++ b/television/frecency.rs
@@ -95,6 +95,13 @@ impl FrecencyScores {
     pub fn get(&self, key: &str) -> Option<u64> {
         self.scores.get(key).copied()
     }
+
+    /// Get the underlying Arc for efficient access in sort comparisons.
+    /// This avoids repeated cloning when accessing scores multiple times.
+    #[inline]
+    pub fn scores_arc(&self) -> &Arc<FxHashMap<String, u64>> {
+        &self.scores
+    }
 }
 
 /// Thread-safe cache for frecency scores, refreshed periodically.


### PR DESCRIPTION
## 📺 PR Description

Hi there, it's been a while. When testing the new frencency feature I noticed it tanked the performance on the home dir, so I did some digging and noticed some allocations on a hot zone that could be improved

See bench below

```sh
❯ ./bench_frecency.sh
Benchmark 1: before-frecency (ab6bbfc6)
  Time (mean ± σ):     122.1 ms ±  13.0 ms    [User: 259.1 ms, System: 136.3 ms]
  Range (min … max):   106.8 ms … 152.6 ms    50 runs

Benchmark 2: after-frecency (6cfca4de)
  Time (mean ± σ):     159.1 ms ±  15.2 ms    [User: 297.3 ms, System: 121.7 ms]
  Range (min … max):   131.7 ms … 192.0 ms    50 runs

Benchmark 3: after-perf-patch (e4c033ff)
  Time (mean ± σ):      86.7 ms ±  10.0 ms    [User: 233.5 ms, System: 123.3 ms]
  Range (min … max):    72.6 ms …  97.7 ms    50 runs

Summary
  after-perf-patch (e4c033ff) ran
    1.41 ± 0.22 times faster than before-frecency (ab6bbfc6)
    1.84 ± 0.27 times faster than after-frecency (6cfca4de)
```

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [x] I have added a reasonable amount of documentation to the code where appropriate
