### PR TITLE
fix: select-1 with prefilled input

### DIFF
--- a/television/app.rs
+++ b/television/app.rs
@@ -374,10 +374,10 @@ impl App {
 
             if self.television.merged_config.select_1
                 && !self.television.channel.running()
-                && self.television.channel.total_count() == 1
+                && self.television.channel.result_count() == 1
             {
                 // If `self.select_1` is true, the channel is not running, and there is
-                // only one entry available, automatically select the first entry.
+                // only one matched entry available, automatically select it.
                 if let Some(outcome) = self.maybe_select_1() {
                     action_outcome = outcome;
                 }

--- a/tests/cli/selection.rs
+++ b/tests/cli/selection.rs
@@ -23,6 +23,23 @@ fn test_select_1_auto_selects_single_entry() {
     tester.assert_raw_output_contains("UNIQUE16CHARID");
 }
 
+/// Tests that --select-1 respects the initial --input filter.
+#[test]
+fn test_select_1_respects_initial_input() {
+    let mut tester = PtyTester::new();
+
+    let cmd = tv_local_config_and_cable_with_args(&[
+        "--source-command",
+        "printf 'television\\ntelescope\\n'",
+        "--select-1",
+        "--input",
+        "telev",
+    ]);
+    tester.spawn_command(cmd);
+
+    tester.assert_raw_output_contains("television");
+}
+
 /// Tests that --take-1 automatically selects the first entry after loading completes.
 #[test]
 fn test_take_1_auto_selects_first_entry() {


### PR DESCRIPTION
## 📺 PR Description

This PR closes #940

```bash
echo aaaa\nwwww\neeee\nrrrr\ntttt\nyyyy | tv -- --select-1 --input 'a'
```

Running this command now automatically selects `aaaa` entry. The `--select-1` command now does so after `--input` is applied

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [x] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [x] I have added a reasonable amount of documentation to the code where appropriate
