### PR TITLE
fix(channels): deduplicate bash-history entries

### DIFF
--- a/cable/unix/bash-history.toml
+++ b/cable/unix/bash-history.toml
@@ -4,6 +4,6 @@ description = "A channel to select from your bash history"
 requirements = ["bash"]
 
 [source]
-command = "sed '1!G;h;$!d' ${HISTFILE:-${HOME}/.bash_history}"
+command = "sed '1!G;h;$!d' ${HISTFILE:-${HOME}/.bash_history} | awk '!seen[$0]++'"
 no_sort = true
 frecency = false


### PR DESCRIPTION
## 📺 PR Description

The `bash-history` channel currently displays all entries from `HISTFILE`, including duplicate commands that accumulate over time.

This PR adds `| awk '!seen[$0]++'` to the source command to filter out duplicates, keeping only the most recent occurrence of each command.

## Checklist

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [x] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [ ] I have added a reasonable amount of documentation to the code where appropriate