### PR TITLE
feat(cable): add pj channel for project directory finding

### DIFF
--- a/cable/unix/pj.toml
+++ b/cable/unix/pj.toml
@@ -1,0 +1,48 @@
+[metadata]
+name = "pj"
+description = "Fast project directory finder that searches your filesystem for project directories"
+requirements = ["pj"]
+
+[source]
+command = [
+  "pj --icons --ansi --shorten",
+  "pj --icons --ansi --shorten --no-nested"
+]
+ansi = true
+
+[preview]
+command = "ls -la --color=always \"$(echo {strip_ansi|split: :1} | sed 's|^~|$HOME|')\""
+
+[keybindings]
+enter = "actions:expand"
+ctrl-e = "actions:edit"
+ctrl-t = "actions:connect"
+ctrl-n = "actions:new_tab"
+ctrl-r = ["actions:clear_cache", "reload_source"]
+
+[actions.expand]
+description = "Expand to absolute path"
+command = "echo {strip_ansi|split: :1} | sed 's|^~|$HOME|'"
+mode = "execute"
+
+[actions.edit]
+description = "Open in $EDITOR"
+command = "$EDITOR \"$(echo {strip_ansi|split: :1} | sed 's|^~|$HOME|')\""
+mode = "execute"
+
+# Requires tmux
+[actions.connect]
+description = "Connect to selected tmux session"
+command = "sh -c 'n=$(basename $1|tr .: _); tmux new -ds $n -c $1 2>/dev/null; tmux switchc -t $n' _ \"$(echo {strip_ansi|split: :1} | sed 's|^~|$HOME|')\""
+mode = "execute"
+
+# Requires tmux
+[actions.new_tab]
+description = "Open in new tmux tab"
+command = "tmux new-window -c \"$(echo {strip_ansi|split: :1} | sed 's|^~|$HOME|')\""
+mode = "execute"
+
+[actions.clear_cache]
+description = "Clear pj cache"
+command = "pj --clear-cache"
+mode = "fork"

--- a/cable/windows/pj.toml
+++ b/cable/windows/pj.toml
@@ -1,0 +1,41 @@
+[metadata]
+name = "pj"
+description = "Fast project directory finder that searches your filesystem for project directories"
+requirements = ["pj"]
+
+[source]
+command = [
+  "pj --icons --ansi --shorten",
+  "pj --icons --ansi --shorten --no-nested"
+]
+ansi = true
+
+[preview]
+command = "Get-ChildItem -Force '{strip_ansi|split: :1}' | Format-Table Mode,LastWriteTime,Length,Name -AutoSize"
+
+[keybindings]
+enter = "actions:expand"
+ctrl-e = "actions:edit"
+ctrl-n = "actions:new_tab"
+ctrl-r = ["actions:clear_cache", "reload_source"]
+
+[actions.expand]
+description = "Expand to absolute path"
+command = "Write-Output ('{strip_ansi|split: :1}' -replace '^~', $HOME)"
+mode = "execute"
+
+[actions.edit]
+description = "Open in $EDITOR"
+command = "& $env:EDITOR ('{strip_ansi|split: :1}' -replace '^~', $HOME)"
+mode = "execute"
+
+# Requires Windows Terminal
+[actions.new_tab]
+description = "Open in new Windows Terminal tab"
+command = "$p = ('{strip_ansi|split: :1}' -replace '^~', $HOME); $n = (Split-Path $p -Leaf) -replace '[.:]','_'; wt new-tab --title $n -d $p"
+mode = "execute"
+
+[actions.clear_cache]
+description = "Clear pj cache"
+command = "pj --clear-cache"
+mode = "fork"


### PR DESCRIPTION
## 📺 PR Description

Adds a new cable channel for [`pj`](https://github.com/josephschmitt/pj), a fast project directory finder that searches your filesystem for project directories.
<img width="1508" height="1126" alt="image" src="https://github.com/user-attachments/assets/2c15ceef-8d5c-4f74-9835-03f41b7c3cd0" />

Works with monorepos by deeply looking for nested projects, too:
<img width="1508" height="1126" alt="image" src="https://github.com/user-attachments/assets/7f13ec40-fb8b-4ef0-be6c-11e6a33e1817" />

- Two source modes: default and `--no-nested`
- Preview using `ls`
- Actions: expand path, open in `$EDITOR`, connect to tmux session, open new tmux tab, clear cache
- Keybindings for all actions

Two of the actions require `tmux` to work. Given they’re optional and not the primary (nor even secondary) actions, I figured it was ok to not list `tmux` as a requirement. Let me know if you disagree.

## Checklist

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [x] I have added a reasonable amount of documentation to the code where appropriate