### PR TITLE
fix(docker): add `jq` as needed dependency

### DIFF
--- a/cable/unix/docker-containers.toml
+++ b/cable/unix/docker-containers.toml
@@ -1,7 +1,7 @@
 [metadata]
 name = "docker-containers"
 description = "List and manage Docker containers"
-requirements = ["docker"]
+requirements = ["docker", "jq"]
 
 [source]
 command = [

--- a/cable/unix/docker-networks.toml
+++ b/cable/unix/docker-networks.toml
@@ -1,7 +1,7 @@
 [metadata]
 name = "docker-networks"
 description = "List and manage Docker networks"
-requirements = ["docker"]
+requirements = ["docker", "jq"]
 
 [source]
 command = "docker network ls --format '{{.Name}}\t{{.Driver}}\t{{.Scope}}'"

--- a/cable/unix/docker-volumes.toml
+++ b/cable/unix/docker-volumes.toml
@@ -1,7 +1,7 @@
 [metadata]
 name = "docker-volumes"
 description = "List and manage Docker volumes"
-requirements = ["docker"]
+requirements = ["docker", "jq"]
 
 [source]
 command = "docker volume ls --format '{{.Name}}\t{{.Driver}}'"


### PR DESCRIPTION
## 📺 PR Description

Add `jq` as needed dependency. It is used in commands actually.

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [x] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [x] I have added a reasonable amount of documentation to the code where appropriate
