### PR TITLE
fix(screen): fix sources list flicker on first selection

### DIFF
--- a/television/screen/constants.rs
+++ b/television/screen/constants.rs
@@ -1,4 +1,4 @@
-pub const POINTER_SYMBOL: &str = "> ";
+pub const POINTER_SYMBOL: &str = ">";
 pub const SELECTED_SYMBOL: &str = "● ";
 pub const DESELECTED_SYMBOL: &str = "  ";
 pub const LOGO_WIDTH: u16 = 24;

--- a/television/screen/result_item.rs
+++ b/television/screen/result_item.rs
@@ -90,7 +90,7 @@ pub fn build_result_line<'a, T: ResultItem + ?Sized>(
         .unwrap_or(0);
 
     let item_max_width = area_width
-        .saturating_sub(2) // pointer + space (kept for caller)
+        .saturating_sub(POINTER_SYMBOL.len() as u16)
         .saturating_sub(2) // borders
         .saturating_sub(selection_prefix_width)
         .saturating_sub(shortcut_extra);

--- a/television/screen/results.rs
+++ b/television/screen/results.rs
@@ -72,8 +72,6 @@ pub fn draw_results_list(
         InputPosition::Top => ratatui::widgets::ListDirection::TopToBottom,
     };
 
-    let has_multi_select = !selected_entries.is_empty();
-
     let results_list = result_item::build_results_list(
         results_block,
         entries,
@@ -81,13 +79,7 @@ pub fn draw_results_list(
         list_direction,
         &colorscheme.results,
         rect.width - 1, // right padding
-        |entry| {
-            if has_multi_select {
-                Some(selected_entries.contains(entry))
-            } else {
-                None
-            }
-        },
+        |entry| Some(selected_entries.contains(entry)),
     );
 
     f.render_stateful_widget(results_list, rect, relative_picker_state);


### PR DESCRIPTION
## 📺 PR Description

Fix sources flicker on first selection https://github.com/alexpasmantier/television/issues/994

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [ ] I have added a reasonable amount of documentation to the code where appropriate
