### PR TITLE
feat: add custom source command names for multi-source channels

### DIFF
--- a/benches/main/previewer.rs
+++ b/benches/main/previewer.rs
@@ -1,5 +1,4 @@
 use criterion::{Criterion, criterion_group};
-use rustc_hash::FxHashMap;
 use std::hint::black_box;
 use television::{
     channels::{
@@ -11,8 +10,7 @@ use television::{
 use tokio::sync::mpsc;
 
 fn make_command(cmd: &str) -> CommandSpec {
-    let template = Template::parse(cmd).unwrap();
-    CommandSpec::new(vec![template], false, FxHashMap::default(), None)
+    CommandSpec::from(Template::parse(cmd).unwrap())
 }
 
 fn bench_preview(

--- a/cable/unix/brew-packages.toml
+++ b/cable/unix/brew-packages.toml
@@ -5,8 +5,8 @@ requirements = ["brew"]
 
 [source]
 command = [
-  "brew list --formula",
-  "brew list --cask",
+  { name = "Formulae", run = "brew list --formula" },
+  { name = "Casks",    run = "brew list --cask" },
 ]
 
 [preview]

--- a/cable/unix/dirs.toml
+++ b/cable/unix/dirs.toml
@@ -4,7 +4,10 @@ description = "A channel to select from directories"
 requirements = ["fd"]
 
 [source]
-command = ["fd -t d", "fd -t d --hidden"]
+command = [
+  { name = "Default", run = "fd -t d" },
+  { name = "Hidden",  run = "fd -t d --hidden" },
+]
 
 [preview]
 command = "ls -la --color=always '{}'"

--- a/cable/unix/docker-containers.toml
+++ b/cable/unix/docker-containers.toml
@@ -5,8 +5,8 @@ requirements = ["docker", "jq"]
 
 [source]
 command = [
-  "docker ps --format '{{.Names}}\\t{{.Image}}\\t{{.Status}}'",
-  "docker ps -a --format '{{.Names}}\\t{{.Image}}\\t{{.Status}}'",
+  { name = "Running", run = "docker ps --format '{{.Names}}\\t{{.Image}}\\t{{.Status}}'" },
+  { name = "All",     run = "docker ps -a --format '{{.Names}}\\t{{.Image}}\\t{{.Status}}'" },
 ]
 display = "{split:\\t:0} ({split:\\t:2})"
 output = "{split:\\t:0}"

--- a/cable/unix/files.toml
+++ b/cable/unix/files.toml
@@ -4,7 +4,10 @@ description = "A channel to select files and directories"
 requirements = ["fd", "bat"]
 
 [source]
-command = ["fd -t f", "fd -t f -H"]
+command = [
+  { name = "Default", run = "fd -t f" },
+  { name = "Hidden",  run = "fd -t f -H" },
+]
 
 [preview]
 command = "bat -n --color=always '{}'"

--- a/cable/unix/images.toml
+++ b/cable/unix/images.toml
@@ -5,8 +5,8 @@ requirements = ["fd", "chafa"]
 
 [source]
 command = [
-  "fd -t f -e png -e jpg -e jpeg -e gif -e webp -e bmp -e svg .",
-  "fd -t f -e png -e jpg -e jpeg -e gif -e webp -e bmp -e svg -H .",
+  { name = "Default", run = "fd -t f -e png -e jpg -e jpeg -e gif -e webp -e bmp -e svg ." },
+  { name = "Hidden",  run = "fd -t f -e png -e jpg -e jpeg -e gif -e webp -e bmp -e svg -H ." },
 ]
 
 [preview]

--- a/cable/unix/k8s-deployments.toml
+++ b/cable/unix/k8s-deployments.toml
@@ -11,15 +11,19 @@ Press `ctrl-d` to delete the selected Deployment.
 requirements = ["kubectl"]
 
 [source]
-command = [
-  '''
-  kubectl get deployments -o go-template --template '{{range .items}}{{.metadata.namespace}} {{.metadata.name}}{{"\n"}}{{end}}'
-  ''',
-  '''
-  kubectl get deployments -o go-template --template '{{range .items}}{{.metadata.namespace}} {{.metadata.name}}{{"\n"}}{{end}}' --all-namespaces
-  ''',
-]
 output = "{1}"
+
+[[source.command]]
+name = "Current ns"
+run = '''
+kubectl get deployments -o go-template --template '{{range .items}}{{.metadata.namespace}} {{.metadata.name}}{{"\n"}}{{end}}'
+'''
+
+[[source.command]]
+name = "All namespaces"
+run = '''
+kubectl get deployments -o go-template --template '{{range .items}}{{.metadata.namespace}} {{.metadata.name}}{{"\n"}}{{end}}' --all-namespaces
+'''
 
 [preview]
 command = "kubectl describe -n {0} deployments/{1}"

--- a/cable/unix/k8s-pods.toml
+++ b/cable/unix/k8s-pods.toml
@@ -13,15 +13,19 @@ Press `ctrl-l` to print and follow the logs of the selected Pod.
 requirements = ["kubectl"]
 
 [source]
-command = [
-  '''
-  kubectl get pods -o go-template --template '{{range .items}}{{.metadata.namespace}} {{.metadata.name}}{{"\n"}}{{end}}'
-  ''',
-  '''
-  kubectl get pods -o go-template --template '{{range .items}}{{.metadata.namespace}} {{.metadata.name}}{{"\n"}}{{end}}' --all-namespaces
-  ''',
-]
 output = "{1}"
+
+[[source.command]]
+name = "Current ns"
+run = '''
+kubectl get pods -o go-template --template '{{range .items}}{{.metadata.namespace}} {{.metadata.name}}{{"\n"}}{{end}}'
+'''
+
+[[source.command]]
+name = "All namespaces"
+run = '''
+kubectl get pods -o go-template --template '{{range .items}}{{.metadata.namespace}} {{.metadata.name}}{{"\n"}}{{end}}' --all-namespaces
+'''
 
 [preview]
 command = "kubectl describe -n {0} pods/{1}"

--- a/cable/unix/k8s-services.toml
+++ b/cable/unix/k8s-services.toml
@@ -11,15 +11,19 @@ Press `ctrl-d` to delete the selected Service.
 requirements = ["kubectl"]
 
 [source]
-command = [
-  '''
-  kubectl get services -o go-template --template '{{range .items}}{{.metadata.namespace}} {{.metadata.name}}{{"\n"}}{{end}}'
-  ''',
-  '''
-  kubectl get services -o go-template --template '{{range .items}}{{.metadata.namespace}} {{.metadata.name}}{{"\n"}}{{end}}' --all-namespaces
-  ''',
-]
 output = "{1}"
+
+[[source.command]]
+name = "Current ns"
+run = '''
+kubectl get services -o go-template --template '{{range .items}}{{.metadata.namespace}} {{.metadata.name}}{{"\n"}}{{end}}'
+'''
+
+[[source.command]]
+name = "All namespaces"
+run = '''
+kubectl get services -o go-template --template '{{range .items}}{{.metadata.namespace}} {{.metadata.name}}{{"\n"}}{{end}}' --all-namespaces
+'''
 
 [preview]
 command = "kubectl describe -n {0} services/{1}"

--- a/cable/unix/pdf-files.toml
+++ b/cable/unix/pdf-files.toml
@@ -5,8 +5,8 @@ requirements = ["fd", "pdftotext"]
 
 [source]
 command = [
-  "fd -t f -e pdf .",
-  "fd -t f -e pdf -H .",
+  { name = "Default", run = "fd -t f -e pdf ." },
+  { name = "Hidden",  run = "fd -t f -e pdf -H ." },
 ]
 
 [preview]

--- a/cable/unix/podman-containers.toml
+++ b/cable/unix/podman-containers.toml
@@ -5,8 +5,8 @@ requirements = ["podman", "jq"]
 
 [source]
 command = [
-  "podman ps --format '{{.Names}}\t{{.Image}}\t{{.Status}}'",
-  "podman ps -a --format '{{.Names}}\t{{.Image}}\t{{.Status}}'",
+  { name = "Running", run = "podman ps --format '{{.Names}}\t{{.Image}}\t{{.Status}}'" },
+  { name = "All",     run = "podman ps -a --format '{{.Names}}\t{{.Image}}\t{{.Status}}'" },
 ]
 display = "{split:\t:0} ({split:\t:2})"
 output = "{split:\t:0}"

--- a/cable/unix/recent-files.toml
+++ b/cable/unix/recent-files.toml
@@ -5,8 +5,8 @@ requirements = ["git", "bat"]
 
 [source]
 command = [
-  "git diff --name-only HEAD~10 HEAD 2>/dev/null || find . -type f -mtime -7 -not -path '*/.*' 2>/dev/null | head -100",
-  "find . -type f -mmin -60 -not -path '*/.*' 2>/dev/null | head -100",
+  { name = "Recent",    run = "git diff --name-only HEAD~10 HEAD 2>/dev/null || find . -type f -mtime -7 -not -path '*/.*' 2>/dev/null | head -100" },
+  { name = "Last hour", run = "find . -type f -mmin -60 -not -path '*/.*' 2>/dev/null | head -100" },
 ]
 
 [preview]

--- a/cable/unix/sesh.toml
+++ b/cable/unix/sesh.toml
@@ -10,11 +10,11 @@ requirements = ["sesh", "fd"]
 # Multiple source commands for cycling through different modes
 # Press Ctrl+S to cycle between sources
 command = [
-  "sesh list --icons",             # all sessions (default)
-  "sesh list -t --icons",          # tmux sessions only
-  "sesh list -c --icons",          # config directories
-  "sesh list -z --icons",          # zoxide directories
-  "fd -H -d 2 -t d -E .Trash . ~", # find directories
+  { name = "All",         run = "sesh list --icons" },
+  { name = "Tmux",        run = "sesh list -t --icons" },
+  { name = "Configs",     run = "sesh list -c --icons" },
+  { name = "Zoxide",      run = "sesh list -z --icons" },
+  { name = "Directories", run = "fd -H -d 2 -t d -E .Trash . ~" },
 ]
 ansi = true
 frecency = false # handled by sesh

--- a/cable/unix/systemd-units.toml
+++ b/cable/unix/systemd-units.toml
@@ -5,8 +5,8 @@ requirements = ["systemctl"]
 
 [source]
 command = [
-  "systemctl list-units --type=service --no-pager --no-legend --plain",
-  "systemctl list-units --type=service --all --no-pager --no-legend --plain",
+  { name = "Active", run = "systemctl list-units --type=service --no-pager --no-legend --plain" },
+  { name = "All",    run = "systemctl list-units --type=service --all --no-pager --no-legend --plain" },
 ]
 display = "{split: :0}"
 

--- a/cable/unix/text.toml
+++ b/cable/unix/text.toml
@@ -5,8 +5,8 @@ requirements = ["rg", "bat"]
 
 [source]
 command = [
-  "rg . --no-heading --line-number --colors 'match:fg:white' --colors 'path:fg:blue' --color=always",
-  "rg . --no-heading --line-number --hidden --colors 'match:fg:white' --colors 'path:fg:blue' --color=always",
+  { name = "Default", run = "rg . --no-heading --line-number --colors 'match:fg:white' --colors 'path:fg:blue' --color=always" },
+  { name = "Hidden",  run = "rg . --no-heading --line-number --hidden --colors 'match:fg:white' --colors 'path:fg:blue' --color=always" },
 ]
 ansi = true
 output = "{strip_ansi|split:\\::..2}"

--- a/cable/windows/dirs.toml
+++ b/cable/windows/dirs.toml
@@ -4,7 +4,10 @@ description = "A channel to select from directories"
 requirements = ["fd"]
 
 [source]
-command = ["fd -t d", "fd -t d --hidden"]
+command = [
+  { name = "Default", run = "fd -t d" },
+  { name = "Hidden",  run = "fd -t d --hidden" },
+]
 
 [preview]
 command = "ls -l '{}'"

--- a/cable/windows/files.toml
+++ b/cable/windows/files.toml
@@ -4,7 +4,10 @@ description = "A channel to select files and directories"
 requirements = ["fd", "bat"]
 
 [source]
-command = ["fd -t f", "fd -t f -H"]
+command = [
+  { name = "Default", run = "fd -t f" },
+  { name = "Hidden",  run = "fd -t f -H" },
+]
 
 [preview]
 command = "bat -n --color=always -- '{}'"

--- a/docs/reference/03-channel-spec.md
+++ b/docs/reference/03-channel-spec.md
@@ -56,6 +56,7 @@ Defines what data the channel searches through.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `command` | string or string[] | Yes | Command(s) that produce entries |
+| `command_name` | string or string[] | No | Display name(s) for source commands, shown in the results panel header when cycling |
 | `ansi` | boolean | No | Parse ANSI escape codes (default: false) |
 | `display` | string | No | Template for display (incompatible with `ansi = true`) |
 | `output` | string | No | Template for final output |
@@ -77,6 +78,18 @@ command = "fd -t f"
 [source]
 command = ["fd -t f", "fd -t f -H", "fd -t f -H -I"]
 # Press Ctrl+S to cycle between commands
+```
+
+### Named Source Commands
+
+When using multiple source commands, you can give each one a display name.
+The name replaces the generic "Results" label in the results panel header,
+making it easy to see which source is active.
+
+```toml
+[source]
+command = ["fd -t f", "fd -t f -H", "fd -t f -H -I"]
+command_name = ["Default", "Hidden", "All"]
 ```
 
 ### With ANSI Colors
@@ -354,6 +367,7 @@ requirements = ["docker"]
 [source]
 command = ["docker ps --format '{{.ID}}\\t{{.Names}}\\t{{.Status}}'",
            "docker ps -a --format '{{.ID}}\\t{{.Names}}\\t{{.Status}}'"]
+command_name = ["Running", "All"]
 display = "{split:\\t:1} | {split:\\t:2}"
 output = "{split:\\t:0}"
 

--- a/docs/reference/03-channel-spec.md
+++ b/docs/reference/03-channel-spec.md
@@ -55,8 +55,7 @@ Defines what data the channel searches through.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `command` | string or string[] | Yes | Command(s) that produce entries |
-| `command_name` | string or string[] | No | Display name(s) for source commands, shown in the results panel header when cycling |
+| `command` | string, string[], `{name, run}`, or array thereof | Yes | Command(s) that produce entries. Entries may be bare strings or `{ name = "...", run = "..." }` tables; names appear in the results panel header when cycling |
 | `ansi` | boolean | No | Parse ANSI escape codes (default: false) |
 | `display` | string | No | Template for display (incompatible with `ansi = true`) |
 | `output` | string | No | Template for final output |
@@ -82,14 +81,19 @@ command = ["fd -t f", "fd -t f -H", "fd -t f -H -I"]
 
 ### Named Source Commands
 
-When using multiple source commands, you can give each one a display name.
-The name replaces the generic "Results" label in the results panel header,
-making it easy to see which source is active.
+When using multiple source commands, you can give each one a display name by
+writing entries as `{ name, run }` tables instead of bare strings. The name
+replaces the generic "Results" label in the results panel header, making it
+easy to see which source is active. Named and unnamed entries can be mixed
+within the same array.
 
 ```toml
 [source]
-command = ["fd -t f", "fd -t f -H", "fd -t f -H -I"]
-command_name = ["Default", "Hidden", "All"]
+command = [
+    { name = "Default", run = "fd -t f" },
+    { name = "Hidden",  run = "fd -t f -H" },
+    { name = "All",     run = "fd -t f -H -I" },
+]
 ```
 
 ### With ANSI Colors
@@ -365,9 +369,10 @@ description = "Manage Docker containers"
 requirements = ["docker"]
 
 [source]
-command = ["docker ps --format '{{.ID}}\\t{{.Names}}\\t{{.Status}}'",
-           "docker ps -a --format '{{.ID}}\\t{{.Names}}\\t{{.Status}}'"]
-command_name = ["Running", "All"]
+command = [
+    { name = "Running", run = "docker ps --format '{{.ID}}\\t{{.Names}}\\t{{.Status}}'" },
+    { name = "All",     run = "docker ps -a --format '{{.ID}}\\t{{.Names}}\\t{{.Status}}'" },
+]
 display = "{split:\\t:1} | {split:\\t:2}"
 output = "{split:\\t:0}"
 

--- a/television/channels/action_picker.rs
+++ b/television/channels/action_picker.rs
@@ -33,7 +33,7 @@ impl ActionEntry {
             .command
             .inner
             .iter()
-            .map(|t| t.raw().to_string())
+            .map(|c| c.template().raw().to_string())
             .collect();
         ActionEntry {
             action_string: format!("{}{}", CUSTOM_ACTION_PREFIX, action_name),

--- a/television/channels/channel.rs
+++ b/television/channels/channel.rs
@@ -155,6 +155,10 @@ impl<P: EntryProcessor> Channel<P> {
         self.source_command.get_nth(self.current_source_index).raw()
     }
 
+    pub fn current_source_name(&self) -> Option<&str> {
+        self.source_command.get_name(self.current_source_index)
+    }
+
     pub fn find(&mut self, pattern: &str) {
         self.matcher.find(pattern);
     }
@@ -581,6 +585,7 @@ impl ChannelKind {
     // Generate all immutable delegation methods
     delegate_to_channel!(ref
         current_command() -> &str,
+        current_source_name() -> Option<&str>,
         selected_entries() -> &FxHashSet<Entry>,
         result_count() -> u32,
         total_count() -> u32,

--- a/television/channels/channel.rs
+++ b/television/channels/channel.rs
@@ -152,11 +152,16 @@ impl<P: EntryProcessor> Channel<P> {
     }
 
     pub fn current_command(&self) -> &str {
-        self.source_command.get_nth(self.current_source_index).raw()
+        self.source_command
+            .get_nth(self.current_source_index)
+            .template()
+            .raw()
     }
 
     pub fn current_source_name(&self) -> Option<&str> {
-        self.source_command.get_name(self.current_source_index)
+        self.source_command
+            .get_nth(self.current_source_index)
+            .name()
     }
 
     pub fn find(&mut self, pattern: &str) {
@@ -279,7 +284,7 @@ pub async fn load_candidates<P: EntryProcessor>(
 ) {
     debug!("Loading candidates from command: {:?}", command);
     let mut std_command = shell_command(
-        command.get_nth(command_index).raw(),
+        command.get_nth(command_index).template().raw(),
         command.interactive,
         &command.env,
         command.shell,

--- a/television/channels/prototypes.rs
+++ b/television/channels/prototypes.rs
@@ -106,6 +106,12 @@ pub struct CommandSpec {
     #[serde(rename = "command")]
     #[serde_as(as = "OneOrMany<_>")]
     pub inner: Vec<Template>,
+    /// Optional display names for each source command.
+    /// When multiple source commands are defined, these names are shown
+    /// in the results panel header instead of generic dot indicators.
+    #[serde(default)]
+    #[serde_as(as = "Option<OneOrMany<_>>")]
+    pub command_name: Option<Vec<String>>,
     #[serde(default)]
     pub interactive: bool,
     #[serde(default)]
@@ -145,6 +151,7 @@ impl CommandSpec {
     ) -> Self {
         Self {
             inner,
+            command_name: None,
             interactive,
             env,
             shell,
@@ -165,6 +172,16 @@ impl CommandSpec {
     /// If the command spec does not contain any commands.
     pub fn get_nth(&self, index: usize) -> &Template {
         &self.inner[index % self.inner.len()]
+    }
+
+    /// Get the display name for the source command at the given index.
+    ///
+    /// Returns `None` if no custom names are defined or the index has no name.
+    pub fn get_name(&self, index: usize) -> Option<&str> {
+        self.command_name
+            .as_ref()
+            .and_then(|names| names.get(index % self.inner.len()))
+            .map(String::as_str)
     }
 
     pub fn from_template(template: Template) -> Self {
@@ -263,6 +280,7 @@ impl ChannelPrototype {
                         Template::parse(command)
                             .expect("Failed to parse command"),
                     ],
+                    command_name: None,
                     interactive: false,
                     env: FxHashMap::default(),
                     shell: None,
@@ -444,6 +462,7 @@ impl PreviewSpec {
                     Template::parse(command)
                         .expect("Failed to parse preview command"),
                 ],
+                command_name: None,
                 interactive: false,
                 env: FxHashMap::default(),
                 shell: None,
@@ -517,6 +536,7 @@ mod tests {
                 Template::parse("cmd2").unwrap(),
                 Template::parse("cmd3").unwrap(),
             ],
+            command_name: None,
             interactive: false,
             env: FxHashMap::default(),
             shell: None,
@@ -739,6 +759,67 @@ mod tests {
         assert!(!prototype.source.command.interactive);
         assert!(prototype.source.command.env.is_empty());
         assert_eq!(prototype.source.output.unwrap().raw(), "{}");
+        assert!(prototype.source.command.command_name.is_none());
+    }
+
+    #[test]
+    fn test_channel_prototype_deserialization_multiple_commands_with_names() {
+        let toml_data = r#"
+        [metadata]
+        name = "files"
+        description = "A channel to select files and directories"
+
+        [source]
+        command = ["fd -t f", "fd -t f --hidden", "fd -t f --no-ignore"]
+        command_name = ["Default", "Hidden", "All"]
+        "#;
+
+        let prototype: ChannelPrototype = from_str(toml_data).unwrap();
+
+        let names = prototype.source.command.command_name.as_ref().unwrap();
+        assert_eq!(names, &["Default", "Hidden", "All"]);
+        assert_eq!(prototype.source.command.get_name(0), Some("Default"));
+        assert_eq!(prototype.source.command.get_name(1), Some("Hidden"));
+        assert_eq!(prototype.source.command.get_name(2), Some("All"));
+        // wraps around
+        assert_eq!(prototype.source.command.get_name(3), Some("Default"));
+    }
+
+    #[test]
+    fn test_channel_prototype_deserialization_single_command_name() {
+        let toml_data = r#"
+        [metadata]
+        name = "files"
+        description = "A channel"
+
+        [source]
+        command = "fd -t f"
+        command_name = "All Files"
+        "#;
+
+        let prototype: ChannelPrototype = from_str(toml_data).unwrap();
+
+        let names = prototype.source.command.command_name.as_ref().unwrap();
+        assert_eq!(names, &["All Files"]);
+        assert_eq!(prototype.source.command.get_name(0), Some("All Files"));
+    }
+
+    #[test]
+    fn test_channel_prototype_deserialization_no_command_names() {
+        let toml_data = r#"
+        [metadata]
+        name = "files"
+        description = "A channel"
+
+        [source]
+        command = ["fd -t f", "fd -t f --hidden"]
+        "#;
+
+        let prototype: ChannelPrototype = from_str(toml_data).unwrap();
+
+        assert!(prototype.source.command.command_name.is_none());
+        assert_eq!(prototype.source.command.get_name(0), None);
+        assert_eq!(prototype.source.command.get_name(1), None);
     }
 
     #[test]

--- a/television/channels/prototypes.rs
+++ b/television/channels/prototypes.rs
@@ -98,6 +98,41 @@ impl<'de> Deserialize<'de> for Template {
     }
 }
 
+/// A single source command, optionally with a display name.
+///
+/// Accepts two TOML forms in arrays/single values:
+/// - Bare string: `"fd -t f"` — no display name.
+/// - Inline table: `{ name = "Default", run = "fd -t f" }` — named.
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize, PartialEq)]
+#[serde(untagged)]
+pub enum SourceCommand {
+    Bare(Template),
+    Named { name: String, run: Template },
+}
+
+impl SourceCommand {
+    pub fn template(&self) -> &Template {
+        match self {
+            Self::Bare(t) | Self::Named { run: t, .. } => t,
+        }
+    }
+
+    pub fn name(&self) -> Option<&str> {
+        match self {
+            Self::Named { name, .. } if !name.is_empty() => {
+                Some(name.as_str())
+            }
+            _ => None,
+        }
+    }
+}
+
+impl From<Template> for SourceCommand {
+    fn from(template: Template) -> Self {
+        Self::Bare(template)
+    }
+}
+
 #[serde_as]
 #[derive(
     Debug, Clone, serde::Deserialize, serde::Serialize, PartialEq, Default,
@@ -105,13 +140,7 @@ impl<'de> Deserialize<'de> for Template {
 pub struct CommandSpec {
     #[serde(rename = "command")]
     #[serde_as(as = "OneOrMany<_>")]
-    pub inner: Vec<Template>,
-    /// Optional display names for each source command.
-    /// When multiple source commands are defined, these names are shown
-    /// in the results panel header instead of generic dot indicators.
-    #[serde(default)]
-    #[serde_as(as = "Option<OneOrMany<_>>")]
-    pub command_name: Option<Vec<String>>,
+    pub inner: Vec<SourceCommand>,
     #[serde(default)]
     pub interactive: bool,
     #[serde(default)]
@@ -129,7 +158,7 @@ impl Display for CommandSpec {
             "[{}]",
             self.inner
                 .iter()
-                .map(Template::raw)
+                .map(|c| c.template().raw())
                 .collect::<Vec<_>>()
                 .join(";")
         )
@@ -138,54 +167,20 @@ impl Display for CommandSpec {
 
 impl From<Template> for CommandSpec {
     fn from(template: Template) -> Self {
-        Self::new(vec![template], false, FxHashMap::default(), None)
+        Self {
+            inner: vec![template.into()],
+            ..Default::default()
+        }
     }
 }
 
 impl CommandSpec {
-    pub fn new(
-        inner: Vec<Template>,
-        interactive: bool,
-        env: FxHashMap<String, String>,
-        shell: Option<Shell>,
-    ) -> Self {
-        Self {
-            inner,
-            command_name: None,
-            interactive,
-            env,
-            shell,
-        }
-    }
-
-    pub fn command_count(&self) -> usize {
-        self.inner.len()
-    }
-
-    pub fn has_multiple_commands(&self) -> bool {
-        self.inner.len() > 1
-    }
-
     /// This wraps back to the first command in a circular manner.
     ///
     /// # Panics
     /// If the command spec does not contain any commands.
-    pub fn get_nth(&self, index: usize) -> &Template {
+    pub fn get_nth(&self, index: usize) -> &SourceCommand {
         &self.inner[index % self.inner.len()]
-    }
-
-    /// Get the display name for the source command at the given index.
-    ///
-    /// Returns `None` if no custom names are defined or the index has no name.
-    pub fn get_name(&self, index: usize) -> Option<&str> {
-        self.command_name
-            .as_ref()
-            .and_then(|names| names.get(index % self.inner.len()))
-            .map(String::as_str)
-    }
-
-    pub fn from_template(template: Template) -> Self {
-        Self::new(vec![template], false, FxHashMap::default(), None)
     }
 }
 
@@ -278,9 +273,9 @@ impl ChannelPrototype {
                 command: CommandSpec {
                     inner: vec![
                         Template::parse(command)
-                            .expect("Failed to parse command"),
+                            .expect("Failed to parse command")
+                            .into(),
                     ],
-                    command_name: None,
                     interactive: false,
                     env: FxHashMap::default(),
                     shell: None,
@@ -315,7 +310,7 @@ impl ChannelPrototype {
                 // read directly from process stdin in Rust. We keep a no-op
                 // placeholder because the field is required.
                 command: CommandSpec {
-                    inner: vec![Template::parse("true").unwrap()],
+                    inner: vec![Template::parse("true").unwrap().into()],
                     ..Default::default()
                 },
                 ..Default::default()
@@ -460,9 +455,9 @@ impl PreviewSpec {
             command: CommandSpec {
                 inner: vec![
                     Template::parse(command)
-                        .expect("Failed to parse preview command"),
+                        .expect("Failed to parse preview command")
+                        .into(),
                 ],
-                command_name: None,
                 interactive: false,
                 env: FxHashMap::default(),
                 shell: None,
@@ -532,20 +527,19 @@ mod tests {
     fn test_command_spec_get_nth() {
         let command_spec = CommandSpec {
             inner: vec![
-                Template::parse("cmd1").unwrap(),
-                Template::parse("cmd2").unwrap(),
-                Template::parse("cmd3").unwrap(),
+                Template::parse("cmd1").unwrap().into(),
+                Template::parse("cmd2").unwrap().into(),
+                Template::parse("cmd3").unwrap().into(),
             ],
-            command_name: None,
             interactive: false,
             env: FxHashMap::default(),
             shell: None,
         };
 
-        assert_eq!(command_spec.get_nth(0).raw(), "cmd1");
-        assert_eq!(command_spec.get_nth(1).raw(), "cmd2");
-        assert_eq!(command_spec.get_nth(2).raw(), "cmd3");
-        assert_eq!(command_spec.get_nth(3).raw(), "cmd1"); // wraps around
+        assert_eq!(command_spec.get_nth(0).template().raw(), "cmd1");
+        assert_eq!(command_spec.get_nth(1).template().raw(), "cmd2");
+        assert_eq!(command_spec.get_nth(2).template().raw(), "cmd3");
+        assert_eq!(command_spec.get_nth(3).template().raw(), "cmd1"); // wraps around
     }
 
     #[test]
@@ -646,7 +640,7 @@ mod tests {
             Some("A channel to select files and directories".to_string())
         );
         assert_eq!(
-            format!("{}", prototype.source.command.inner[0]),
+            format!("{}", prototype.source.command.inner[0].template()),
             "fd -t f"
         );
 
@@ -656,7 +650,7 @@ mod tests {
 
         let preview = prototype.preview.as_ref().unwrap();
         assert_eq!(
-            format!("{}", preview.command.inner[0]),
+            format!("{}", preview.command.inner[0].template()),
             "bat -n --color=always {}"
         );
         assert!(!preview.command.interactive);
@@ -752,74 +746,92 @@ mod tests {
                 .command
                 .inner
                 .iter()
-                .map(Template::raw)
+                .map(|c| c.template().raw())
                 .collect::<Vec<_>>(),
             vec!["fd -t f", "fd -t f --hidden"]
         );
         assert!(!prototype.source.command.interactive);
         assert!(prototype.source.command.env.is_empty());
         assert_eq!(prototype.source.output.unwrap().raw(), "{}");
-        assert!(prototype.source.command.command_name.is_none());
+        assert_eq!(prototype.source.command.inner[0].name(), None);
+        assert_eq!(prototype.source.command.inner[1].name(), None);
     }
 
     #[test]
-    fn test_channel_prototype_deserialization_multiple_commands_with_names() {
+    fn test_channel_prototype_deserialization_named_commands() {
         let toml_data = r#"
         [metadata]
         name = "files"
         description = "A channel to select files and directories"
 
         [source]
-        command = ["fd -t f", "fd -t f --hidden", "fd -t f --no-ignore"]
-        command_name = ["Default", "Hidden", "All"]
+        command = [
+            { name = "Default", run = "fd -t f" },
+            { name = "Hidden", run = "fd -t f --hidden" },
+            { name = "All", run = "fd -t f --no-ignore" },
+        ]
         "#;
 
         let prototype: ChannelPrototype = from_str(toml_data).unwrap();
 
-        let names = prototype.source.command.command_name.as_ref().unwrap();
-        assert_eq!(names, &["Default", "Hidden", "All"]);
-        assert_eq!(prototype.source.command.get_name(0), Some("Default"));
-        assert_eq!(prototype.source.command.get_name(1), Some("Hidden"));
-        assert_eq!(prototype.source.command.get_name(2), Some("All"));
-        // wraps around
-        assert_eq!(prototype.source.command.get_name(3), Some("Default"));
+        assert_eq!(
+            prototype.source.command.get_nth(0).template().raw(),
+            "fd -t f"
+        );
+        assert_eq!(prototype.source.command.inner[0].name(), Some("Default"));
+        assert_eq!(prototype.source.command.inner[1].name(), Some("Hidden"));
+        assert_eq!(prototype.source.command.inner[2].name(), Some("All"));
     }
 
     #[test]
-    fn test_channel_prototype_deserialization_single_command_name() {
+    fn test_channel_prototype_deserialization_single_named_command() {
         let toml_data = r#"
         [metadata]
         name = "files"
         description = "A channel"
 
         [source]
-        command = "fd -t f"
-        command_name = "All Files"
+        command = { name = "All Files", run = "fd -t f" }
         "#;
 
         let prototype: ChannelPrototype = from_str(toml_data).unwrap();
 
-        let names = prototype.source.command.command_name.as_ref().unwrap();
-        assert_eq!(names, &["All Files"]);
-        assert_eq!(prototype.source.command.get_name(0), Some("All Files"));
+        assert_eq!(
+            prototype.source.command.get_nth(0).template().raw(),
+            "fd -t f"
+        );
+        assert_eq!(
+            prototype.source.command.inner[0].name(),
+            Some("All Files")
+        );
     }
 
     #[test]
-    fn test_channel_prototype_deserialization_no_command_names() {
+    fn test_channel_prototype_deserialization_mixed_named_and_bare() {
         let toml_data = r#"
         [metadata]
         name = "files"
         description = "A channel"
 
         [source]
-        command = ["fd -t f", "fd -t f --hidden"]
+        command = [
+            "fd -t f",
+            { name = "Hidden", run = "fd -t f --hidden" },
+        ]
         "#;
 
         let prototype: ChannelPrototype = from_str(toml_data).unwrap();
 
-        assert!(prototype.source.command.command_name.is_none());
-        assert_eq!(prototype.source.command.get_name(0), None);
-        assert_eq!(prototype.source.command.get_name(1), None);
+        assert_eq!(
+            prototype.source.command.get_nth(0).template().raw(),
+            "fd -t f"
+        );
+        assert_eq!(prototype.source.command.inner[0].name(), None);
+        assert_eq!(
+            prototype.source.command.get_nth(1).template().raw(),
+            "fd -t f --hidden"
+        );
+        assert_eq!(prototype.source.command.inner[1].name(), Some("Hidden"));
     }
 
     #[test]
@@ -842,7 +854,7 @@ mod tests {
             Some("A channel to select files and directories".to_string())
         );
         assert_eq!(
-            format!("{}", prototype.source.command.inner[0]),
+            format!("{}", prototype.source.command.inner[0].template()),
             "fd -t f"
         );
         assert!(!prototype.source.command.interactive);
@@ -884,7 +896,7 @@ mod tests {
             Some("A channel to select files and directories".to_string())
         );
         assert_eq!(
-            format!("{}", prototype.source.command.inner[0]),
+            format!("{}", prototype.source.command.inner[0].template()),
             "fd -t f"
         );
         assert!(!prototype.source.command.interactive);
@@ -959,7 +971,7 @@ mod tests {
         // Verify edit action
         let thebatman = prototype.actions.get("thebatman").unwrap();
         assert_eq!(thebatman.description, Some("cats the file".to_string()));
-        assert_eq!(thebatman.command.inner[0].raw(), "bat '{}'");
+        assert_eq!(thebatman.command.inner[0].template().raw(), "bat '{}'");
         assert_eq!(
             thebatman.command.env.get("BAT_THEME"),
             Some(&"ansi".to_string())
@@ -968,7 +980,7 @@ mod tests {
         // Verify lsman action
         let lsman = prototype.actions.get("lsman").unwrap();
         assert_eq!(lsman.description, Some("show stats".to_string()));
-        assert_eq!(lsman.command.inner[0].raw(), "ls '{}'");
+        assert_eq!(lsman.command.inner[0].template().raw(), "ls '{}'");
         assert!(lsman.command.env.is_empty());
 
         // Verify keybindings reference the actions

--- a/television/config/layers.rs
+++ b/television/config/layers.rs
@@ -117,7 +117,7 @@ impl ConfigLayers {
         // Build source command and apply global shell if no channel-specific shell
         let mut channel_source_command =
             if let Some(template) = &self.channel_cli.source_command {
-                CommandSpec::from_template(template.clone())
+                CommandSpec::from(template.clone())
             } else {
                 self.channel.source.command.clone()
             };
@@ -151,7 +151,7 @@ impl ConfigLayers {
             .channel_cli
             .preview_command
             .as_ref()
-            .map(|t| CommandSpec::from_template(t.clone()))
+            .map(|t| CommandSpec::from(t.clone()))
             .or(self.channel.preview.as_ref().map(|p| p.command.clone()));
         if let Some(ref mut cmd) = channel_preview_command
             && cmd.shell.is_none()

--- a/television/draw.rs
+++ b/television/draw.rs
@@ -32,6 +32,7 @@ pub struct ChannelState {
     pub total_count: u32,
     pub running: bool,
     pub current_command: String,
+    pub current_source_name: Option<String>,
     pub source_index: usize,
     pub source_count: usize,
 }
@@ -44,6 +45,7 @@ impl ChannelState {
         total_count: u32,
         running: bool,
         current_command: String,
+        current_source_name: Option<String>,
         source_index: usize,
         source_count: usize,
     ) -> Self {
@@ -53,6 +55,7 @@ impl ChannelState {
             total_count,
             running,
             current_command,
+            current_source_name,
             source_index,
             source_count,
         }
@@ -68,6 +71,7 @@ impl Hash for ChannelState {
         self.total_count.hash(state);
         self.running.hash(state);
         self.current_command.hash(state);
+        self.current_source_name.hash(state);
         self.source_index.hash(state);
         self.source_count.hash(state);
     }
@@ -209,6 +213,7 @@ pub fn draw(ctx: Ctx, f: &mut Frame<'_>, area: Rect) -> Result<Layout> {
         &ctx.config.results_panel_border_type,
         ctx.tv_state.channel_state.source_index,
         ctx.tv_state.channel_state.source_count,
+        ctx.tv_state.channel_state.current_source_name.as_deref(),
         cycle_sources_key,
     )?;
 

--- a/television/main.rs
+++ b/television/main.rs
@@ -344,15 +344,8 @@ mod tests {
     #[test]
     fn test_determine_channel_with_cli_preview() {
         let preview_command = Template::parse("echo hello").unwrap();
-        let preview_spec = PreviewSpec::new(
-            CommandSpec::new(
-                vec![preview_command.clone()],
-                false,
-                FxHashMap::default(),
-                None,
-            ),
-            None,
-        );
+        let preview_spec =
+            PreviewSpec::new(CommandSpec::from(preview_command.clone()), None);
 
         let args = PostProcessedCli {
             channel: ChannelCli {
@@ -392,6 +385,9 @@ mod tests {
             determine_channel(&cli.channel, &config, false, &Cable::default());
 
         assert_eq!(channel.metadata.name, "Custom Channel");
-        assert_eq!(channel.source.command.inner[0].raw(), "fd -t f -H");
+        assert_eq!(
+            channel.source.command.get_nth(0).template().raw(),
+            "fd -t f -H"
+        );
     }
 }

--- a/television/previewer/mod.rs
+++ b/television/previewer/mod.rs
@@ -373,7 +373,8 @@ pub async fn try_preview(
     cache: Option<Arc<Mutex<Cache>>>,
 ) -> Result<()> {
     let preview_count = command.inner.len();
-    let formatted_command = command.get_nth(cycle_index).format(&entry.raw)?;
+    let formatted_command =
+        command.get_nth(cycle_index).template().format(&entry.raw)?;
 
     // Check if the entry is already cached
     if let Some(cache) = &cache

--- a/television/screen/results.rs
+++ b/television/screen/results.rs
@@ -27,10 +27,13 @@ pub fn draw_results_list(
     results_panel_border_type: &BorderType,
     source_index: usize,
     source_count: usize,
+    current_source_name: Option<&str>,
     cycle_key: Option<Key>,
 ) -> Result<()> {
     let title = if source_count > 1 {
-        let mut spans = vec![Span::from(" Results ")];
+        let header = current_source_name
+            .map_or_else(|| " Results ".to_string(), |name| format!(" {} ", name));
+        let mut spans = vec![Span::from(header)];
         let dots: String = (0..source_count)
             .map(|i| if i == source_index { "●" } else { "○" })
             .collect::<Vec<_>>()

--- a/television/screen/results.rs
+++ b/television/screen/results.rs
@@ -31,9 +31,12 @@ pub fn draw_results_list(
     cycle_key: Option<Key>,
 ) -> Result<()> {
     let title = if source_count > 1 {
-        let header = current_source_name
-            .map_or_else(|| " Results ".to_string(), |name| format!(" {} ", name));
-        let mut spans = vec![Span::from(header)];
+        let mut spans = match current_source_name {
+            Some(name) => {
+                vec![Span::from(" "), Span::from(name), Span::from(" ")]
+            }
+            None => vec![Span::from(" Results ")],
+        };
         let dots: String = (0..source_count)
             .map(|i| if i == source_index { "●" } else { "○" })
             .collect::<Vec<_>>()

--- a/television/television.rs
+++ b/television/television.rs
@@ -273,6 +273,7 @@ impl Television {
             self.channel.total_count(),
             self.channel.running(),
             self.channel.current_command().to_string(),
+            self.channel.current_source_name().map(str::to_string),
             self.channel.source_index(),
             self.channel.source_count(),
         );

--- a/television/utils/command.rs
+++ b/television/utils/command.rs
@@ -159,7 +159,7 @@ pub fn execute_action(
 ) -> Result<ExitStatus> {
     debug!("Executing external action with {} entries", entries.len());
 
-    let template: &Template = action_spec.command.get_nth(0);
+    let template: &Template = action_spec.command.get_nth(0).template();
     let formatted_command =
         format_command(entries, template, &action_spec.separator)?;
 

--- a/tests/config/cli_overrides.rs
+++ b/tests/config/cli_overrides.rs
@@ -279,7 +279,7 @@ fn test_cli_input_position_override() {
         .find("position-prompt>")
         .expect("Expected input prompt in frame");
     let results_index = frame
-        .find("Results")
+        .find("Default")
         .expect("Expected results header in frame");
 
     assert!(


### PR DESCRIPTION
## 📺 PR Description

Add an optional `command_name` field to the `[source]` section of cable channel TOML definitions. When multiple source commands are defined, these names are displayed in the results panel header instead of the generic "Results" label, making it easier to identify which source is currently active.

Example usage:
```
[source]
command = ["ls", "ls -a", "ls -la"]
command_name = ["Default", "Hidden", "Detailed"]
```
Closes #1025

![named_source_commands_1](https://github.com/user-attachments/assets/5436673a-c964-4888-94f1-2e140c188273)

![named_source_commands_2](https://github.com/user-attachments/assets/6d2c1d3e-0d70-4901-a295-48ae3602599e)

![named_source_commands_3](https://github.com/user-attachments/assets/6d5decba-850e-4eaf-bd10-3f4dda31d082)

## Checklist

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [x] I have added a reasonable amount of documentation to the code where appropriate
