### PR TITLE
Fix display of man-pages

### DIFF
--- a/cable/unix/man-pages.toml
+++ b/cable/unix/man-pages.toml
@@ -1,7 +1,7 @@
 [metadata]
 name = "man-pages"
 description = "Browse and preview system manual pages"
-requirements = ["apropos", "man", "col"]
+requirements = ["apropos", "man"]
 
 [source]
 # List all man pages using apropos
@@ -9,7 +9,7 @@ command = "apropos ."
 
 [preview]
 # Show the man page for the selected entry
-command = "man '{0}' | col -bx"
+command = "man '{0}'"
 env = { "MANWIDTH" = "80" }
 
 [keybindings]


### PR DESCRIPTION
## 📺 PR Description

<!-- summary of the change + which issue is fixed if applicable. -->
A better looking man-pages preview:

<img width="2016" height="1146" alt="Screenshot 2026-02-13 at 2 44 42 AM" src="https://github.com/user-attachments/assets/05fcf104-8e93-48c4-9f75-2109366350ac" />

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [x] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [x] I have added a reasonable amount of documentation to the code where appropriate
