### PR TITLE
feat(cable): add zellij-sessions channel

### DIFF
--- a/cable/unix/zellij-sessions.toml
+++ b/cable/unix/zellij-sessions.toml
@@ -1,0 +1,27 @@
+[metadata]
+name = "zellij-sessions"
+description = "List and manage zellij sessions"
+requirements = ["zellij"]
+
+[source]
+command = "zellij list-sessions | sed 's/\\x1b\\[[0-9;]*m//g'"
+display = "{}"
+output = "{split: :0}"
+
+[preview]
+command = "zellij --session '{split: :0}' action dump-screen 2>/dev/null || echo 'No preview available'"
+
+[actions.attach]
+description = "Attach to the selected session"
+command = "zellij attach '{split: :0}'"
+mode = "execute"
+
+[actions.kill]
+description = "Kill the selected session (resurrectable)"
+command = "zellij kill-session '{split: :0}'"
+mode = "fork"
+
+[actions.delete]
+description = "Delete the selected session (permanent)"
+command = "zellij delete-session '{split: :0}'"
+mode = "fork"


### PR DESCRIPTION
## 📺 PR Description

Add a zellij-sessions channel for searching through the Zellij multiplexer's sessions, similar to the tmux-sessions channel.

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [x] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [x] I have added a reasonable amount of documentation to the code where appropriate
