### PR TITLE
Fix incorrect Windows paths in documentation

### DIFF
--- a/.config/config.toml
+++ b/.config/config.toml
@@ -4,7 +4,7 @@
 # ---------
 #  Linux:   `$HOME/.config/television/config.toml`
 #  macOS:   `$HOME/.config/television/config.toml`
-#  Windows: `%LocalAppData%\television\config.toml`
+#  Windows: `%LocalAppData%\television\config\config.toml`
 #
 # XDG dirs:
 # ---------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ The logs are written to a file called `television.log` in a directory that depen
 | -------- | ------------------------------------------------------------------------------------------------------------ |
 | Linux    | `$XDG_DATA_HOME/television/television.log` or `$HOME/.local/share/television/television.log`                 |
 | macOS    | `$XDG_DATA_HOME/television/television.log` or `$HOME/Library/Application\ Support/television/television.log` |
-| Windows  | `%LocalAppData%\television\television.log`                                                                   |
+| Windows  | `%LocalAppData%\television\data\television.log`                                                              |
 
 To check for linting and formatting issues (and fix them automatically), run:
 

--- a/docs/advanced/03-troubleshooting.md
+++ b/docs/advanced/03-troubleshooting.md
@@ -193,7 +193,7 @@ Tv writes logs to help diagnose issues:
 |----------|----------|
 | Linux | `~/.local/share/television/television.log` |
 | macOS | `~/Library/Application Support/television/television.log` |
-| Windows | `%LocalAppData%\television\television.log` |
+| Windows | `%LocalAppData%\television\data\television.log` |
 
 Or if `$TELEVISION_DATA` is set: `$TELEVISION_DATA/television.log`
 

--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -75,7 +75,7 @@ The logs are written to a file called `television.log` in a directory that depen
 | -------- | ------------------------------------------------------------------------------------------------------------ |
 | Linux    | `$XDG_DATA_HOME/television/television.log` or `$HOME/.local/share/television/television.log`                 |
 | macOS    | `$XDG_DATA_HOME/television/television.log` or `$HOME/Library/Application\ Support/television/television.log` |
-| Windows  | `%LocalAppData%\television\television.log`                                                          |
+| Windows  | `%LocalAppData%\television\data\television.log`                                                     |
 
 If `TELEVISION_DATA` is set, logs will be written to `$TELEVISION_DATA/television.log` instead.
 

--- a/docs/getting-started/03-first-channel.md
+++ b/docs/getting-started/03-first-channel.md
@@ -29,7 +29,7 @@ A channel is a TOML configuration file that tells tv:
 - **How to preview** results (optional)
 - **Custom keybindings and actions** (optional)
 
-Channels live in `~/.config/television/cable/` (or `%LocalAppData%\television\cable\` on Windows).
+Channels live in `~/.config/television/cable/` (or `%LocalAppData%\television\config\cable\` on Windows).
 
 ## Step 1: Create the Channel File
 

--- a/docs/reference/03-channel-spec.md
+++ b/docs/reference/03-channel-spec.md
@@ -6,7 +6,7 @@ This document provides the complete reference for channel TOML configuration fil
 
 Channels are stored as `.toml` files in:
 - **Linux/macOS**: `~/.config/television/cable/`
-- **Windows**: `%LocalAppData%\television\cable\`
+- **Windows**: `%LocalAppData%\television\config\cable\`
 - **Custom**: Set via `$TELEVISION_CONFIG/cable/` or `--cable-dir`
 
 ## High-Level Structure

--- a/docs/user-guide/02-configuration.md
+++ b/docs/user-guide/02-configuration.md
@@ -10,7 +10,7 @@ Locations where `television` expects the user configuration file to be located f
 | -------- | :------------------------------------: |
 | Linux    | `$HOME/.config/television/config.toml` |
 | macOS    | `$HOME/.config/television/config.toml` |
-| Windows  | `%LocalAppData%\television\config.toml` |
+| Windows  | `%LocalAppData%\television\config\config.toml` |
 
 Or, if you'd rather use the XDG Base Directory Specification, tv will look for the configuration file in
 `$XDG_CONFIG_HOME/television/config.toml` if the environment variable is set.


### PR DESCRIPTION
## Summary

The documented Windows paths for config, cable, and log files are missing subdirectories that the `directories` crate adds on Windows.

For example, the config file path is documented as `%LocalAppData%\television\config.toml` but the actual path is `%LocalAppData%\television\config\config.toml`. Similarly, log files are under a `data\` subdirectory.

Fixed paths across all affected docs:
- Config: `%LocalAppData%\television\config\config.toml`
- Cable: `%LocalAppData%\television\config\cable\`
- Logs: `%LocalAppData%\television\data\television.log`

## Test plan

- Verified the actual paths on a Windows 11 machine by checking the directory structure created by `tv` after a fresh `winget` install