### PR TITLE
fix(tests): use --take-1 in test_cli_working_directory_override

### DIFF
--- a/tests/config/cli_overrides.rs
+++ b/tests/config/cli_overrides.rs
@@ -112,6 +112,8 @@ fn test_cli_overrides_channel_source_and_preview() {
 /// Tests CLI working directory parameter
 #[test]
 fn test_cli_working_directory_override() {
+    use std::time::Duration;
+
     let mut tester = PtyTester::new();
     let temp_dir = TempDir::new().unwrap();
 
@@ -128,18 +130,18 @@ fn test_cli_working_directory_override() {
         DEFAULT_CABLE_DIR,
         "--input",
         "working-dir-test",
-        "--take-1-fast",
+        "--take-1",
         &temp_dir.path().to_string_lossy(), // PATH as positional argument
     ]);
 
     // Should exit with the found file
     let mut child = tester.spawn_command(cmd);
-    // wait for completion so that the TUI doesn't interfere with
-    // what we're capturing
-    PtyTester::assert_exit_ok(&mut child, DEFAULT_DELAY);
 
     // Should find our test file in the target directory
-    tester.assert_raw_output_contains("working-dir-test.txt");
+    tester.assert_raw_output_contains_with_timeout(
+        "working-dir-test.txt",
+        Duration::from_secs(2),
+    );
 
     PtyTester::assert_exit_ok(&mut child, DEFAULT_DELAY);
 }


### PR DESCRIPTION
--take-1 waits for loading to complete before selecting the first entry, making it more reliable than --take-1-fast which may race with data loading.

Also switch to assert_raw_output_contains_with_timeout for more reliable output verification.

Ref https://github.com/alexpasmantier/television/commit/6fbfc23fc41a9da342679d2573b1c40792d23906

## 📺 PR Description

<!-- summary of the change + which issue is fixed if applicable. -->

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [ ] I have added a reasonable amount of documentation to the code where appropriate
