### PR TITLE
feat(fish): add channel name completion

### DIFF
--- a/television/utils/shell/completion.fish
+++ b/television/utils/shell/completion.fish
@@ -1,3 +1,6 @@
+# Complete channel names for the first positional argument
+complete -c tv -n "__fish_tv_needs_command" -f -a "(tv list-channels 2>/dev/null)" -d "Channel"
+
 function __tv_parse_commandline --description 'Parse the current command line token and return split of existing filepath, and query'
     # credits to the junegunn/fzf project
     # https://github.com/junegunn/fzf/blob/9c1a47acf7453f9dad5905b7f23ad06e5195d51f/shell/key-bindings.fish#L53-L131


### PR DESCRIPTION
## Summary

- Add dynamic completion for channel names in fish shell
- Disables file completion fallback (fixes channels mixing with file names)
- Groups channels with "Channel" label to distinguish from subcommands

## Before

When typing `tv <Tab>`, fish showed file names mixed with subcommands - no channel completion.

## After

Channel names are completed dynamically from `tv list-channels` output, grouped and labeled separately from subcommands.

## Test plan

```fish
tv init fish | source
tv <Tab>
# Should show channels labeled "(Channel)" and subcommands with their descriptions
```

🤖 Generated with [Claude Code](https://claude.ai/code)