### PR TITLE
docs(readme): add tv.yazi to integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,6 @@ See [Shell Integration](https://alexpasmantier.github.io/television/user-guide/s
 - **VSCode**: [Television extension](https://marketplace.visualstudio.com/items?itemName=alexpasmantier.television)
 - **Zed**: [Telescope-style setup](https://zed.dev/blog/hidden-gems-part-2#emulate-vims-telescope-via-television)
 
-## File Manager Integration
-
-- **Yazi**: [tv.yazi](https://github.com/cap153/tv.yazi) 
-
 ## Documentation
 
 - [Getting Started](https://alexpasmantier.github.io/television/getting-started/quickstart)


### PR DESCRIPTION
## 📺 PR Description

Added a link to `tv.yazi`, a Yazi plugin that integrates `television`.

Link: [https://github.com/cap153/tv.yazi](https://github.com/cap153/tv.yazi)

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [ ] I have added a reasonable amount of documentation to the code where appropriate
