### PR TITLE
feat(config): Support multiple offsets in preview config

### DIFF
--- a/television/channels/prototypes.rs
+++ b/television/channels/prototypes.rs
@@ -408,12 +408,14 @@ where
     }
 }
 
+#[serde_as]
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct PreviewSpec {
     #[serde(flatten)]
     pub command: CommandSpec,
     #[serde(default)]
-    pub offset: Option<Template>,
+    #[serde_as(as = "Option<OneOrMany<_>>")]
+    pub offset: Option<Vec<Template>>,
     #[serde(default = "cached_default")]
     pub cached: bool,
 }
@@ -432,7 +434,7 @@ impl PreviewSpec {
     pub fn new(command: CommandSpec, offset: Option<Template>) -> Self {
         Self {
             command,
-            offset,
+            offset: offset.map(|t| vec![t]),
             cached: false,
         }
     }
@@ -982,5 +984,37 @@ mod tests {
 
         // Verify powershell deserializes correctly
         assert_eq!(prototype.source.command.shell, Some(Shell::Psh));
+    }
+
+    #[test]
+    fn test_preview_spec_single_offset() {
+        let toml_str = r#"
+            command = "preview"
+            offset = "3"
+        "#;
+        let preview: PreviewSpec = from_str(toml_str).unwrap();
+        assert_eq!(preview.offset.as_ref().unwrap().len(), 1);
+        assert_eq!(preview.offset.as_ref().unwrap()[0].raw(), "3");
+    }
+
+    #[test]
+    fn test_preview_spec_multi_offset() {
+        let toml_str = r#"
+            command = ["p1", "p2"]
+            offset = ["3", ""]
+        "#;
+        let preview: PreviewSpec = from_str(toml_str).unwrap();
+        assert_eq!(preview.offset.as_ref().unwrap().len(), 2);
+        assert_eq!(preview.offset.as_ref().unwrap()[0].raw(), "3");
+        assert_eq!(preview.offset.as_ref().unwrap()[1].raw(), "");
+    }
+
+    #[test]
+    fn test_preview_spec_no_offset() {
+        let toml_str = r#"
+            command = "preview"
+        "#;
+        let preview: PreviewSpec = from_str(toml_str).unwrap();
+        assert!(preview.offset.is_none());
     }
 }

--- a/television/config/layers.rs
+++ b/television/config/layers.rs
@@ -158,14 +158,18 @@ impl ConfigLayers {
         {
             cmd.shell = global_shell;
         }
-        let channel_preview_offset =
-            self.channel_cli.preview_offset.clone().or(
+        let channel_preview_offset = self
+            .channel_cli
+            .preview_offset
+            .clone()
+            .map(|t| vec![t])
+            .or_else(|| {
                 if let Some(preview) = &self.channel.preview {
                     preview.offset.clone()
                 } else {
                     None
-                },
-            );
+                }
+            });
         let channel_preview_cached = self.channel_cli.cache_preview
             || self.channel.preview.as_ref().is_some_and(|p| p.cached);
 
@@ -664,7 +668,7 @@ pub struct MergedConfig {
     pub channel_source_output: Option<Template>,
     // preview
     pub channel_preview_command: Option<CommandSpec>,
-    pub channel_preview_offset: Option<Template>,
+    pub channel_preview_offset: Option<Vec<Template>>,
     pub channel_preview_cached: bool,
     pub channel_actions: FxHashMap<String, ActionSpec>,
     /// Whether frecency is enabled for the current channel (per-channel override)

--- a/television/previewer/mod.rs
+++ b/television/previewer/mod.rs
@@ -181,7 +181,7 @@ pub struct Previewer {
     cycle_index: usize,
     title_template: Option<Template>,
     footer_template: Option<Template>,
-    offset_expr: Option<Template>,
+    offset_expr: Option<Vec<Template>>,
     results: UnboundedSender<Preview>,
     cache: Option<Arc<Mutex<Cache>>>,
 }
@@ -190,7 +190,7 @@ impl Previewer {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         command: &CommandSpec,
-        offset_expr: Option<Template>,
+        offset_expr: Option<Vec<Template>>,
         title_template: Option<Template>,
         footer_template: Option<Template>,
         config: Config,
@@ -323,16 +323,26 @@ fn build_preview_from_text(
     text: Text<'static>,
     title_template: Option<&Template>,
     footer_template: Option<&Template>,
-    offset_expr: Option<&Template>,
+    offset_expr: Option<&Vec<Template>>,
     preview_index: usize,
     preview_count: usize,
 ) -> Result<Preview> {
     let total_lines = u16::try_from(text.lines.len()).unwrap_or(0);
 
     // try to extract a line number from the offset expression if provided
-    let line_number = if let Some(offset_expr) = offset_expr.as_ref() {
-        let offset_str = offset_expr.format(&entry.raw)?;
-        offset_str.parse::<u16>().ok()
+    let line_number = if let Some(offset_exprs) = offset_expr.as_ref() {
+        let current_offset =
+            offset_exprs.get(preview_index).or_else(|| offset_exprs.first());
+        if let Some(offset_expr) = current_offset {
+            if offset_expr.raw().is_empty() {
+                None
+            } else {
+                let offset_str = offset_expr.format(&entry.raw)?;
+                offset_str.parse::<u16>().ok()
+            }
+        } else {
+            None
+        }
     } else {
         None
     };
@@ -367,7 +377,7 @@ pub async fn try_preview(
     cycle_index: usize,
     title_template: Option<Template>,
     footer_template: Option<Template>,
-    offset_expr: Option<Template>,
+    offset_expr: Option<Vec<Template>>,
     entry: Entry,
     results_handle: UnboundedSender<Preview>,
     cache: Option<Arc<Mutex<Cache>>>,

--- a/television/television.rs
+++ b/television/television.rs
@@ -240,7 +240,7 @@ impl Television {
     fn setup_previewer(
         command: &CommandSpec,
         cached: bool,
-        offset_expr: Option<Template>,
+        offset_expr: Option<Vec<Template>>,
         title_template: Option<Template>,
         footer_template: Option<Template>,
     ) -> (UnboundedSender<PreviewRequest>, UnboundedReceiver<Preview>) {


### PR DESCRIPTION
## 📺 PR Description

This PR implements support for specifying unique scroll offsets for each preview command in a channel, addressing the limitation described in #1033. 

### Key Changes:
- **Multi-Offset Support**: The `offset` field in `PreviewSpec` now supports both single strings and arrays of strings using `serde_with::OneOrMany`.
- **Index-based Lookup**: The `Previewer` now tracks the `cycle_index` to select the corresponding offset template for the active preview command.
- **Backwards Compatibility**: Existing single-string configurations continue to work without modification.
- **Explicit Disable**: Users can now use an empty string `""` in the offset array to explicitly disable scrolling for specific commands in a cycle.
- **Fallback Logic**: If fewer offsets are provided than commands, the system falls back to the first offset for all remaining commands.

Fixes #1033

```toml
[metadata]
name = "multi-offset-demo"

[source]
command = "grep -nE '.*' README.md"

[preview]
command = ["bat -n --color=always README.md", "cat README.md"]
offset = ["{split:\\::0}", ""]
```

## Checklist

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [x] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [x] I have added a reasonable amount of documentation to the code where appropriate
