### PR TITLE
fix(previewer): prevent panic when scroll exceeds content lines length

### DIFF
--- a/television/previewer/state.rs
+++ b/television/previewer/state.rs
@@ -52,10 +52,9 @@ impl PreviewState {
     // What if we did it only when the preview content or scroll changes?
     pub fn for_render_context(&self, height: usize) -> Self {
         // PERF: this allocates every time
-        let scroll = self.scroll as usize;
-        let num_lines = self.preview.total_lines.saturating_sub(
-            u16::try_from(scroll).expect("scroll should fit in a u16"),
-        ) as usize;
+        let content_len = self.preview.content.lines.len();
+        let scroll = (self.scroll as usize).min(content_len);
+        let num_lines = content_len.saturating_sub(scroll);
         let cropped_content: Text<'_> = self.preview.content.lines
             [scroll..scroll + num_lines.min(height)]
             .to_vec()


### PR DESCRIPTION
## 📺 PR Description

Fixes a panic in `previewer/state.rs` that occurred when `scroll` exceeded the actual number of lines in `content.lines`.
The root cause was that `for_render_context` used `total_lines` to compute slice bounds, but `total_lines` and `content.lines.len()` can be out of sync (e.g. while a new preview is still loading). This caused:

range start index 4906 out of range for slice of length 1

**Fix:** clamp `scroll` to the real content length and derive `num_lines` from `content.lines.len()` instead of `total_lines`.

Fixes panic reported via human-panic in `television/previewer/state.rs:60`.

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [ x] my commits **and PR title** follow the [conventional commits]
