### PR TITLE
fix(cable): use bash for actions with ${EDITOR:-} syntax

### DIFF
--- a/cable/unix/dotfiles.toml
+++ b/cable/unix/dotfiles.toml
@@ -15,4 +15,5 @@ enter = "actions:edit"
 [actions.edit]
 description = "Edit the selected dotfile"
 command = "${EDITOR:-vim} '{}'"
+shell = "bash"
 mode = "execute"

--- a/cable/unix/files.toml
+++ b/cable/unix/files.toml
@@ -18,6 +18,7 @@ ctrl-up = "actions:goto_parent_dir"
 [actions.edit]
 description = "Opens the selected entries with the default editor (falls back to vim)"
 command = "${EDITOR:-vim} '{}'"
+shell = "bash"
 # use `mode = "fork"` if you want to return to tv afterwards
 mode = "execute"
 

--- a/cable/unix/git-diff.toml
+++ b/cable/unix/git-diff.toml
@@ -30,4 +30,5 @@ mode = "fork"
 [actions.edit]
 description = "Open the selected file in editor"
 command = "${EDITOR:-vim} '{}'"
+shell = "bash"
 mode = "execute"

--- a/cable/unix/git-files.toml
+++ b/cable/unix/git-files.toml
@@ -16,4 +16,5 @@ f12 = "actions:edit"
 [actions.edit]
 description = "Opens the selected entries with the default editor (falls back to vim)"
 command = "${EDITOR:-vim} '{}'"
+shell = "bash"
 mode = "execute"

--- a/cable/unix/git-repos.toml
+++ b/cable/unix/git-repos.toml
@@ -27,4 +27,5 @@ mode = "execute"
 [actions.edit]
 description = "Open the repository in editor"
 command = "${EDITOR:-vim} '{}'"
+shell = "bash"
 mode = "execute"

--- a/cable/unix/recent-files.toml
+++ b/cable/unix/recent-files.toml
@@ -19,4 +19,5 @@ enter = "actions:edit"
 [actions.edit]
 description = "Open the selected file in editor"
 command = "${EDITOR:-vim} '{}'"
+shell = "bash"
 mode = "execute"

--- a/cable/unix/text.toml
+++ b/cable/unix/text.toml
@@ -25,4 +25,5 @@ enter = "actions:edit"
 [actions.edit]
 description = "Open file in editor at line"
 command = "${EDITOR:-vim} '+{strip_ansi|split:\\::1}' '{strip_ansi|split:\\::0}'"
+shell = "bash"
 mode = "execute"

--- a/cable/unix/todo-comments.toml
+++ b/cable/unix/todo-comments.toml
@@ -22,4 +22,5 @@ enter = "actions:edit"
 [actions.edit]
 description = "Open file in editor at the comment"
 command = "${EDITOR:-vim} '+{strip_ansi|split:\\::1}' '{strip_ansi|split:\\::0}'"
+shell = "bash"
 mode = "execute"


### PR DESCRIPTION
Closes #910

Now using bash for channel actions that require POSIX-style `${VAR:-default}` parameter expansion (e.g. `${EDITOR:-vim}`), which is not supported by fish or nu.

Affected channels: `files`, `dotfiles`, `recent-files`, `text`, `todo-comments`, `git-diff`, `git-files`, `git-repos`