### PR TITLE
fix(cable): remove redundant quoting around {} in action commands

### DIFF
--- a/cable/unix/aws-profiles.toml
+++ b/cable/unix/aws-profiles.toml
@@ -17,5 +17,5 @@ enter = "actions:export"
 
 [actions.export]
 description = "Export the selected profile (sets AWS_PROFILE)"
-command = "export AWS_PROFILE='{}' && echo \"AWS_PROFILE set to '{}'\" && $SHELL"
+command = "export AWS_PROFILE={} && echo \"AWS_PROFILE set to {}\" && $SHELL"
 mode = "execute"

--- a/cable/unix/brew-packages.toml
+++ b/cable/unix/brew-packages.toml
@@ -21,10 +21,10 @@ ctrl-d = "actions:uninstall"
 
 [actions.upgrade]
 description = "Upgrade the selected package"
-command = "brew upgrade '{}'"
+command = "brew upgrade {}"
 mode = "execute"
 
 [actions.uninstall]
 description = "Uninstall the selected package"
-command = "brew uninstall '{}'"
+command = "brew uninstall {}"
 mode = "execute"

--- a/cable/unix/cargo-commands.toml
+++ b/cable/unix/cargo-commands.toml
@@ -18,5 +18,5 @@ enter = "actions:run"
 
 [actions.run]
 description = "Run the selected cargo command"
-command = "cargo '{}'"
+command = "cargo {}"
 mode = "execute"

--- a/cable/unix/dirs.toml
+++ b/cable/unix/dirs.toml
@@ -14,7 +14,7 @@ shortcut = "f2"
 
 [actions.cd]
 description = "Open a shell in the selected directory"
-command = "cd '{}' && $SHELL"
+command = "cd {} && $SHELL"
 mode = "execute"
 
 [actions.goto_parent_dir]

--- a/cable/unix/dirs.toml
+++ b/cable/unix/dirs.toml
@@ -17,7 +17,7 @@ shortcut = "f2"
 
 [actions.cd]
 description = "Open a shell in the selected directory"
-command = "cd '{}' && $SHELL"
+command = "cd {} && $SHELL"
 mode = "execute"
 
 [actions.goto_parent_dir]

--- a/cable/unix/dnf-packages.toml
+++ b/cable/unix/dnf-packages.toml
@@ -11,7 +11,7 @@ command = "rpm -q --info '{}' 2>/dev/null"
 # I use rpm here to avoid the delay that happens when dnf updates it's repository
 [actions.remove]
 description = "Remove the selected package"
-command = "sudo dnf remove '{}'"
+command = "sudo dnf remove {}"
 mode = "execute"
 
 

--- a/cable/unix/dotfiles.toml
+++ b/cable/unix/dotfiles.toml
@@ -14,6 +14,6 @@ enter = "actions:edit"
 
 [actions.edit]
 description = "Edit the selected dotfile"
-command = "${EDITOR:-vim} '{}'"
+command = "${EDITOR:-vim} {}"
 shell = "bash"
 mode = "execute"

--- a/cable/unix/downloads.toml
+++ b/cable/unix/downloads.toml
@@ -17,15 +17,15 @@ ctrl-m = "actions:move"
 
 [actions.open]
 description = "Open the selected file with default application"
-command = "xdg-open '{}' 2>/dev/null || open '{}'"
+command = "xdg-open {} 2>/dev/null || open {}"
 mode = "fork"
 
 [actions.delete]
 description = "Delete the selected file"
-command = "rm -i '{}'"
+command = "rm -i {}"
 mode = "execute"
 
 [actions.move]
 description = "Move the selected file to current directory"
-command = "mv '{}' ."
+command = "mv {} ."
 mode = "fork"

--- a/cable/unix/files.toml
+++ b/cable/unix/files.toml
@@ -17,7 +17,7 @@ ctrl-up = "actions:goto_parent_dir"
 
 [actions.edit]
 description = "Opens the selected entries with the default editor (falls back to vim)"
-command = "${EDITOR:-vim} '{}'"
+command = "${EDITOR:-vim} {}"
 shell = "bash"
 # use `mode = "fork"` if you want to return to tv afterwards
 mode = "execute"

--- a/cable/unix/files.toml
+++ b/cable/unix/files.toml
@@ -20,7 +20,7 @@ ctrl-up = "actions:goto_parent_dir"
 
 [actions.edit]
 description = "Opens the selected entries with the default editor (falls back to vim)"
-command = "${EDITOR:-vim} '{}'"
+command = "${EDITOR:-vim} {}"
 shell = "bash"
 # use `mode = "fork"` if you want to return to tv afterwards
 mode = "execute"

--- a/cable/unix/git-deletions.toml
+++ b/cable/unix/git-deletions.toml
@@ -15,10 +15,10 @@ ctrl-r = "actions:restore_file"
 
 [actions.print_commit]
 description = "Print the latest commit where file was deleted"
-command = "echo \"$(git rev-list -n1 HEAD -- '{}')\""
+command = "echo \"$(git rev-list -n1 HEAD -- {})\""
 mode = "execute"
 
 [actions.restore_file]
 description = "Restore the selected file"
-command = "git checkout \"$(git rev-list -n1 HEAD -- '{}')^\" -- '{}'"
+command = "git checkout \"$(git rev-list -n1 HEAD -- {})^\" -- {}"
 

--- a/cable/unix/git-diff.toml
+++ b/cable/unix/git-diff.toml
@@ -19,16 +19,16 @@ ctrl-e = "actions:edit"
 
 [actions.stage]
 description = "Stage the selected file"
-command = "git add '{}'"
+command = "git add {}"
 mode = "fork"
 
 [actions.restore]
 description = "Discard changes in the selected file"
-command = "git restore '{}'"
+command = "git restore {}"
 mode = "fork"
 
 [actions.edit]
 description = "Open the selected file in editor"
-command = "${EDITOR:-vim} '{}'"
+command = "${EDITOR:-vim} {}"
 shell = "bash"
 mode = "execute"

--- a/cable/unix/git-files.toml
+++ b/cable/unix/git-files.toml
@@ -15,6 +15,6 @@ f12 = "actions:edit"
 
 [actions.edit]
 description = "Opens the selected entries with the default editor (falls back to vim)"
-command = "${EDITOR:-vim} '{}'"
+command = "${EDITOR:-vim} {}"
 shell = "bash"
 mode = "execute"

--- a/cable/unix/git-remotes.toml
+++ b/cable/unix/git-remotes.toml
@@ -11,10 +11,10 @@ command = "git remote show '{}'"
 
 [actions.fetch]
 description = "Fetch from the selected remote"
-command = "git fetch '{}'"
+command = "git fetch {}"
 mode = "execute"
 
 [actions.remove]
 description = "Remove the selected remote"
-command = "git remote remove '{}'"
+command = "git remote remove {}"
 mode = "execute"

--- a/cable/unix/git-repos.toml
+++ b/cable/unix/git-repos.toml
@@ -21,11 +21,11 @@ ctrl-e = "actions:edit"
 
 [actions.cd]
 description = "Open a new shell in the selected repository"
-command = "cd '{}' && $SHELL"
+command = "cd {} && $SHELL"
 mode = "execute"
 
 [actions.edit]
 description = "Open the repository in editor"
-command = "${EDITOR:-vim} '{}'"
+command = "${EDITOR:-vim} {}"
 shell = "bash"
 mode = "execute"

--- a/cable/unix/git-submodules.toml
+++ b/cable/unix/git-submodules.toml
@@ -11,10 +11,10 @@ command = "git -C '{}' log --oneline -10 --color=always"
 
 [actions.update]
 description = "Update the selected submodule"
-command = "git submodule update --init --recursive '{}'"
+command = "git submodule update --init --recursive {}"
 mode = "execute"
 
 [actions.sync]
 description = "Sync the selected submodule URL"
-command = "git submodule sync '{}'"
+command = "git submodule sync {}"
 mode = "execute"

--- a/cable/unix/git-tags.toml
+++ b/cable/unix/git-tags.toml
@@ -17,10 +17,10 @@ ctrl-d = "actions:delete"
 
 [actions.checkout]
 description = "Checkout the selected tag"
-command = "git checkout '{}'"
+command = "git checkout {}"
 mode = "execute"
 
 [actions.delete]
 description = "Delete the selected tag"
-command = "git tag -d '{}'"
+command = "git tag -d {}"
 mode = "execute"

--- a/cable/unix/git-worktrees.toml
+++ b/cable/unix/git-worktrees.toml
@@ -15,10 +15,10 @@ ctrl-d = "actions:remove"
 
 [actions.cd]
 description = "Change to the selected worktree"
-command = "cd '{}' && $SHELL"
+command = "cd {} && $SHELL"
 mode = "execute"
 
 [actions.remove]
 description = "Remove the selected worktree"
-command = "git worktree remove '{}'"
+command = "git worktree remove {}"
 mode = "execute"

--- a/cable/unix/gradle-tasks.toml
+++ b/cable/unix/gradle-tasks.toml
@@ -14,5 +14,5 @@ enter = "actions:run"
 
 [actions.run]
 description = "Run the selected Gradle task"
-command = "gradle '{}'"
+command = "gradle {}"
 mode = "execute"

--- a/cable/unix/images.toml
+++ b/cable/unix/images.toml
@@ -17,5 +17,5 @@ enter = "actions:open"
 
 [actions.open]
 description = "Open the selected image with default viewer"
-command = "xdg-open '{}' 2>/dev/null || open '{}'"
+command = "xdg-open {} 2>/dev/null || open {}"
 mode = "fork"

--- a/cable/unix/jj-diff.toml
+++ b/cable/unix/jj-diff.toml
@@ -17,21 +17,21 @@ ctrl-a = "actions:absorb"
 
 [actions.restore]
 description = "Discard changes in the selected file"
-command = "jj restore '{}'"
+command = "jj restore {}"
 mode = "fork"
 
 [actions.edit]
 description = "Open the selected file in editor"
-command = "${EDITOR:-vim} '{}'"
+command = "${EDITOR:-vim} {}"
 shell = "bash"
 mode = "execute"
 
 [actions.squash]
 description = "Squash changes to the selected file into the parent change"
-command = "jj squash -- '{}'"
+command = "jj squash -- {}"
 mode = "fork"
 
 [actions.absorb]
 description = "Absorb changes to the selected file into the appropriate ancestor"
-command = "jj absorb -- '{}'"
+command = "jj absorb -- {}"
 mode = "fork"

--- a/cable/unix/jj-files.toml
+++ b/cable/unix/jj-files.toml
@@ -16,11 +16,11 @@ ctrl-r = "actions:restore"
 
 [actions.edit]
 description = "Open the selected file in editor"
-command = "${EDITOR:-vim} '{}'"
+command = "${EDITOR:-vim} {}"
 shell = "bash"
 mode = "execute"
 
 [actions.restore]
 description = "Discard changes to the selected file"
-command = "jj restore '{}'"
+command = "jj restore {}"
 mode = "fork"

--- a/cable/unix/journal.toml
+++ b/cable/unix/journal.toml
@@ -15,10 +15,10 @@ preview_panel = { size = 70 }
 
 [actions.logs]
 description = "Follow live logs for the selected identifier"
-command = "journalctl -f SYSLOG_IDENTIFIER='{}'"
+command = "journalctl -f SYSLOG_IDENTIFIER={}"
 mode = "execute"
 
 [actions.full]
 description = "View all logs for the selected identifier in a pager"
-command = "journalctl -b --no-pager -o short-iso SYSLOG_IDENTIFIER='{}' | less"
+command = "journalctl -b --no-pager -o short-iso SYSLOG_IDENTIFIER={} | less"
 mode = "fork"

--- a/cable/unix/k8s-contexts.toml
+++ b/cable/unix/k8s-contexts.toml
@@ -18,10 +18,10 @@ ctrl-d = "actions:delete"
 
 [actions.use]
 description = "Switch to the selected context"
-command = "kubectl config use-context '{}'"
+command = "kubectl config use-context {}"
 mode = "execute"
 
 [actions.delete]
 description = "Delete the selected context"
-command = "kubectl config delete-context '{}'"
+command = "kubectl config delete-context {}"
 mode = "execute"

--- a/cable/unix/mounts.toml
+++ b/cable/unix/mounts.toml
@@ -15,5 +15,5 @@ enter = "actions:cd"
 
 [actions.cd]
 description = "Open a shell in the selected mount point"
-command = "cd '{}' && $SHELL"
+command = "cd {} && $SHELL"
 mode = "execute"

--- a/cable/unix/npm-packages.toml
+++ b/cable/unix/npm-packages.toml
@@ -11,10 +11,10 @@ command = "npm info '{}' 2>/dev/null | head -30"
 
 [actions.uninstall]
 description = "Uninstall the selected global package"
-command = "npm uninstall -g '{}'"
+command = "npm uninstall -g {}"
 mode = "execute"
 
 [actions.update]
 description = "Update the selected global package"
-command = "npm update -g '{}'"
+command = "npm update -g {}"
 mode = "execute"

--- a/cable/unix/path.toml
+++ b/cable/unix/path.toml
@@ -11,5 +11,5 @@ command = "fd -tx -d1 . \"{}\" -X printf \"%s\n\" \"{/}\" | sort -f | bat -n --c
 
 [actions.cd]
 description = "Open a shell in the selected PATH directory"
-command = "cd '{}' && $SHELL"
+command = "cd {} && $SHELL"
 mode = "execute"

--- a/cable/unix/pdf-files.toml
+++ b/cable/unix/pdf-files.toml
@@ -20,5 +20,5 @@ enter = "actions:open"
 
 [actions.open]
 description = "Open the selected PDF with default viewer"
-command = "xdg-open '{}' 2>/dev/null || open '{}'"
+command = "xdg-open {} 2>/dev/null || open {}"
 mode = "fork"

--- a/cable/unix/pip-packages.toml
+++ b/cable/unix/pip-packages.toml
@@ -18,10 +18,10 @@ ctrl-d = "actions:uninstall"
 
 [actions.upgrade]
 description = "Upgrade the selected package"
-command = "pip install --upgrade '{}'"
+command = "pip install --upgrade {}"
 mode = "execute"
 
 [actions.uninstall]
 description = "Uninstall the selected package"
-command = "pip uninstall '{}'"
+command = "pip uninstall {}"
 mode = "execute"

--- a/cable/unix/recent-files.toml
+++ b/cable/unix/recent-files.toml
@@ -18,6 +18,6 @@ enter = "actions:edit"
 
 [actions.edit]
 description = "Open the selected file in editor"
-command = "${EDITOR:-vim} '{}'"
+command = "${EDITOR:-vim} {}"
 shell = "bash"
 mode = "execute"

--- a/cable/unix/ssh-hosts.toml
+++ b/cable/unix/ssh-hosts.toml
@@ -14,5 +14,5 @@ enter = "actions:connect"
 
 [actions.connect]
 description = "SSH into the selected host"
-command = "ssh '{}'"
+command = "ssh {}"
 mode = "execute"

--- a/cable/unix/tailscale-exit-node.toml
+++ b/cable/unix/tailscale-exit-node.toml
@@ -14,5 +14,5 @@ enter = "actions:connect"
 
 [actions.connect]
 description = "Set selected host as exit node"
-command = "tailscale set --exit-node='{}'"
+command = "tailscale set --exit-node={}"
 mode = "execute"

--- a/cable/unix/zoxide.toml
+++ b/cable/unix/zoxide.toml
@@ -17,10 +17,10 @@ ctrl-d = "actions:remove"
 
 [actions.cd]
 description = "Change to the selected directory"
-command = "cd '{}' && $SHELL"
+command = "cd {} && $SHELL"
 mode = "execute"
 
 [actions.remove]
 description = "Remove the selected directory from zoxide"
-command = "zoxide remove '{}'"
+command = "zoxide remove {}"
 mode = "fork"


### PR DESCRIPTION
Since `format_command()` already wraps each entry in single quotes when substituting a bare `{}` placeholder, having `'{}'` in the channel config results in `''entry''`, which the shell parses as an unquoted string. This breaks any action on entries containing spaces, e.g. in the `downloads`, `dirs`, `files` and `zoxide` channels:

```
rm: cannot remove '/home/user/Downloads/Ethereum': No such file or directory
rm: cannot remove 'Flakes.pdf': No such file or directory
```

Preview commands are left untouched since they go through `Template::format` which does not auto-quote.

Fixes #976