### PR TITLE
fix(update-channels): Use `GITHUB_TOKEN` to avoid request rate limit

### DIFF
--- a/television/gh.rs
+++ b/television/gh.rs
@@ -41,7 +41,7 @@ fn make_gh_request(url: &str) -> Result<RequestBuilder<WithoutBody>> {
 
     let headers = request.headers_mut().unwrap();
     if let Ok(token) = std::env::var("GITHUB_TOKEN") {
-        debug!("Use GITHUB_TOKEN from environment variables");
+        debug!("Using GITHUB_TOKEN environment variable");
         headers.insert("Authorization", HeaderValue::try_from(token)?);
     }
 

--- a/television/gh.rs
+++ b/television/gh.rs
@@ -3,7 +3,7 @@ use colored::Colorize;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use std::path::Path;
 use tracing::debug;
-use ureq::get;
+use ureq::{RequestBuilder, get, http::HeaderValue, typestate::WithoutBody};
 
 use crate::{
     cable::{CABLE_DIR_NAME, CHANNEL_FILE_FORMAT},
@@ -36,14 +36,25 @@ enum NodeType {
 const GITHUB_API_BASE_URL: &str =
     "https://api.github.com/repos/alexpasmantier/television/contents/";
 
+fn make_gh_request(url: &str) -> Result<RequestBuilder<WithoutBody>> {
+    let mut request = get(url).header("User-Agent", "television-client");
+
+    let headers = request.headers_mut().unwrap();
+    if let Ok(token) = std::env::var("GITHUB_TOKEN") {
+        debug!("Use GITHUB_TOKEN from environment variables");
+        headers.insert("Authorization", HeaderValue::try_from(token)?);
+    }
+
+    Ok(request)
+}
+
 fn make_gh_content_request(
     gh_dir: &Path,
     git_ref: &str,
 ) -> Result<Vec<GhNode>> {
     let url = format!("{}{}", GITHUB_API_BASE_URL, gh_dir.to_str().unwrap());
     debug!("Making GitHub API request to: {}", url);
-    get(&url)
-        .header("User-Agent", "television-client")
+    make_gh_request(&url)?
         .header("Accept", "application/vnd.github+json")
         .query("ref", git_ref)
         .call()
@@ -63,8 +74,8 @@ fn make_gh_content_request(
 }
 
 fn fetch_raw_content_from_url(url: &str) -> Result<String> {
-    let response =
-        get(url).header("User-Agent", "television-client").call()?;
+    let request = make_gh_request(url)?;
+    let response = request.call()?;
 
     if response.status().is_success() {
         Ok(response.into_body().read_to_string()?)


### PR DESCRIPTION
## 📺 PR Description

GitHub may reject requests with 429. Requests within an organization may be rejected more often because they share the same network client IP.

This change gives a way to isolate requests by `GITHUB_TOKEN` when available from the shell environment variable. e.g.

```bash
GITHUB_TOKEN="$(gh auth token)" tv update-channels
```

Just like the shell script version does here:
https://github.com/alexpasmantier/television/blob/f3cb4c4/scripts/update-channels.sh#L23

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [ ] I have added a reasonable amount of documentation to the code where appropriate
