### PR TITLE
docs: add JetBrains IDE plugin link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ See [Shell Integration](https://alexpasmantier.github.io/television/user-guide/s
 - **Vim**: [tv.vim](https://github.com/prabirshrestha/tv.vim)
 - **VSCode**: [Television extension](https://marketplace.visualstudio.com/items?itemName=alexpasmantier.television)
 - **Zed**: [Telescope-style setup](https://zed.dev/blog/hidden-gems-part-2#emulate-vims-telescope-via-television)
+- **JetBrains IDEs**: [Television plugin](https://plugins.jetbrains.com/plugin/31448-television)
 
 ## Documentation
 


### PR DESCRIPTION
## 📺 PR Description

Hi! 

This PR adds the new JetBrains integration to the `Editor Integration` section of the README. 

I've been working on a plugin to bring the Television experience to the JetBrains ecosystem (IntelliJ, PyCharm, WebStorm, etc.). The implementation is heavily inspired by and based on [television-vscode](https://github.com/alexpasmantier/television-vscode). 

**Links:**
* **Marketplace:** [Television Plugin](https://plugins.jetbrains.com/plugin/31448-television)
* **Source Code:** [television-intellij-plugin](https://github.com/ckob/television-intellij-plugin)

Let me know if you need any adjustments to the README formatting. Or if you got any feedback on the integration itself. Thanks for building such an awesome tool!

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [ ] I have added a reasonable amount of documentation to the code where appropriate
