### PR TITLE
fix(cli): prioritize registered channel over path when argument matches both

### DIFF
--- a/television/cli/mod.rs
+++ b/television/cli/mod.rs
@@ -1,13 +1,13 @@
 use crate::{
     action::{Action, Actions},
-    cable::Cable,
+    cable::{CABLE_DIR_NAME, Cable, load_cable},
     channels::prototypes::{ChannelPrototype, Template},
     cli::args::{Cli, Command},
     config::{
         Keybindings, get_config_dir, get_data_dir, merge_keybindings,
         ui::{BorderType, Padding},
     },
-    errors::cli_parsing_error_exit,
+    errors::{cli_parsing_error_exit, unknown_channel_exit},
     event::Key,
     screen::layout::{InputPosition, Orientation},
     utils::paths::expand_tilde,
@@ -238,11 +238,24 @@ pub fn post_process(cli: Cli, readable_stdin: bool) -> PostProcessedCli {
         );
     }
 
+    // Load cable to resolve channel vs path ambiguity (issue #1043)
+    let cable_dir = cli
+        .cable_dir
+        .as_ref()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| get_config_dir().join(CABLE_DIR_NAME));
+    let cable = load_cable(&cable_dir);
+
     // Determine channel and working_directory
+    // Priority: registered channel > path fallback (issue #1043)
     let (channel, working_directory) = match &cli.channel {
-        Some(c) if Path::new(c).exists() => {
-            // If the channel is a path, use it as the working directory
-            (None, Some(PathBuf::from(c)))
+        Some(c) if !cable.has_channel(c) => {
+            // Not a registered channel — if it exists as a path, use it as working directory
+            if cli.working_directory.is_none() && Path::new(c).exists() {
+                (None, Some(PathBuf::from(c)))
+            } else {
+                unknown_channel_exit(c);
+            }
         }
         _ => (
             cli.channel.clone(),

--- a/television/cli/mod.rs
+++ b/television/cli/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     action::{Action, Actions},
-    cable::{CABLE_DIR_NAME, Cable, load_cable},
+    cable::Cable,
     channels::prototypes::{ChannelPrototype, Template},
     cli::args::{Cli, Command},
     config::{
@@ -147,6 +147,9 @@ pub struct GlobalCli {
 
 /// Post-processes the raw CLI arguments into a structured format with validation.
 ///
+/// `cable` is consulted to resolve the first positional arg when it could be either
+/// a registered channel name or a path on disk: a registered channel always wins.
+///
 /// This function handles the two main CLI use cases:
 ///
 /// **Channel-based mode**: When `cli.channel` is provided, all flags are treated as
@@ -159,7 +162,11 @@ pub struct GlobalCli {
 /// - Source flags (`--source-display`, `--source-output`) require `--source-command`
 ///
 /// This prevents creating broken ad-hoc channels that reference non-existent commands.
-pub fn post_process(cli: Cli, readable_stdin: bool) -> PostProcessedCli {
+pub fn post_process(
+    cli: Cli,
+    readable_stdin: bool,
+    cable: &Cable,
+) -> PostProcessedCli {
     // Parse literal keybindings passed through the CLI
     let mut keybindings = cli.keybindings.as_ref().map(|kb| {
         parse_keybindings_literal(kb, CLI_KEYBINDINGS_DELIMITER)
@@ -215,9 +222,11 @@ pub fn post_process(cli: Cli, readable_stdin: bool) -> PostProcessedCli {
         })
     });
 
+    // Forbid `--autocomplete-prompt` together with a real channel arg.
+    // It's allowed when the arg resolves to a working-directory path (not a registered channel).
     if cli.autocomplete_prompt.is_some()
         && let Some(ch) = &cli.channel
-        && !Path::new(ch).exists()
+        && (cable.has_channel(ch) || !Path::new(ch).exists())
     {
         let mut cmd = Cli::command();
         let arg1 = "'--autocomplete-prompt <STRING>'".yellow();
@@ -238,19 +247,11 @@ pub fn post_process(cli: Cli, readable_stdin: bool) -> PostProcessedCli {
         );
     }
 
-    // Load cable to resolve channel vs path ambiguity (issue #1043)
-    let cable_dir = cli
-        .cable_dir
-        .as_ref()
-        .map(PathBuf::from)
-        .unwrap_or_else(|| get_config_dir().join(CABLE_DIR_NAME));
-    let cable = load_cable(&cable_dir);
-
-    // Determine channel and working_directory
-    // Priority: registered channel > path fallback (issue #1043)
+    // Resolve the first positional arg: registered channel takes precedence over
+    // a same-named path in the current directory. Falls back to treating the arg
+    // as a working directory only when it isn't a known channel and the path exists.
     let (channel, working_directory) = match &cli.channel {
         Some(c) if !cable.has_channel(c) => {
-            // Not a registered channel — if it exists as a path, use it as working directory
             if cli.working_directory.is_none() && Path::new(c).exists() {
                 (None, Some(PathBuf::from(c)))
             } else {
@@ -670,6 +671,14 @@ mod tests {
 
     use super::*;
 
+    fn test_cable() -> Cable {
+        Cable::from_prototypes(vec![
+            ChannelPrototype::new("files", "fd -t f"),
+            ChannelPrototype::new("dirs", "ls"),
+            ChannelPrototype::new("git", "git status"),
+        ])
+    }
+
     #[test]
     #[allow(clippy::float_cmp)]
     fn test_from_cli() {
@@ -680,7 +689,7 @@ mod tests {
             ..Default::default()
         };
 
-        let post_processed_cli = post_process(cli, false);
+        let post_processed_cli = post_process(cli, false, &test_cable());
 
         assert_eq!(
             post_processed_cli.channel.preview_command.unwrap().raw(),
@@ -701,13 +710,43 @@ mod tests {
             ..Default::default()
         };
 
-        let post_processed_cli = post_process(cli, false);
+        let post_processed_cli = post_process(cli, false, &test_cable());
 
         assert_eq!(
             post_processed_cli.global.workdir,
             Some(PathBuf::from("."))
         );
         assert_eq!(post_processed_cli.global.command, None);
+    }
+
+    /// Regression test for issue #1043: a registered channel name must take
+    /// precedence over a same-named subdirectory in the current working dir.
+    #[test]
+    fn test_channel_priority_over_same_named_path() {
+        struct CwdGuard(PathBuf);
+        impl Drop for CwdGuard {
+            fn drop(&mut self) {
+                let _ = std::env::set_current_dir(&self.0);
+            }
+        }
+
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir(tmp.path().join("files")).unwrap();
+        let _guard = CwdGuard(std::env::current_dir().unwrap());
+        std::env::set_current_dir(tmp.path()).unwrap();
+
+        let cli = Cli {
+            channel: Some("files".to_string()),
+            ..Default::default()
+        };
+        let post_processed_cli = post_process(cli, false, &test_cable());
+
+        assert_eq!(
+            post_processed_cli.channel.channel.as_deref(),
+            Some("files"),
+            "registered channel should win over same-named path"
+        );
+        assert_eq!(post_processed_cli.global.workdir, None);
     }
 
     #[test]
@@ -723,7 +762,7 @@ mod tests {
             ..Default::default()
         };
 
-        let post_processed_cli = post_process(cli, false);
+        let post_processed_cli = post_process(cli, false, &test_cable());
 
         let mut expected = Keybindings::new();
         expected.insert(Key::Esc, Action::Quit.into());

--- a/television/main.rs
+++ b/television/main.rs
@@ -20,6 +20,7 @@ use television::{
     gh::update_local_channels,
     television::Mode,
     utils::clipboard::CLIPBOARD,
+    utils::paths::expand_tilde,
     utils::{
         shell::{
             Shell, completion_script, render_autocomplete_script_template,
@@ -39,22 +40,26 @@ async fn main() -> Result<()> {
 
     let readable_stdin = is_readable_stdin();
 
-    let cli = post_process(Cli::parse(), readable_stdin);
-    debug!("PostProcessedCli: {:?}", cli);
+    let raw_cli = Cli::parse();
 
-    // load the configuration file
+    // Load configuration first so the cable directory it points to (which may differ
+    // from the default) is honored when resolving channel-vs-path ambiguity in post_process.
     debug!("Loading configuration...");
+    let config_file = raw_cli.config_file.as_deref().map(expand_tilde);
     let base_config =
-        Config::new(&ConfigEnv::init()?, cli.global.config_file.as_deref())?;
+        Config::new(&ConfigEnv::init()?, config_file.as_deref())?;
 
-    let cable_dir = cli
-        .global
+    let cable_dir = raw_cli
         .cable_dir
-        .clone()
+        .as_deref()
+        .map(expand_tilde)
         .unwrap_or_else(|| base_config.application.cable_dir.clone());
 
     debug!("Loading cable channels...");
     let cable = load_cable(&cable_dir);
+
+    let cli = post_process(raw_cli, readable_stdin, &cable);
+    debug!("PostProcessedCli: {:?}", cli);
 
     // handle subcommands
     debug!("Handling subcommands...");


### PR DESCRIPTION
Fixes #1043

## Problem

When a channel name (e.g., `npins`) coincides with a subdirectory in the current working directory, the CLI incorrectly treated the argument as a path and fell back to the default `files` channel.

For example, running `tv npins` in a project root with an `npins/` subdirectory would show files inside `npins/` instead of opening the `npins` channel.

This is a regression introduced in e76a3df (`refactor(cable)!: cable format redesign`), where the logic was changed from "check if it's a registered channel first" to "check if it's a path first".

## Fix

Restore the pre-e76a3df behavior in `post_process()`:
1. Load the cable directory to get all registered channel names
2. Check if the argument is a registered channel first
3. Only treat it as a working directory if it is NOT a registered channel AND the path exists
4. If it's neither a registered channel nor an existing path, exit with an unknown channel error

## Changes

| File | Change |
|------|--------|
| `television/cli/mod.rs` | Load cable in `post_process`; restore channel-first priority in the channel/path match block |
