### PR TITLE
fix(frecency): persist external-action selections before execute

### DIFF
--- a/television/app.rs
+++ b/television/app.rs
@@ -614,6 +614,8 @@ impl App {
                                     ))
                                     .cloned()
                             {
+                                self.record_selection(&selected_entries)?;
+
                                 match action_spec.mode {
                                     // suspend the TUI and execute the action
                                     ExecutionMode::Fork => {
@@ -706,6 +708,14 @@ impl App {
             while !rendering_task.is_finished() {
                 sleep(Duration::from_millis(10));
             }
+        }
+
+        if let Err(e) = self.history.save_to_file() {
+            error!("Failed to persist history: {}", e);
+        }
+
+        if let Err(e) = self.frecency.save_to_file() {
+            error!("Failed to persist frecency: {}", e);
         }
 
         execute_action(action_spec, entries).map_err(|e| {


### PR DESCRIPTION
## 📺 PR Description

closes #917 
Persistence was not being called on the `execute` execution path, this should cover it

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [ ] I have added a reasonable amount of documentation to the code where appropriate
