### PR TITLE
fix(ui): add CJK punctuation unicode ranges to replace_non_printable

### DIFF
--- a/television/utils/strings.rs
+++ b/television/utils/strings.rs
@@ -454,6 +454,16 @@ pub fn replace_non_printable_bulk<'a>(
                     c if ('\u{4E00}'..='\u{9FFF}').contains(&c) => {
                         output.push(c);
                     }
+                    // CJK Symbols and Punctuation (includes book title marks 《》)
+                    // ex: 《 》 【 】
+                    c if ('\u{3000}'..='\u{303F}').contains(&c) => {
+                        output.push(c);
+                    }
+                    // Halfwidth and Fullwidth Forms (includes fullwidth parentheses)
+                    // ex: （ ） ＜＞ ＝
+                    c if ('\u{FF00}'..='\u{FFEF}').contains(&c) => {
+                        output.push(c);
+                    }
                     // Korean: Hangul syllables
                     c if ('\u{AC00}'..='\u{D7AF}').contains(&c) => {
                         output.push(c);


### PR DESCRIPTION
## 📺 PR Description

CJK punctuation characters (e.g. `《》`, `（）`, `【】`) were incorrectly replaced with NUL symbols in the television entry list because `replace_non_printable` did not include their Unicode ranges.

This PR adds support for two additional Unicode ranges:

- **CJK Symbols and Punctuation** (U+3000..U+303F): covers `《》`, `【】`, `「」`, etc.
- **Halfwidth and Fullwidth Forms** (U+FF00..U+FFEF): covers `（）`, `＜＞`, and other fullwidth characters

## Checklist

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [x] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [ ] I have added a reasonable amount of documentation to the code where appropriate