### PR TITLE
refactor: remove redundant install dir branch

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -179,12 +179,7 @@ install_binary() {
     info "Extracting binary..."
     tar -xzf "$TARBALL"
     
-    # Install to appropriate location
-    if [[ "$OS" == "macos" ]]; then
-        INSTALL_DIR="/usr/local/bin"
-    else
-        INSTALL_DIR="/usr/local/bin"
-    fi
+    INSTALL_DIR="/usr/local/bin"
     
     info "Installing to $INSTALL_DIR..."
     sudo mkdir -p "$INSTALL_DIR"


### PR DESCRIPTION
## 📺 PR Description

<!-- summary of the change + which issue is fixed if applicable. -->

Remove the redundant branch when assigning `INSTALL_DIR` in `install.sh`.

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [ ] I have added a reasonable amount of documentation to the code where appropriate
