### PR TITLE
feat(tests): make command order assertions flexible in tests

### DIFF
--- a/television/utils/command.rs
+++ b/television/utils/command.rs
@@ -237,7 +237,10 @@ mod tests {
         let result = format_command(&entries, &template, "\n").unwrap();
 
         // Result should contain both files quoted and joined with space
-        assert_eq!(result, "nvim 'file1.txt' 'file2.txt'");
+        assert!(
+            result == "nvim 'file1.txt' 'file2.txt'"
+                || result == "nvim 'file2.txt' 'file1.txt'"
+        );
     }
 
     #[test]
@@ -265,7 +268,10 @@ mod tests {
         let result = format_command(&entries, &template, "\n").unwrap();
 
         // Result should contain both files quoted and joined with space
-        assert_eq!(result, "nvim 'file1.txt' 'file2.txt'");
+        assert!(
+            result == "nvim 'file1.txt' 'file2.txt'"
+                || result == "nvim 'file2.txt' 'file1.txt'"
+        );
     }
 
     #[test]
@@ -282,6 +288,9 @@ mod tests {
         let result = format_command(&entries, &template, "\n").unwrap();
 
         // Result should be escaped with single quotes in filenames
-        assert_eq!(result, "nvim 'file1\\'s.txt' 'file2.txt'");
+        assert!(
+            result == "nvim 'file1\\'s.txt' 'file2.txt'"
+                || result == "nvim 'file2.txt' 'file1\\'s.txt'"
+        );
     }
 }


### PR DESCRIPTION
Since FxHashSet is unordered, accept either order

## 📺 PR Description

<!-- summary of the change + which issue is fixed if applicable. -->

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [ ] I have added a reasonable amount of documentation to the code where appropriate

```
ailures:
---- utils::command::tests::test_simple_braces_multiple_entries stdout ----
thread 'utils::command::tests::test_simple_braces_multiple_entries' (7758) panicked at television/utils/command.rs:240:9:
assertion `left == right` failed
  left: "nvim 'file2.txt' 'file1.txt'"
 right: "nvim 'file1.txt' 'file2.txt'"
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
failures:
    utils::command::tests::test_simple_braces_multiple_entries
test result: FAILED. 181 passed; 1 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.15s
error: test failed, to rerun pass `--lib`
```