### PR TITLE
fix(tests): use timeout-based assertions for flaky selection tests

### DIFF
--- a/tests/cli/selection.rs
+++ b/tests/cli/selection.rs
@@ -9,6 +9,8 @@ use super::super::common::*;
 /// Tests that --select-1 automatically selects and returns when only one entry matches.
 #[test]
 fn test_select_1_auto_selects_single_entry() {
+    use std::time::Duration;
+
     let mut tester = PtyTester::new();
 
     // This should auto-select "UNIQUE16CHARID" since it's the only result
@@ -19,13 +21,20 @@ fn test_select_1_auto_selects_single_entry() {
     ]);
     tester.spawn_command(cmd);
 
-    // Should auto-select and output the result without showing TUI
-    tester.assert_raw_output_contains("UNIQUE16CHARID");
+    // Should auto-select and output the result without showing TUI.
+    // Use timeout-based assertion because --select-1 waits for loading to
+    // complete, which may take longer than the initial spawn delay.
+    tester.assert_raw_output_contains_with_timeout(
+        "UNIQUE16CHARID",
+        Duration::from_secs(2),
+    );
 }
 
 /// Tests that --select-1 respects the initial --input filter.
 #[test]
 fn test_select_1_respects_initial_input() {
+    use std::time::Duration;
+
     let mut tester = PtyTester::new();
 
     let cmd = tv_local_config_and_cable_with_args(&[
@@ -37,12 +46,17 @@ fn test_select_1_respects_initial_input() {
     ]);
     tester.spawn_command(cmd);
 
-    tester.assert_raw_output_contains("television");
+    tester.assert_raw_output_contains_with_timeout(
+        "television",
+        Duration::from_secs(2),
+    );
 }
 
 /// Tests that --take-1 automatically selects the first entry after loading completes.
 #[test]
 fn test_take_1_auto_selects_first_entry() {
+    use std::time::Duration;
+
     let mut tester = PtyTester::new();
 
     // This should auto-select "UNIQUE16CHARID" since it's the only result
@@ -53,8 +67,13 @@ fn test_take_1_auto_selects_first_entry() {
     ]);
     tester.spawn_command(cmd);
 
-    // Should auto-select and output the result without showing TUI
-    tester.assert_raw_output_contains("UNIQUE16CHARID");
+    // Should auto-select and output the result without showing TUI.
+    // Use timeout-based assertion because --take-1 waits for loading to
+    // complete, which may take longer than the initial spawn delay.
+    tester.assert_raw_output_contains_with_timeout(
+        "UNIQUE16CHARID",
+        Duration::from_secs(2),
+    );
 }
 
 /// Tests that --take-1-fast immediately selects the first entry as it appears.


### PR DESCRIPTION
## Summary
- The `--select-1` and `--take-1` selection tests were flaky because they used a single-shot raw output read after the 300ms spawn delay
- The full pipeline (TUI start → source command → nucleo processing → channel finish → auto-select → exit) can exceed that delay, causing the test to read TUI escape sequences instead of the expected output
- Switched all three auto-select tests to use `assert_raw_output_contains_with_timeout` with a 2s timeout and exponential backoff, matching the approach already used by `--take-1-fast`

## Test plan
- [x] `cargo test --test command_line cli::selection -- --nocapture` — all 11 tests pass