### PR TITLE
fix(config): bat cannot print file paths that starts with '-' on windows

### DIFF
--- a/cable/windows/dotfiles.toml
+++ b/cable/windows/dotfiles.toml
@@ -8,4 +8,4 @@ command = "fd -t f . \"$env:USERPROFILE\\AppData\\Roaming\\\""
 
 
 [preview]
-command = "bat -n --color=always '{}'"
+command = "bat -n --color=always -- '{}'"

--- a/cable/windows/files.toml
+++ b/cable/windows/files.toml
@@ -7,7 +7,7 @@ requirements = ["fd", "bat"]
 command = ["fd -t f", "fd -t f -H"]
 
 [preview]
-command = "bat -n --color=always '.\\{}'"
+command = "bat -n --color=always -- '{}'"
 env = { BAT_THEME = "ansi" }
 
 [keybindings]

--- a/cable/windows/text.toml
+++ b/cable/windows/text.toml
@@ -9,7 +9,7 @@ display = "[{split:\\::..2}]\t{split:\\::2..}"
 output = "{split:\\::..2}"
 
 [preview]
-command = "bat -n --color=always '.\\{split:\\::0}'"
+command = "bat -n --color=always -- '{split:\\::0}'"
 env = { BAT_THEME = "ansi" }
 offset = '{split:\::1}'
 

--- a/docs/community/channels-windows.md
+++ b/docs/community/channels-windows.md
@@ -96,7 +96,7 @@ requirements = [ "fd", "bat",]
 command = "fd -t f . \"$env:USERPROFILE\\AppData\\Roaming\\\""
 
 [preview]
-command = "bat -n --color=always '{}'"
+command = "bat -n --color=always -- '{}'"
 
 ```
 
@@ -156,7 +156,7 @@ requirements = [ "fd", "bat",]
 command = [ "fd -t f", "fd -t f -H",]
 
 [preview]
-command = "bat -n --color=always '.\\{}'"
+command = "bat -n --color=always -- '{}'"
 
 [keybindings]
 shortcut = "f1"
@@ -371,7 +371,7 @@ display = "[{split:\\::..2}]\t{split:\\::2..}"
 output = "{split:\\::..2}"
 
 [preview]
-command = "bat -n --color=always '.\\{split:\\::0}'"
+command = "bat -n --color=always -- '{split:\\::0}'"
 offset = "{split:\\::1}"
 
 [preview.env]


### PR DESCRIPTION
## 📺 PR Description

<!-- summary of the change + which issue is fixed if applicable. -->
when trying to print content of file paths that starts with '-' on windows, bat puts out this error:
error: unexpected argument '-1' found

  tip: to pass '-1' as a value, use '-- -1'

Usage: bat.exe [OPTIONS] [FILE]...
       bat.exe <COMMAND>

For more information, try '--help'.

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [x] I have added a reasonable amount of documentation to the code where appropriate
