### PR TITLE
feat(tui): enables the kitty keyboard-protocol and enable support for uppercase keybindings

### DIFF
--- a/docs/user-guide/02-configuration.md
+++ b/docs/user-guide/02-configuration.md
@@ -145,9 +145,18 @@ Map keyboard keys to actions. Keys can be specified as:
 - Special keys: `enter`, `esc`, `tab`, `backtab`, `space`, `backspace`, `delete`, `insert`, `home`, `end`, `pageup`, `pagedown`, `up`, `down`, `left`, `right`
 - Control keys: `ctrl-a`, `ctrl-b`, `ctrl-c`, etc.
 - Alt keys: `alt-a`, `alt-enter`, etc.
+- Shifted letters: `ctrl-shift-a`, `alt-shift-a`, etc. An uppercase letter implies shift: `ctrl-A` is the same as `ctrl-shift-a`.
 - Function keys: `f1`, `f2`, ..., `f12`
 
 Modifiers can be combined with special keys, e.g. `ctrl-up`, `ctrl-down`, `alt-enter`.
+
+:::note
+Telling `ctrl-a` apart from `ctrl-shift-a` requires a terminal that supports the
+[kitty keyboard protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/) (kitty, Ghostty, WezTerm, foot, recent
+Alacritty and iTerm2, ...). Television enables it automatically when available. In other terminals, and inside tmux,
+both combinations send the same bytes, so only the lowercase binding fires. Terminals that support the protocol also
+report `ctrl-i`, `ctrl-m` and `ctrl-[` as themselves instead of `tab`, `enter` and `esc`.
+:::
 
 **Available Actions**:
 

--- a/television/config/keybindings.rs
+++ b/television/config/keybindings.rs
@@ -135,7 +135,8 @@ pub fn merge_keybindings(
 /// ```
 pub fn parse_key_event(raw: &str) -> anyhow::Result<KeyEvent, String> {
     let raw_lower = raw.to_ascii_lowercase();
-    let (remaining, modifiers) = extract_modifiers(&raw_lower);
+    let (remaining_lower, modifiers) = extract_modifiers(&raw_lower);
+    let remaining = &raw[raw.len() - remaining_lower.len()..];
     parse_key_code_with_modifiers(remaining, modifiers)
 }
 
@@ -263,17 +264,19 @@ fn parse_key_code_with_modifiers(
             .collect()
         });
 
-    let c = if let Some(&key_code) = KEY_CODE_MAP.get(raw) {
+    let raw_lower = raw.to_ascii_lowercase();
+    let c = if let Some(&key_code) = KEY_CODE_MAP.get(raw_lower.as_str()) {
         key_code
-    } else if raw == "backtab" {
+    } else if raw_lower == "backtab" {
         modifiers.insert(KeyModifiers::SHIFT);
         KeyCode::BackTab
     } else if raw.len() == 1 {
-        let mut c = raw.chars().next().unwrap();
-        if modifiers.contains(KeyModifiers::SHIFT) {
-            c = c.to_ascii_uppercase();
+        let c = raw.chars().next().unwrap();
+        if c.is_ascii_uppercase() || modifiers.contains(KeyModifiers::SHIFT) {
+            KeyCode::Char(c.to_ascii_uppercase())
+        } else {
+            KeyCode::Char(c)
         }
-        KeyCode::Char(c)
     } else {
         return Err(format!("Unable to parse {raw}"));
     };
@@ -310,6 +313,8 @@ fn parse_key_code_with_modifiers(
 #[allow(dead_code)]
 pub fn key_event_to_string(key_event: &KeyEvent) -> String {
     let char;
+    let is_shifted_char = key_event.modifiers.intersects(KeyModifiers::SHIFT)
+        && matches!(key_event.code, KeyCode::Char(_));
     let key_code = match key_event.code {
         KeyCode::Backspace => "backspace",
         KeyCode::Enter => "enter",
@@ -331,7 +336,11 @@ pub fn key_event_to_string(key_event: &KeyEvent) -> String {
         }
         KeyCode::Char(' ') => "space",
         KeyCode::Char(c) => {
-            char = c.to_string();
+            char = if is_shifted_char {
+                c.to_ascii_uppercase().to_string()
+            } else {
+                c.to_string()
+            };
             &char
         }
         KeyCode::Esc => "esc",
@@ -353,7 +362,8 @@ pub fn key_event_to_string(key_event: &KeyEvent) -> String {
         modifiers.push("ctrl");
     }
 
-    if key_event.modifiers.intersects(KeyModifiers::SHIFT) {
+    if key_event.modifiers.intersects(KeyModifiers::SHIFT) && !is_shifted_char
+    {
         modifiers.push("shift");
     }
 
@@ -487,6 +497,72 @@ mod tests {
                 KeyModifiers::CONTROL | KeyModifiers::ALT
             )),
             "ctrl-alt-a".to_string()
+        );
+    }
+
+    #[test]
+    fn test_uppercase_bindings() {
+        // Bare uppercase char → Char('A') with no modifiers
+        assert_eq!(
+            parse_key_event("A").unwrap(),
+            KeyEvent::new(KeyCode::Char('A'), KeyModifiers::NONE)
+        );
+
+        // ctrl + uppercase char → Char('A') with CONTROL
+        assert_eq!(
+            parse_key_event("ctrl-A").unwrap(),
+            KeyEvent::new(KeyCode::Char('A'), KeyModifiers::CONTROL)
+        );
+
+        // alt + uppercase char → Char('A') with ALT
+        assert_eq!(
+            parse_key_event("alt-A").unwrap(),
+            KeyEvent::new(KeyCode::Char('A'), KeyModifiers::ALT)
+        );
+
+        // shift-a and bare A are equivalent
+        assert_eq!(
+            parse_key_event("shift-a").unwrap(),
+            parse_key_event("A").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_key_event_to_string_uppercase() {
+        // Shift+char → uppercase notation, no "shift-" prefix
+        assert_eq!(
+            key_event_to_string(&KeyEvent::new(
+                KeyCode::Char('a'),
+                KeyModifiers::SHIFT
+            )),
+            "A".to_string()
+        );
+
+        // ctrl + shift + char → "ctrl-A"
+        assert_eq!(
+            key_event_to_string(&KeyEvent::new(
+                KeyCode::Char('a'),
+                KeyModifiers::CONTROL | KeyModifiers::SHIFT
+            )),
+            "ctrl-A".to_string()
+        );
+
+        // Already uppercase char with no modifiers → "A"
+        assert_eq!(
+            key_event_to_string(&KeyEvent::new(
+                KeyCode::Char('A'),
+                KeyModifiers::NONE
+            )),
+            "A".to_string()
+        );
+
+        // Non-char shift (e.g. shift-enter) keeps the "shift-" prefix
+        assert_eq!(
+            key_event_to_string(&KeyEvent::new(
+                KeyCode::Enter,
+                KeyModifiers::SHIFT
+            )),
+            "shift-enter".to_string()
         );
     }
 

--- a/television/config/keybindings.rs
+++ b/television/config/keybindings.rs
@@ -119,6 +119,8 @@ pub fn merge_keybindings(
 /// - `cmd-` - Command key (macOS)
 /// - `super-` - Super key (Linux/Windows)
 ///
+/// An uppercase letter implies shift: `ctrl-A` is the same as `ctrl-shift-a`.
+///
 /// # Examples
 ///
 /// ```rust
@@ -136,6 +138,7 @@ pub fn merge_keybindings(
 pub fn parse_key_event(raw: &str) -> anyhow::Result<KeyEvent, String> {
     let raw_lower = raw.to_ascii_lowercase();
     let (remaining_lower, modifiers) = extract_modifiers(&raw_lower);
+    // recover the original key (ascii lowercasing preserves boundaries)
     let remaining = &raw[raw.len() - remaining_lower.len()..];
     parse_key_code_with_modifiers(remaining, modifiers)
 }

--- a/television/config/keybindings.rs
+++ b/television/config/keybindings.rs
@@ -136,10 +136,7 @@ pub fn merge_keybindings(
 /// assert_eq!(event.modifiers, KeyModifiers::ALT);
 /// ```
 pub fn parse_key_event(raw: &str) -> anyhow::Result<KeyEvent, String> {
-    let raw_lower = raw.to_ascii_lowercase();
-    let (remaining_lower, modifiers) = extract_modifiers(&raw_lower);
-    // recover the original key (ascii lowercasing preserves boundaries)
-    let remaining = &raw[raw.len() - remaining_lower.len()..];
+    let (remaining, modifiers) = extract_modifiers(raw);
     parse_key_code_with_modifiers(remaining, modifiers)
 }
 
@@ -151,7 +148,7 @@ pub fn parse_key_event(raw: &str) -> anyhow::Result<KeyEvent, String> {
 ///
 /// # Arguments
 ///
-/// * `raw` - The raw key string (already lowercased)
+/// * `raw` - The raw key string (modifier prefixes are matched case-insensitively)
 ///
 /// # Returns
 ///
@@ -165,39 +162,39 @@ pub fn parse_key_event(raw: &str) -> anyhow::Result<KeyEvent, String> {
 /// assert!(mods.contains(KeyModifiers::CONTROL | KeyModifiers::ALT));
 /// ```
 fn extract_modifiers(raw: &str) -> (&str, KeyModifiers) {
+    const MODIFIERS: [(&str, KeyModifiers); 5] = [
+        ("ctrl-", KeyModifiers::CONTROL),
+        ("shift-", KeyModifiers::SHIFT),
+        ("alt-", KeyModifiers::ALT),
+        ("cmd-", KeyModifiers::SUPER),
+        ("super-", KeyModifiers::SUPER),
+    ];
+
     let mut modifiers = KeyModifiers::empty();
     let mut current = raw;
 
-    loop {
-        if let Some(rest) = current.strip_prefix("ctrl-") {
-            modifiers.insert(KeyModifiers::CONTROL);
-            current = rest;
-            continue;
-        }
-        if let Some(rest) = current.strip_prefix("shift-") {
-            modifiers.insert(KeyModifiers::SHIFT);
-            current = rest;
-            continue;
-        }
-        if let Some(rest) = current.strip_prefix("alt-") {
-            modifiers.insert(KeyModifiers::ALT);
-            current = rest;
-            continue;
-        }
-        if let Some(rest) = current.strip_prefix("cmd-") {
-            modifiers.insert(KeyModifiers::SUPER);
-            current = rest;
-            continue;
-        }
-        if let Some(rest) = current.strip_prefix("super-") {
-            modifiers.insert(KeyModifiers::SUPER);
-            current = rest;
-            continue;
+    'strip: loop {
+        for (prefix, modifier) in MODIFIERS {
+            if let Some(rest) = strip_prefix_ignore_ascii_case(current, prefix)
+            {
+                modifiers.insert(modifier);
+                current = rest;
+                continue 'strip;
+            }
         }
         break;
     }
 
     (current, modifiers)
+}
+
+fn strip_prefix_ignore_ascii_case<'a>(
+    s: &'a str,
+    prefix: &str,
+) -> Option<&'a str> {
+    let head = s.get(..prefix.len())?;
+    head.eq_ignore_ascii_case(prefix)
+        .then(|| &s[prefix.len()..])
 }
 
 /// Parses a key code string with pre-extracted modifiers into a `KeyEvent`.
@@ -585,6 +582,14 @@ mod tests {
         assert_eq!(
             parse_key_event("AlT-eNtEr").unwrap(),
             KeyEvent::new(KeyCode::Enter, KeyModifiers::ALT)
+        );
+
+        assert_eq!(
+            parse_key_event("Ctrl-Shift-A").unwrap(),
+            KeyEvent::new(
+                KeyCode::Char('A'),
+                KeyModifiers::CONTROL | KeyModifiers::SHIFT
+            )
         );
     }
 

--- a/television/event.rs
+++ b/television/event.rs
@@ -380,12 +380,19 @@ pub fn convert_raw_event_to_key(event: KeyEvent) -> Key {
             KeyModifiers::ALT => Key::AltSpace,
             _ => Key::Null,
         },
-        Char(c) => match event.modifiers {
-            KeyModifiers::NONE | KeyModifiers::SHIFT => Key::Char(c),
-            KeyModifiers::CONTROL => Key::Ctrl(c),
-            KeyModifiers::ALT => Key::Alt(c),
-            _ => Key::Null,
-        },
+        Char(c) => {
+            let c = if event.modifiers.contains(KeyModifiers::SHIFT) {
+                c.to_uppercase().next().unwrap_or(c)
+            } else {
+                c
+            };
+            match event.modifiers - KeyModifiers::SHIFT {
+                KeyModifiers::NONE => Key::Char(c),
+                KeyModifiers::CONTROL => Key::Ctrl(c),
+                KeyModifiers::ALT => Key::Alt(c),
+                _ => Key::Null,
+            }
+        }
         _ => Key::Null,
     }
 }
@@ -430,7 +437,7 @@ mod tests {
             kind: KeyEventKind::Press,
             state: KeyEventState::NONE,
         };
-        assert_eq!(convert_raw_event_to_key(event), Key::Char('a'));
+        assert_eq!(convert_raw_event_to_key(event), Key::Char('A'));
 
         let event = KeyEvent {
             code: KeyCode::Char(' '),

--- a/television/tui.rs
+++ b/television/tui.rs
@@ -7,11 +7,15 @@ use std::{
 use anyhow::Result;
 use crossterm::{
     cursor,
-    event::{DisableMouseCapture, EnableMouseCapture},
+    event::{
+        DisableMouseCapture, EnableMouseCapture, KeyboardEnhancementFlags,
+        PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+    },
     execute,
     terminal::{
         ClearType, EnterAlternateScreen, LeaveAlternateScreen, ScrollUp,
         disable_raw_mode, enable_raw_mode, is_raw_mode_enabled,
+        supports_keyboard_enhancement,
     },
 };
 use ratatui::{
@@ -244,6 +248,15 @@ where
 
         execute!(backend, EnableMouseCapture)?;
 
+        if supports_keyboard_enhancement().unwrap_or(false) {
+            execute!(
+                backend,
+                PushKeyboardEnhancementFlags(
+                    KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES,
+                )
+            )?;
+        }
+
         if self.viewport == Viewport::Fullscreen {
             execute!(backend, EnterAlternateScreen)?;
             self.terminal.clear()?;
@@ -269,6 +282,11 @@ where
             )?;
 
             execute!(backend, cursor::Show)?;
+
+            if supports_keyboard_enhancement().unwrap_or(false) {
+                execute!(backend, PopKeyboardEnhancementFlags)?;
+            }
+
             execute!(backend, DisableMouseCapture)?;
 
             if self.viewport == Viewport::Fullscreen {

--- a/television/tui.rs
+++ b/television/tui.rs
@@ -55,6 +55,8 @@ where
 {
     pub terminal: ratatui::Terminal<CrosstermBackend<W>>,
     pub viewport: Viewport,
+    /// Whether the terminal supports the kitty keyboard protocol.
+    keyboard_enhancement: bool,
 }
 
 pub const TESTING_ENV_VAR: &str = "TV_TEST";
@@ -81,6 +83,12 @@ where
         let mut backend = CrosstermBackend::new(writer);
         let mut options = TerminalOptions::default();
         enable_raw_mode()?;
+
+        // This is a blocking round trip to the terminal, so do it once here
+        // (raw mode is on and nothing else is reading events yet) rather
+        // than on every enter/exit.
+        let keyboard_enhancement =
+            supports_keyboard_enhancement().unwrap_or(false);
 
         let terminal_size = backend.size()?;
         let viewport = match mode {
@@ -128,7 +136,11 @@ where
 
         options.viewport = viewport.clone();
         let terminal = Terminal::with_options(backend, options)?;
-        Ok(Self { terminal, viewport })
+        Ok(Self {
+            terminal,
+            viewport,
+            keyboard_enhancement,
+        })
     }
 
     /// Handles scrolling logic when there's insufficient space for the requested height.
@@ -269,15 +281,6 @@ where
 
         execute!(backend, EnableMouseCapture)?;
 
-        if supports_keyboard_enhancement().unwrap_or(false) {
-            execute!(
-                backend,
-                PushKeyboardEnhancementFlags(
-                    KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES,
-                )
-            )?;
-        }
-
         if self.viewport == Viewport::Fullscreen {
             execute!(backend, EnterAlternateScreen)?;
             self.clear()?;
@@ -285,6 +288,18 @@ where
             // the minimal non-fullscreen UI has no prompt decoration; a
             // steady bar cursor marks the input position instead
             execute!(backend, cursor::SetCursorStyle::SteadyBar)?;
+        }
+
+        // Terminals keep separate keyboard flag stacks for the main and
+        // alternate screens, so this has to happen after entering the
+        // alternate screen (and the matching pop before leaving it).
+        if self.keyboard_enhancement {
+            execute!(
+                self.terminal.backend_mut(),
+                PushKeyboardEnhancementFlags(
+                    KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+                )
+            )?;
         }
         Ok(())
     }
@@ -308,7 +323,7 @@ where
 
             execute!(backend, cursor::Show)?;
 
-            if supports_keyboard_enhancement().unwrap_or(false) {
+            if self.keyboard_enhancement {
                 execute!(backend, PopKeyboardEnhancementFlags)?;
             }
 

--- a/television/tui.rs
+++ b/television/tui.rs
@@ -7,11 +7,15 @@ use std::{
 use anyhow::Result;
 use crossterm::{
     cursor,
-    event::{DisableMouseCapture, EnableMouseCapture},
+    event::{
+        DisableMouseCapture, EnableMouseCapture, KeyboardEnhancementFlags,
+        PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+    },
     execute,
     terminal::{
         ClearType, EnterAlternateScreen, LeaveAlternateScreen, ScrollUp,
         disable_raw_mode, enable_raw_mode, is_raw_mode_enabled,
+        supports_keyboard_enhancement,
     },
 };
 use ratatui::{
@@ -265,6 +269,15 @@ where
 
         execute!(backend, EnableMouseCapture)?;
 
+        if supports_keyboard_enhancement().unwrap_or(false) {
+            execute!(
+                backend,
+                PushKeyboardEnhancementFlags(
+                    KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES,
+                )
+            )?;
+        }
+
         if self.viewport == Viewport::Fullscreen {
             execute!(backend, EnterAlternateScreen)?;
             self.clear()?;
@@ -294,6 +307,11 @@ where
             )?;
 
             execute!(backend, cursor::Show)?;
+
+            if supports_keyboard_enhancement().unwrap_or(false) {
+                execute!(backend, PopKeyboardEnhancementFlags)?;
+            }
+
             execute!(backend, DisableMouseCapture)?;
 
             if self.viewport == Viewport::Fullscreen {

--- a/television/tui.rs
+++ b/television/tui.rs
@@ -84,9 +84,6 @@ where
         let mut options = TerminalOptions::default();
         enable_raw_mode()?;
 
-        // This is a blocking round trip to the terminal, so do it once here
-        // (raw mode is on and nothing else is reading events yet) rather
-        // than on every enter/exit.
         let keyboard_enhancement =
             supports_keyboard_enhancement().unwrap_or(false);
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -46,7 +46,7 @@ pub fn default_delay() -> Duration {
         .unwrap_or(Duration::from_millis(100))
 }
 
-pub const DEFAULT_DELAY: Duration = Duration::from_millis(100);
+pub const DEFAULT_DELAY: Duration = Duration::from_millis(110);
 
 /// A helper to test terminal user interfaces (TUIs) using a pseudo-terminal (pty).
 ///


### PR DESCRIPTION
## 📺 PR Description

This PR checks if the terminal supports the [kitty keyboard protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/) and enables it if supported. It also adds support for defining uppercase bindings, such as `Ctrl-D` or `Ctrl-Shift-d`.

However, on terminals that don't support the kitty keyboard protocol (like tmux; let's hope [tmux PR #4912](https://github.com/tmux/tmux/pull/4912) gets merged), the shift key information is not propagated to `tv`. This means that if bindings for both `ctrl-d` and `Ctrl-D` are defined, only the `ctrl-d` action will be executed, since the shifted binding cannot be distinguished from the unshifted one.

The feature was tested in Ghostty.

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [x] I have added a reasonable amount of documentation to the code where appropriate

Resolves #966