### PR TITLE
fix(tests): replace unsafe env var manipulation with CommandBuilder::env

### DIFF
--- a/tests/cli/errors.rs
+++ b/tests/cli/errors.rs
@@ -132,31 +132,30 @@ fn test_watch_and_selection_flags_conflict_errors() {
 /// Tests that --inline conflicts with --height.
 #[test]
 fn test_inline_and_height_conflict_errors() {
-    unsafe { std::env::set_var(TESTING_ENV_VAR, "1") };
     let mut tester = PtyTester::new();
 
     // This should fail because --inline and --height are mutually exclusive
-    let cmd = tv_local_config_and_cable_with_args(&[
+    let mut cmd = tv_local_config_and_cable_with_args(&[
         "files", "--inline", "--height", "20",
     ]);
+    cmd.env(TESTING_ENV_VAR, "1");
     tester.spawn_command(cmd);
 
     // Confirm the logical incompatibility is detected
     tester.assert_raw_output_contains("cannot be used with");
-    unsafe { std::env::remove_var(TESTING_ENV_VAR) };
 }
 
 /// Tests that --width cannot be used without --height or --inline.
 #[test]
 fn test_width_without_height_or_inline_errors() {
-    unsafe { std::env::set_var(TESTING_ENV_VAR, "1") };
     let mut tester = PtyTester::new();
 
     // This should fail because --width requires --height or --inline
-    let cmd = tv_local_config_and_cable_with_args(&["files", "--width", "80"]);
+    let mut cmd =
+        tv_local_config_and_cable_with_args(&["files", "--width", "80"]);
+    cmd.env(TESTING_ENV_VAR, "1");
     tester.spawn_command(cmd);
 
     // Confirm the logical incompatibility is detected
     tester.assert_raw_output_contains("can only be used");
-    unsafe { std::env::remove_var(TESTING_ENV_VAR) };
 }

--- a/tests/cli/ui.rs
+++ b/tests/cli/ui.rs
@@ -422,14 +422,14 @@ fn test_no_help_panel_conflicts_with_show_help_panel() {
 
 #[test]
 fn test_tui_with_height_and_width() {
-    unsafe { std::env::set_var(TESTING_ENV_VAR, "1") };
     let mut tester = PtyTester::new();
 
     // Test TUI with height 20 and width 80
-    let mut child =
-        tester.spawn_command_tui(tv_local_config_and_cable_with_args(&[
-            "files", "--height", "20", "--width", "80",
-        ]));
+    let mut cmd = tv_local_config_and_cable_with_args(&[
+        "files", "--height", "20", "--width", "80",
+    ]);
+    cmd.env(TESTING_ENV_VAR, "1");
+    let mut child = tester.spawn_command_tui(cmd);
 
     // Check that 'files' appears in the frame content
     tester.assert_tui_frame_contains("CHANNEL  files");
@@ -454,7 +454,6 @@ fn test_tui_with_height_and_width() {
     // Send Ctrl+C to exit
     tester.send(&ctrl('c'));
     PtyTester::assert_exit_ok(&mut child, DEFAULT_DELAY);
-    unsafe { std::env::remove_var(TESTING_ENV_VAR) };
 }
 
 /// Tests that --no-preview disables the preview panel entirely.
@@ -591,14 +590,13 @@ fn test_no_status_bar_conflicts_with_status_bar_flags() {
 // FIXME: needs https://github.com/crossterm-rs/crossterm/pull/957
 #[ignore = "needs https://github.com/crossterm-rs/crossterm/pull/957"]
 fn test_tui_with_height_only() {
-    unsafe { std::env::set_var(TESTING_ENV_VAR, "1") };
     let mut tester = PtyTester::new();
 
     // Test TUI with only height specified
-    let mut child =
-        tester.spawn_command_tui(tv_local_config_and_cable_with_args(&[
-            "files", "--height", "15",
-        ]));
+    let mut cmd =
+        tv_local_config_and_cable_with_args(&["files", "--height", "15"]);
+    cmd.env(TESTING_ENV_VAR, "1");
+    let mut child = tester.spawn_command_tui(cmd);
 
     // Check that 'files' appears in the frame content
     tester.assert_tui_frame_contains("CHANNEL  files");
@@ -617,5 +615,4 @@ fn test_tui_with_height_only() {
     // Send Ctrl+C to exit
     tester.send(&ctrl('c'));
     PtyTester::assert_exit_ok(&mut child, DEFAULT_DELAY);
-    unsafe { std::env::remove_var(TESTING_ENV_VAR) };
 }


### PR DESCRIPTION
The previous implementation used `std::env::set_var` and `std::env::remove_var` within `unsafe` blocks, which could cause SIGSEGV due to race conditions when modifying the process environment while other threads are reading it.

```
     Running tests/command_line.rs (target/debug/deps/command_line-502b1fa4ccd52715)
running 112 tests
error: test failed, to rerun pass `--test command_line` Caused by:
  process didn't exit successfully: `/builds/qaqland/aports/testing/television/src/television-0.15.3/target/debug/deps/command_line-502b1fa4ccd52715` (signal: 11, SIGSEGV: invalid memory reference)
```

## 📺 PR Description

<!-- summary of the change + which issue is fixed if applicable. -->

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [ ] I have added a reasonable amount of documentation to the code where appropriate
