### PR TITLE
fix(tests): add --input filter to fix flaky fd-dependent tests

### DIFF
--- a/tests/cli/modes.rs
+++ b/tests/cli/modes.rs
@@ -106,7 +106,8 @@ fn test_smart_path_detection_switches_to_adhoc_mode() {
 
     // The "./cable/" should be detected as a path, triggering path detection logic
     // This uses the default channel (files) in the cable directory
-    let cmd = tv_local_config_and_cable_with_args(&["./cable/"]);
+    let mut cmd = tv_local_config_and_cable_with_args(&["./cable/"]);
+    cmd.args(["--input", "files.toml"]);
     let mut child = tester.spawn_command_tui(cmd);
 
     // Verify path detection worked and default channel was used

--- a/tests/cli/source.rs
+++ b/tests/cli/source.rs
@@ -29,11 +29,12 @@ fn test_source_command_override_in_channel_mode() {
     let mut tester = PtyTester::new();
 
     // This overrides the files channel's default source command with a custom one
-    let cmd = tv_local_config_and_cable_with_args(&[
+    let mut cmd = tv_local_config_and_cable_with_args(&[
         "files",
         "--source-command",
         "fd -t f . ./cable/",
     ]);
+    cmd.args(["--input", "files.toml"]);
     let mut child = tester.spawn_command_tui(cmd);
 
     // Verify the override is active


### PR DESCRIPTION
Use --input to filter for a specific file to avoid flakiness from fd's unordered output. Affected tests:
- test_smart_path_detection_switches_to_adhoc_mode
- test_source_command_override_in_channel_mode

```
---- cli::modes::test_smart_path_detection_switches_to_adhoc_mode stdout ----
thread 'cli::modes::test_smart_path_detection_switches_to_adhoc_mode' (12063) panicked at tests/common/mod.rs:305:9:
Expected output to contain
'unix/files.toml'
but got:
╭───────────────────────── files ──────────────────────────╮╭──────────────── windows/git-branch.toml ─────────────────╮
│>                                                  1 / 95 ││    1 [metadata]                                          ▲
╰──────────────────────────────────────────────────────────╯│    2 name = "git-branch"                                 █
╭───────────────── Results ⟨ ● ○ ⟩ ctrl-s ─────────────────╮│    3 description = "A channel to select from git branche █
│> windows/git-branch.toml                                 ││    4 requirements = ["git"]                              █
│  windows/nu-history.toml                                 ││    5                                                     █
│  windows/alias.toml                                      ││    6 [source]                                            █
│  windows/docker-images.toml                              ││    7 command = "git --no-pager branch --all --format=\"% █
│  windows/dotfiles.toml                                   ││    8 output = "{split: :0}"                              █
│  windows/git-diff.toml                                   ││    9                                                     █
│  windows/files.toml                                      ││   10 [preview]                                           █
│  windows/dirs.toml                                       ││   11 command = "git show -p --stat --pretty=fuller --col █
│  windows/pwsh-history.toml                               ││                                                          █
│  windows/env.toml                                        ││                                                          █
│  windows/text.toml                                       ││                                                          █
│  windows/git-repos.toml                                  ││                                                          █
│  windows/git-reflog.toml                                 ││                                                          █
│  unix/journal.toml                                       ││                                                          █
│  unix/zoxide.toml                                        ││                                                          █
│  unix/git-reflog.toml                                    ││                                                          █
│  unix/systemd-units.toml                                 ││                                                          █
│  unix/git-repos.toml                                     ││                                                          ║
│  unix/sesh.toml                                          ││                                                          ║
│  unix/make-targets.toml                                  ││                                                          ║
│  unix/ssh-hosts.toml                                     ││                                                          ║
│  unix/bash-history.toml                                  ││                                                          ║
│  unix/docker-networks.toml                               ││                                                          ║
│  unix/path.toml                                          ││                                                          ▼
╰──────────────────────────────────────────────────────────╯╰──────────────────────────────────────────────────────────╯
  CHANNEL  files                 Remote Control: ctrl-t • Actions: ctrl-x • Help: ctrl-h                        v0.15.4
```

## 📺 PR Description

<!-- summary of the change + which issue is fixed if applicable. -->

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [ ] I have added a reasonable amount of documentation to the code where appropriate
