### PR TITLE
feat(channels): flush candidate batches by size or interval

### DIFF
--- a/television/channels/channel.rs
+++ b/television/channels/channel.rs
@@ -19,8 +19,11 @@ use std::process::Stdio;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::time::Duration;
-use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command as TokioCommand;
+use tokio::{
+    io::{AsyncBufReadExt, BufReader},
+    time::Instant,
+};
 use tracing::debug;
 
 const RELOAD_RENDERING_DELAY: Duration = Duration::from_millis(200);
@@ -254,6 +257,8 @@ const DEFAULT_LINE_BUFFER_SIZE: usize = 256;
 // Batch size for pushing candidates to the injector
 // 10k * 500 bytes (pessimistic avg line size) = ~5 MB
 const BATCH_SIZE: usize = 10_000;
+// Automatically flush batch after this interval
+const UPDATE_INTERVAL: Duration = Duration::from_millis(200);
 // Maximum number of concurrent flush tasks to prevent unbounded memory growth
 // 4 * 10_000 * average line size = ~20 MB
 const MAX_CONCURRENT_FLUSHES: usize = 4;
@@ -292,6 +297,7 @@ pub async fn load_candidates<P: EntryProcessor>(
             .map(|d| *d as u8)
             .unwrap_or(DEFAULT_DELIMITER);
 
+        let mut last_flush = Instant::now();
         while {
             buf.clear();
             let n = reader.read_until(delimiter, &mut buf).await.unwrap_or(0);
@@ -300,7 +306,9 @@ pub async fn load_candidates<P: EntryProcessor>(
             batch.push(buf.clone());
 
             // Flush batch when it reaches the target size
-            if batch.len() >= BATCH_SIZE {
+            if batch.len() >= BATCH_SIZE
+                || last_flush.elapsed() >= UPDATE_INTERVAL
+            {
                 if flush_handles.len() >= MAX_CONCURRENT_FLUSHES {
                     // Wait for any task to complete
                     let _ = flush_handles.join_next().await;
@@ -316,6 +324,7 @@ pub async fn load_candidates<P: EntryProcessor>(
                     flush_batch(batch_to_flush, &inj, &proc, delimiter);
                 });
                 produced_output = true;
+                last_flush = Instant::now();
             }
         }
 
@@ -374,6 +383,7 @@ pub async fn load_stdin_candidates<P: EntryProcessor>(
         .map(|d| *d as u8)
         .unwrap_or(DEFAULT_DELIMITER);
 
+    let mut last_flush = Instant::now();
     while {
         buf.clear();
         let n = reader.read_until(delimiter, &mut buf).await.unwrap_or(0);
@@ -381,7 +391,8 @@ pub async fn load_stdin_candidates<P: EntryProcessor>(
     } {
         batch.push(buf.clone());
 
-        if batch.len() >= BATCH_SIZE {
+        if batch.len() >= BATCH_SIZE || last_flush.elapsed() >= UPDATE_INTERVAL
+        {
             if flush_handles.len() >= MAX_CONCURRENT_FLUSHES {
                 let _ = flush_handles.join_next().await;
             }
@@ -393,6 +404,7 @@ pub async fn load_stdin_candidates<P: EntryProcessor>(
             flush_handles.spawn_blocking(move || {
                 flush_batch(batch_to_flush, &inj, &proc, delimiter);
             });
+            last_flush = Instant::now();
         }
     }
 

--- a/tests/cli/selection.rs
+++ b/tests/cli/selection.rs
@@ -100,6 +100,28 @@ fn test_take_1_fast_auto_selects_first_entry_immediately() {
     );
 }
 
+/// Tests that `--take-1` can return before source completion when entries are flushed
+/// periodically.
+#[test]
+fn test_take_1_fast_flushes_before_source_completion() {
+    use std::time::Duration;
+
+    let mut tester = PtyTester::new();
+
+    let cmd = tv_local_config_and_cable_with_args(&[
+        "--source-command",
+        "sleep 0.2 ; echo UNIQUE16CHARID_FIRST ; sleep 4 ; echo UNIQUE16CHARID_SECOND",
+        "--take-1",
+    ]);
+    tester.spawn_command(cmd);
+
+    // Should appear before the source command finishes sleeping.
+    tester.assert_raw_output_contains_with_timeout(
+        "UNIQUE16CHARID_FIRST",
+        Duration::from_secs(3),
+    );
+}
+
 /// Tests that --select-1 and --take-1 cannot be used together.
 #[test]
 fn test_select_1_and_take_1_conflict_errors() {


### PR DESCRIPTION
## 📺 PR Description

This PR improves candidate streaming responsiveness by flushing batches not only when they reach the large batch size threshold, but also when a fixed time interval elapses.

### What changed
- Added a time-based flush interval (`200ms`) for candidate ingestion.
- Kept the existing size-based flush behavior (`BATCH_SIZE`) intact.
- Applied this behavior consistently to both command-based candidate loading and stdin candidate loading.


### Why
Previously, output was primarily flushed on large batch boundaries (or at end-of-stream), which could delay visible updates for slower or incremental sources.  
This change improves perceived responsiveness by delivering partial results earlier while preserving throughput behavior for large streams.
### Notes
- This is intended as a UX/performance improvement for streaming and ad-hoc command scenarios.

## Checklist

- [X] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [X] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [X] I have added a reasonable amount of documentation to the code where appropriate
