### PR TITLE
feat(cable): add cables for fj and tea

### DIFF
--- a/cable/unix/fj-issues.toml
+++ b/cable/unix/fj-issues.toml
@@ -1,0 +1,37 @@
+[metadata]
+name = "fj-issues"
+description = "List Forgejo issues for the current repo"
+requirements = ["fj", "bat"]
+
+[source]
+command = '''fj issue search --state open | awk -F ' [(]by ' '/^#[0-9]+:/ {
+  number=$1; sub(/^#/,"",number); sub(/: .*/,"",number)
+  title=$1; sub(/^#[0-9]+: /,"",title)
+  author=$2; sub(/\)$/,"",author)
+  printf "\033[32m#%s\033[39m\t%s \033[33m@%s\033[39m\n", number, title, author
+}' '''
+ansi = true
+output = "{strip_ansi|split:\t:0|replace:s/^#//}"
+
+[ui]
+layout = "portrait"
+preview_panel = { header = '{strip_ansi|split:\t:1}' }
+
+[preview]
+command = "fj issue view {strip_ansi|split:\t:0|replace:s/^#//} | bat --language=md --style=plain --color=always"
+env = { BAT_THEME = "ansi" }
+
+[actions.open]
+description = "Open the issue in the browser"
+command = "fj issue browse {strip_ansi|split:\t:0|replace:s/^#//}"
+mode = "fork"
+
+[actions.close]
+description = "Close the selected issue"
+command = "fj issue close {strip_ansi|split:\t:0|replace:s/^#//}"
+mode = "fork"
+
+[actions.comment]
+description = "Add a comment to the selected issue"
+command = "fj issue comment {strip_ansi|split:\t:0|replace:s/^#//}"
+mode = "execute"

--- a/cable/unix/fj-prs.toml
+++ b/cable/unix/fj-prs.toml
@@ -1,0 +1,42 @@
+[metadata]
+name = "fj-prs"
+description = "List Forgejo PRs for the current repo"
+requirements = ["fj", "bat"]
+
+[source]
+command = '''fj pr search --state open | awk -F ' [(]by ' '/^#[0-9]+:/ {
+  number=$1; sub(/^#/,"",number); sub(/: .*/,"",number)
+  title=$1; sub(/^#[0-9]+: /,"",title)
+  author=$2; sub(/\)$/,"",author)
+  printf "\033[32m#%s\033[39m\t%s \033[33m@%s\033[39m\n", number, title, author
+}' '''
+ansi = true
+output = "{strip_ansi|split:\t:0|replace:s/^#//}"
+
+[ui]
+layout = "portrait"
+preview_panel = { header = '{strip_ansi|split:\t:1}' }
+
+[preview]
+command = "fj pr view {strip_ansi|split:\t:0|replace:s/^#//} | bat --language=md --style=plain --color=always"
+env = { BAT_THEME = "ansi" }
+
+[actions.open]
+description = "Open the PR in the browser"
+command = "fj pr browse {strip_ansi|split:\t:0|replace:s/^#//}"
+mode = "fork"
+
+[actions.checkout]
+description = "Checkout the PR branch locally"
+command = "fj pr checkout {strip_ansi|split:\t:0|replace:s/^#//}"
+mode = "execute"
+
+[actions.merge]
+description = "Merge the selected PR"
+command = "fj pr merge {strip_ansi|split:\t:0|replace:s/^#//}"
+mode = "execute"
+
+[actions.diff]
+description = "View the PR diff"
+command = "fj pr view {strip_ansi|split:\t:0|replace:s/^#//} diff | less"
+mode = "execute"

--- a/cable/unix/tea-issues.toml
+++ b/cable/unix/tea-issues.toml
@@ -1,0 +1,36 @@
+[metadata]
+name = "tea-issues"
+description = "List Gitea issues for the current repo"
+requirements = ["tea", "jq"]
+
+[source]
+command = '''tea issues list --output json --state open </dev/null | jq -r '.[] | "\u001b[32m#\(.index)\u001b[39m" + "\t\(.title) \u001b[33m@\(.author)\u001b[39m" + (if .labels != "" then " \u001b[35m" + .labels + "\u001b[39m" else "" end)'
+'''
+ansi = true
+output = "{strip_ansi|split:#:1|split:\t:0}"
+
+[ui]
+layout = "portrait"
+preview_panel = { header = '{strip_ansi|split:\t:1}' }
+
+[preview]
+command = '''tea issues --output json {strip_ansi|split:#:1|split:\t:0} </dev/null | jq -r '
+.title,
+"#" + (.index | tostring),
+"",
+"\u001b[36mStatus:\u001b[39m    \u001b[32m" + .state + "\u001b[39m",
+"\u001b[36mAuthor:\u001b[39m    \u001b[33m" + .user + "\u001b[39m",
+"\u001b[36mCreated:\u001b[39m   " + .created[:10],
+(if (.labels | length) > 0 then "\u001b[36mLabels:\u001b[39m    " + ([.labels[] | "\u001b[35m" + .name + "\u001b[39m"]
+| join(" ")) else empty end),
+"",
+"\u001b[90m────────────────────────────────────────────────────────────\u001b[39m",
+"",
+(.body // "")
+'
+'''
+
+[actions.close]
+description = "Close the selected issue"
+command = "tea issues close {strip_ansi|split:#:1|split:\t:0}"
+mode = "fork"

--- a/cable/unix/tea-prs.toml
+++ b/cable/unix/tea-prs.toml
@@ -1,0 +1,42 @@
+[metadata]
+name = "tea-prs"
+description = "List Gitea PRs for the current repo"
+requirements = ["tea", "jq"]
+
+[source]
+command = '''tea pulls list --output json --state open </dev/null | jq -r '.[] | "\u001b[32m#\(.index)\u001b[39m" + "\t\(.title) \u001b[33m@\(.author)\u001b[39m" + (if .labels != "" then " \u001b[35m" + .labels + "\u001b[39m" else "" end)'
+'''
+ansi = true
+output = "{strip_ansi|split:#:1|split:\t:0}"
+
+[ui]
+layout = "portrait"
+preview_panel = { header = '{strip_ansi|split:\t:1}' }
+
+[preview]
+command = '''tea pulls --output json {strip_ansi|split:#:1|split:\t:0} </dev/null | jq -r '
+.title,
+"#" + (.index | tostring),
+"",
+"\u001b[36mStatus:\u001b[39m     \u001b[32m" + .state + "\u001b[39m  " + .base + " ← " + .head,
+"\u001b[36mAuthor:\u001b[39m     \u001b[33m" + .user + "\u001b[39m",
+"\u001b[36mCreated:\u001b[39m    " + .created[:10],
+"\u001b[36mUpdated:\u001b[39m    " + .updated[:10],
+(if (.labels | length) > 0 then "\u001b[36mLabels:\u001b[39m     " + ([.labels[] | "\u001b[35m" + .name + "\u001b[39m"] | join(" ")) else empty end),
+"\u001b[36mMergeable:\u001b[39m  " + (if .mergeable then "\u001b[32m✓ Clean\u001b[39m" else "\u001b[31m✗ Dirty\u001b[39m" end),
+"",
+"\u001b[90m────────────────────────────────────────────────────────────\u001b[39m",
+"",
+(.body // "")
+'
+'''
+
+[actions.checkout]
+description = "Checkout the PR branch locally"
+command = "tea pulls checkout {strip_ansi|split:#:1|split:\t:0}"
+mode = "execute"
+
+[actions.merge]
+description = "Merge the selected PR"
+command = "tea pulls merge {strip_ansi|split:#:1|split:\t:0}"
+mode = "execute"


### PR DESCRIPTION
## 📺 PR Description

This PR introduces two new cables for alternative forge CLIs. These cables provide analogous functionality to `gh-prs` and `gh-issues`. Included are `tea-prs`, `tea-issues` to work with [tea](https://gitea.com/gitea/tea), and `fj-prs`, `fj-issues` to work with [forgejo-cli](https://codeberg.org/forgejo-contrib/forgejo-cli). Since forgejo forked from Gitea, `tea` is currently compatible with both instances, and in my opinion, the more mature of both CLI tools.

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [x] I have added a reasonable amount of documentation to the code where appropriate
