### PR TITLE
fix(channel): clear reloading flag event-driven instead of fixed 200ms

### DIFF
--- a/television/channels/channel.rs
+++ b/television/channels/channel.rs
@@ -16,8 +16,6 @@ use rustc_hash::{FxBuildHasher, FxHashSet};
 use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::process::Stdio;
-use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
 use std::time::Duration;
 use tokio::process::Command as TokioCommand;
 use tokio::{
@@ -26,7 +24,13 @@ use tokio::{
 };
 use tracing::debug;
 
-const RELOAD_RENDERING_DELAY: Duration = Duration::from_millis(200);
+/// Factory that rebuilds a fresh `SortStrategy` for each new staging matcher.
+///
+/// `SortStrategy::Custom` holds a `Box<dyn SortFn>` which is not `Clone`, so we
+/// can't reuse the strategy across matchers. Instead we keep a closure that
+/// knows how to produce a new one (re-capturing any shared state such as the
+/// frecency cache) on every reload.
+type SortStrategyFactory<D> = Box<dyn FnMut() -> SortStrategy<D> + Send>;
 
 pub struct Channel<P: EntryProcessor> {
     pub source_command: CommandSpec,
@@ -34,13 +38,16 @@ pub struct Channel<P: EntryProcessor> {
     pub source_output: Option<Template>,
     pub supports_preview: bool,
     processor: P,
+    /// The matcher serving results to the UI. See `reload()` for the swap.
     matcher: Matcher<P::Data>,
     selected_entries: FxHashSet<Entry>,
     crawl_handle: Option<tokio::task::JoinHandle<()>>,
     current_source_index: usize,
-    /// Indicates if the channel is currently reloading to prevent UI flickering
-    /// by delaying the rendering of a new frame.
-    pub reloading: Arc<AtomicBool>,
+    /// Accumulates the new source's output during a reload; swapped into
+    /// `matcher` by `try_swap_staging()`.
+    staging_matcher: Option<Matcher<P::Data>>,
+    staging_crawl_handle: Option<tokio::task::JoinHandle<()>>,
+    sort_strategy_factory: SortStrategyFactory<P::Data>,
     /// Whether this channel reads from stdin directly instead of spawning a
     /// source command. When true, `load()` reads `tokio::io::stdin()` and
     /// `reload()` is a no-op (stdin can only be consumed once).
@@ -61,31 +68,35 @@ impl<P: EntryProcessor> Channel<P> {
     ) -> Self {
         let config = Config::default().prefer_prefix(true);
 
-        let sort_strategy = if no_sort {
-            SortStrategy::Index
-        } else if let Some((frecency_handle, channel_name)) = frecency {
-            let cache = frecency_handle.create_cache(channel_name);
-            SortStrategy::Custom(Box::new(move |m1, i1, m2, i2| {
-                let scores = cache.snapshot();
-                let key1 = P::frecency_key(&i1);
-                let key2 = P::frecency_key(&i2);
-                let f1 = scores.get(&key1);
-                let f2 = scores.get(&key2);
+        let mut sort_strategy_factory: SortStrategyFactory<P::Data> =
+            if no_sort {
+                Box::new(|| SortStrategy::Index)
+            } else if let Some((frecency_handle, channel_name)) = frecency {
+                let cache = frecency_handle.create_cache(channel_name);
+                Box::new(move || {
+                    let cache = cache.clone();
+                    SortStrategy::Custom(Box::new(move |m1, i1, m2, i2| {
+                        let scores = cache.snapshot();
+                        let key1 = P::frecency_key(&i1);
+                        let key2 = P::frecency_key(&i2);
+                        let f1 = scores.get(&key1);
+                        let f2 = scores.get(&key2);
 
-                match (f1, f2) {
-                    (Some(s1), Some(s2)) => {
-                        s2.cmp(&s1).then_with(|| m2.score.cmp(&m1.score))
-                    }
-                    (Some(_), None) => Ordering::Less,
-                    (None, Some(_)) => Ordering::Greater,
-                    (None, None) => m2.score.cmp(&m1.score),
-                }
-            }))
-        } else {
-            SortStrategy::Score
-        };
+                        match (f1, f2) {
+                            (Some(s1), Some(s2)) => s2
+                                .cmp(&s1)
+                                .then_with(|| m2.score.cmp(&m1.score)),
+                            (Some(_), None) => Ordering::Less,
+                            (None, Some(_)) => Ordering::Greater,
+                            (None, None) => m2.score.cmp(&m1.score),
+                        }
+                    }))
+                })
+            } else {
+                Box::new(|| SortStrategy::Score)
+            };
 
-        let matcher = Matcher::new(&config, sort_strategy);
+        let matcher = Matcher::new(&config, sort_strategy_factory());
         let current_source_index = 0;
         Self {
             source_command,
@@ -97,7 +108,9 @@ impl<P: EntryProcessor> Channel<P> {
             selected_entries: HashSet::with_hasher(FxBuildHasher),
             crawl_handle: None,
             current_source_index,
-            reloading: Arc::new(AtomicBool::new(false)),
+            staging_matcher: None,
+            staging_crawl_handle: None,
+            sort_strategy_factory,
             is_stdin,
         }
     }
@@ -123,32 +136,44 @@ impl<P: EntryProcessor> Channel<P> {
         self.crawl_handle = Some(crawl_handle);
     }
 
+    /// Reload the channel's source with fzf-style atomic-swap semantics.
+    ///
+    /// Builds a fresh *staging* matcher and feeds the new source into it; the
+    /// live matcher keeps serving the previous snapshot until `tick()` swaps
+    /// staging in. The swap is event-driven (no time cap): it fires when
+    /// staging has items, or when the crawl task exits with no output. A
+    /// source that hangs indefinitely keeps the previous snapshot on screen.
     pub fn reload(&mut self) {
         if self.is_stdin {
             debug!("Stdin channel cannot be reloaded, skipping.");
             return;
         }
-        if self.reloading.load(std::sync::atomic::Ordering::Relaxed) {
+        if self.staging_matcher.is_some() {
             debug!("Reload already in progress, skipping.");
             return;
         }
-        self.reloading
-            .store(true, std::sync::atomic::Ordering::Relaxed);
 
-        if let Some(handle) = self.crawl_handle.take()
-            && !handle.is_finished()
-        {
-            handle.abort();
+        // Mirror the current pattern onto staging so the post-swap snapshot is
+        // already filtered to what the user typed during the reload window.
+        let config = Config::default().prefer_prefix(true);
+        let mut staging =
+            Matcher::new(&config, (self.sort_strategy_factory)());
+        if !self.matcher.last_pattern.is_empty() {
+            staging.find(&self.matcher.last_pattern);
         }
-        self.matcher.restart();
-        self.load();
-        // Spawn a thread that turns off reloading after a short delay
-        // to avoid UI flickering (this boolean is used by `Television::should_render`)
-        let reloading = self.reloading.clone();
-        tokio::spawn(async move {
-            tokio::time::sleep(RELOAD_RENDERING_DELAY).await;
-            reloading.store(false, std::sync::atomic::Ordering::Relaxed);
-        });
+
+        let injector = staging.injector();
+        let processor = self.processor.clone();
+        let crawl_handle = tokio::spawn(load_candidates(
+            self.source_command.clone(),
+            self.source_entry_delimiter,
+            self.current_source_index,
+            processor,
+            injector,
+        ));
+
+        self.staging_matcher = Some(staging);
+        self.staging_crawl_handle = Some(crawl_handle);
     }
 
     pub fn current_command(&self) -> &str {
@@ -157,18 +182,55 @@ impl<P: EntryProcessor> Channel<P> {
 
     pub fn find(&mut self, pattern: &str) {
         self.matcher.find(pattern);
+        // Mirror onto staging so the post-swap snapshot is already filtered.
+        if let Some(staging) = self.staging_matcher.as_mut() {
+            staging.find(pattern);
+        }
     }
 
     /// Let the background matcher thread make progress.
     ///
-    /// This is cheap and should be called frequently (e.g. every update cycle)
-    /// to keep the matcher responsive, even when results aren't being fetched.
+    /// Cheap, call every update cycle. Also drives the staging swap when a
+    /// reload is in flight.
     pub fn tick(&mut self) {
         self.matcher.tick();
+        self.try_swap_staging();
+    }
+
+    /// Swap staging into the live slot once staging has items, or once its
+    /// crawl task exits with nothing emitted. A source that hangs with no
+    /// output never triggers a swap — the previous snapshot stays on screen.
+    fn try_swap_staging(&mut self) {
+        let Some(staging) = self.staging_matcher.as_mut() else {
+            return;
+        };
+        staging.tick();
+        let has_items = staging.total_item_count > 0;
+        let source_finished = self
+            .staging_crawl_handle
+            .as_ref()
+            .is_some_and(tokio::task::JoinHandle::is_finished);
+        if !has_items && !source_finished {
+            return;
+        }
+
+        self.matcher = self.staging_matcher.take().unwrap();
+
+        // The new source may still be streaming more items; move its handle
+        // into `crawl_handle` so `running()` keeps reporting accurately.
+        if let Some(old) = self.crawl_handle.take()
+            && !old.is_finished()
+        {
+            old.abort();
+        }
+        self.crawl_handle = self.staging_crawl_handle.take();
     }
 
     pub fn results(&mut self, num_entries: u32, offset: u32) -> Vec<Entry> {
-        self.matcher.tick();
+        // Channel-level tick so a pending staging swap is applied before we
+        // read results; a bare `self.matcher.tick()` would return one last
+        // snapshot from the old matcher.
+        self.tick();
 
         let results = self.matcher.results(num_entries, offset);
 
@@ -210,6 +272,13 @@ impl<P: EntryProcessor> Channel<P> {
         self.matcher.total_item_count
     }
 
+    /// Whether the channel is actively producing results the user can see.
+    ///
+    /// Ignores the staging matcher on purpose: during an atomic-swap reload
+    /// the user is still looking at a stable list, so the UI's loading
+    /// indicator should stay off until the swap happens. The initial load is
+    /// still reported (no live results yet), and after a swap the former
+    /// staging handle moves into `crawl_handle` so this stays accurate.
     pub fn running(&self) -> bool {
         self.matcher.status.running
             || (self.crawl_handle.is_some()
@@ -234,10 +303,6 @@ impl<P: EntryProcessor> Channel<P> {
 
     pub fn supports_preview(&self) -> bool {
         self.supports_preview
-    }
-
-    pub fn reloading(&self) -> bool {
-        self.reloading.load(std::sync::atomic::Ordering::Relaxed)
     }
 
     pub fn source_index(&self) -> usize {
@@ -587,7 +652,6 @@ impl ChannelKind {
         running() -> bool,
         shutdown() -> (),
         supports_preview() -> bool,
-        reloading() -> bool,
         source_index() -> usize,
         source_count() -> usize,
         is_stdin() -> bool,

--- a/television/channels/channel.rs
+++ b/television/channels/channel.rs
@@ -824,4 +824,275 @@ mod tests {
         assert_eq!(results[1].matched_string, "test2");
         assert_eq!(results[2].matched_string, "test3");
     }
+
+    /// Builds a non-stdin `Channel<PlainProcessor>` from a shell command
+    /// string, for tests that exercise reload/tick state machines.
+    fn build_channel(command: &str) -> Channel<PlainProcessor> {
+        let source_spec: SourceSpec = toml::from_str(&format!(
+            r#"command = "{}""#,
+            command.replace('"', r#"\""#)
+        ))
+        .unwrap();
+        Channel::new(
+            source_spec.command,
+            source_spec.entry_delimiter,
+            None,
+            false,
+            false,
+            PlainProcessor,
+            None,
+            false,
+        )
+    }
+
+    /// A source that produces items triggers the swap on the first batch.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+    async fn test_reload_swaps_when_items_arrive() {
+        let mut channel = build_channel("echo 'a\\nb\\nc'");
+        channel.load();
+        // Wait for initial load to finish.
+        let start = Instant::now();
+        while channel.running() && start.elapsed() < Duration::from_millis(500)
+        {
+            channel.tick();
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+
+        channel.reload();
+        assert!(
+            channel.staging_matcher.is_some(),
+            "staging should be active immediately after reload",
+        );
+
+        let start = Instant::now();
+        while channel.staging_matcher.is_some()
+            && start.elapsed() < Duration::from_millis(500)
+        {
+            channel.tick();
+            tokio::time::sleep(Duration::from_millis(2)).await;
+        }
+
+        assert!(
+            channel.staging_matcher.is_none(),
+            "staging should clear once items arrive (elapsed: {:?})",
+            start.elapsed()
+        );
+    }
+
+    /// A source that emits nothing still needs to swap — otherwise the UI
+    /// would be stuck on the old snapshot forever. The trigger is the crawl
+    /// task exiting.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+    async fn test_reload_swaps_when_empty_source_finishes() {
+        let mut channel = build_channel("true");
+        channel.load();
+        let start = Instant::now();
+        while channel.running() && start.elapsed() < Duration::from_millis(500)
+        {
+            channel.tick();
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+
+        channel.reload();
+        assert!(channel.staging_matcher.is_some());
+
+        let start = Instant::now();
+        while channel.staging_matcher.is_some()
+            && start.elapsed() < Duration::from_millis(500)
+        {
+            channel.tick();
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        assert!(
+            channel.staging_matcher.is_none(),
+            "staging should clear once the empty source task finishes"
+        );
+    }
+
+    /// While a reload is in flight against a slow source, the channel must
+    /// keep serving the old results — never an empty list. This is the
+    /// core atomic-swap invariant that prevents `--watch` flicker.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+    async fn test_reload_keeps_old_results_visible_until_swap() {
+        let mut channel = build_channel("echo 'a\\nb\\nc'");
+        channel.load();
+
+        // Wait for the initial source to land.
+        let start = Instant::now();
+        while channel.result_count() < 3
+            && start.elapsed() < Duration::from_millis(500)
+        {
+            channel.tick();
+            channel.find("");
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        assert_eq!(
+            channel.result_count(),
+            3,
+            "initial source should have produced three entries"
+        );
+
+        // Slow second source so the swap can't happen on the first tick —
+        // we need a window in which to observe staging-in-flight behavior.
+        let slow_spec: SourceSpec =
+            toml::from_str(r#"command = "sleep 0.08 && echo 'z'""#).unwrap();
+        channel.source_command = slow_spec.command;
+        channel.reload();
+        assert!(
+            channel.staging_matcher.is_some(),
+            "staging should be active immediately after reload",
+        );
+
+        // Invariant under test: while staging is in flight, the live matcher
+        // still holds the old three entries. Check staging BEFORE the count
+        // so the two observations come from the same tick.
+        let mut swapped = false;
+        let start = Instant::now();
+        while start.elapsed() < Duration::from_millis(400) {
+            channel.find("");
+            let staging_before = channel.staging_matcher.is_some();
+            let count = channel.result_count();
+            if staging_before {
+                assert!(
+                    count >= 3,
+                    "old results must stay visible during reload (saw {count})",
+                );
+            } else {
+                swapped = true;
+                let end = Instant::now();
+                while channel.running()
+                    && end.elapsed() < Duration::from_millis(300)
+                {
+                    channel.tick();
+                    tokio::time::sleep(Duration::from_millis(2)).await;
+                }
+                channel.find("");
+                channel.tick();
+                assert_eq!(
+                    channel.result_count(),
+                    1,
+                    "after swap, new source's entries should be live"
+                );
+                break;
+            }
+            channel.tick();
+            tokio::time::sleep(Duration::from_millis(2)).await;
+        }
+        assert!(swapped, "reload should have swapped within the time budget");
+    }
+
+    /// `running()` is true during the initial load (no live results yet)
+    /// but false during a staging-only reload (user sees stable old list).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+    async fn test_running_ignores_staging_but_not_initial_load() {
+        let mut channel = build_channel("echo 'a\\nb\\nc'");
+        channel.load();
+        assert!(
+            channel.running(),
+            "running() must be true during the initial load (no live results yet)"
+        );
+
+        // Drain the initial load. `find("")` must run inside the loop so the
+        // matcher surfaces items into `result_count`.
+        let start = Instant::now();
+        while channel.result_count() < 3
+            && start.elapsed() < Duration::from_millis(500)
+        {
+            channel.tick();
+            channel.find("");
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        assert_eq!(
+            channel.result_count(),
+            3,
+            "initial load must have populated the live matcher"
+        );
+        // The crawl handle can lag the last item by a tick; wait it out.
+        let start = Instant::now();
+        while channel.running() && start.elapsed() < Duration::from_millis(500)
+        {
+            channel.tick();
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        assert!(
+            !channel.running(),
+            "after initial load completes, running() must be false"
+        );
+
+        // Slow source so staging is guaranteed to still be in flight when
+        // we observe `running()`.
+        let slow_spec: SourceSpec =
+            toml::from_str(r#"command = "sleep 0.08 && echo 'z'""#).unwrap();
+        channel.source_command = slow_spec.command;
+        channel.reload();
+        assert!(
+            channel.staging_matcher.is_some(),
+            "staging is the implementation-level signal, still set"
+        );
+        assert!(
+            !channel.running(),
+            "running() must be false while staging is in flight — the user still sees stable old results"
+        );
+
+        // Confirm the invariant holds across ticks, not just on first obs.
+        for _ in 0..3 {
+            channel.tick();
+            if channel.staging_matcher.is_none() {
+                break;
+            }
+            assert!(
+                !channel.running(),
+                "running() must stay false across staging ticks"
+            );
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    }
+
+    /// A source that hangs with no output must not swap to empty — the
+    /// previous matcher stays live until the new source emits or exits.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+    async fn test_reload_does_not_swap_to_empty_while_source_hangs() {
+        let mut channel = build_channel("echo 'a\\nb\\nc'");
+        channel.load();
+        let start = Instant::now();
+        while channel.result_count() < 3
+            && start.elapsed() < Duration::from_millis(500)
+        {
+            channel.tick();
+            channel.find("");
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        assert_eq!(channel.result_count(), 3);
+
+        let slow_spec: SourceSpec =
+            toml::from_str(r#"command = "sleep 5""#).unwrap();
+        channel.source_command = slow_spec.command;
+        channel.reload();
+        assert!(channel.staging_matcher.is_some());
+
+        // Tick for long enough that any timer-based fallback would fire.
+        // Staging must stay in flight and the live matcher keeps old entries.
+        let start = Instant::now();
+        while start.elapsed() < Duration::from_millis(400) {
+            channel.tick();
+            channel.find("");
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        assert!(
+            channel.staging_matcher.is_some(),
+            "staging must stay in flight while the source hangs with no output",
+        );
+        assert_eq!(
+            channel.result_count(),
+            3,
+            "old results must remain visible while the source hangs (no flicker to empty)",
+        );
+
+        // Don't leak the child for 5 seconds after the test exits.
+        if let Some(h) = channel.staging_crawl_handle.take() {
+            h.abort();
+        }
+    }
 }

--- a/television/matcher/mod.rs
+++ b/television/matcher/mod.rs
@@ -84,8 +84,14 @@ where
     /// Tick the fuzzy matcher.
     ///
     /// This should be called periodically to update the state of the matcher.
+    /// It also refreshes `total_item_count` and `matched_item_count` from the
+    /// latest snapshot so callers can observe progress without having to call
+    /// `results()` first.
     pub fn tick(&mut self) {
         self.status = self.inner.tick(MATCHER_TICK_TIMEOUT).into();
+        let snapshot = self.inner.snapshot();
+        self.total_item_count = snapshot.item_count();
+        self.matched_item_count = snapshot.matched_item_count();
     }
 
     /// Get an injector that can be used to push items into the fuzzy matcher.

--- a/television/television.rs
+++ b/television/television.rs
@@ -575,7 +575,7 @@ impl Television {
     /// triggered the update.
     fn should_render(&self, action: &Action) -> bool {
         // always render the first N ticks
-        (self.ticks < FIRST_TICKS_TO_RENDER
+        self.ticks < FIRST_TICKS_TO_RENDER
             // then render at regular intervals
             || self.ticks.is_multiple_of(RENDERING_INTERVAL)
             // more frequently if the channel is running
@@ -613,12 +613,7 @@ impl Television {
                     | Action::CycleSources
                     | Action::CyclePreviews
                     | Action::ReloadSource
-            ))
-            // We want to avoid too much rendering while the channel is reloading
-            // to prevent UI flickering.
-            && !self
-                .channel
-                .reloading()
+            )
     }
 
     pub fn update_preview_state(


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is fully vibe coded, I just preferred providing a solution instead of just ranting in an issue, feel free to close it and use it only as inspiration if its not up to the repo's standards.

## Motivation

I'm porting a shell-script session picker to a television channel. It refreshes a tmux/sesh list every ~250ms and each row has a small spinner indicator for whether the Claude session attached to that window is waiting for input.

Under fzf (with `reload-sync`) the refresh is invisible: old rows stay on screen until new rows are ready, then they swap in one frame. Under `tv <channel> --watch 0.3` the list flickers on every refresh — noticeable on its own, very visible on the spinner — because the blank frame lands right where the glyph would animate. Same source, same cadence, so this is a `--watch` rendering issue in tv.

## Root cause

Two things compound in `Channel::reload()`:

1. `matcher.restart()` drops the previous snapshot up-front, leaving the matcher empty for the whole source runtime.
2. `Television::should_render` is AND-gated on `!channel.reloading()`, a flag cleared by a fixed `200ms` sleep. The UI is frozen for 200ms regardless of source speed — and if the source is slower than 200ms (e.g. `fd . $HOME --type f`, ~270ms), the flag gets re-set on the next watch tick before the previous load finishes, so the UI never unfreezes.

## Fix: fzf-style atomic swap

`reload()` now builds a fresh *staging* matcher and feeds the new source into it. The live matcher keeps serving the previous snapshot — `results()`, `find()`, rendering, scrolling all stay responsive — until `tick()` swaps staging in as a single statement. The swap is purely event-driven: it fires when staging has items, or when the staging crawl task exits with no output.

Supporting pieces:

- `find()` is mirrored onto staging so the post-swap snapshot is already filtered to whatever the user typed during the reload window.
- `SortStrategy::Custom` holds a `Box<dyn SortFn>` that isn't `Clone`, so we carry a `SortStrategyFactory` closure that builds a fresh strategy per staging matcher. Frecency caches are `Arc`-cloned in.
- `running()` ignores staging. During a reload the user sees a stable list, so the UI's loading indicator should stay off. The initial load still reports running (no live results yet), and after a swap the former staging handle moves into `crawl_handle` so `running()` stays accurate while the new source drains.
- The `reloading` flag, the `should_render` gate, the `reload_deadline` field, and the `RELOAD_RENDERING_DELAY` constant all go away — the atomic swap replaces them.

## Behavior change

A source that hangs without producing output no longer times out to an empty list after 200ms — it keeps showing stale data. This is strictly better than flickering to empty: the stale data is at least coherent, and `--watch` retries on its next tick anyway.

## Repro

Before this PR, this flickers every 300ms on most terminals:

```sh
cat >/tmp/watch-flicker.toml <<'TOML'
[metadata]
name = "flicker-demo"

[source]
command = "seq 1 30 && date +%S.%N"
TOML

tv --cable-dir /tmp --config flicker-demo --watch 0.3
```

After this PR the list is stable; only the clock value (last line) changes in place. A source slower than 200ms (e.g. `fd . $HOME --type f`) also no longer flickers to empty.

## Tests

- `test_reload_swaps_when_items_arrive` — swap fires as soon as the new source produces output.
- `test_reload_swaps_when_empty_source_finishes` — with a source that emits nothing (`true`), swap fires once the crawl task exits.
- `test_reload_keeps_old_results_visible_until_swap` — against a slow source (~80ms), `result_count()` stays at the pre-reload value for the full reload window, then flips to the new value after the swap.
- `test_reload_does_not_swap_to_empty_while_source_hangs` — against `sleep 5`, staging stays in flight well past any prior time cap; old entries remain visible.
- `test_running_ignores_staging_but_not_initial_load` — `running()` is true during the initial load and false during a staging-only reload.

`cargo test --all --all-features`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo fmt --check` all pass locally on macOS.
