### PR TITLE
fix(shell): correct PowerShell and interactive flag ordering

### DIFF
--- a/television/utils/command.rs
+++ b/television/utils/command.rs
@@ -25,8 +25,8 @@ static COMPLEX_BRACES_REGEX: &Lazy<Regex> = regex!(r"\{[^}]+\}");
 ///
 /// # Arguments
 /// * `command` - The command string to execute
-/// * `interactive` - Whether to run in interactive mode (adds `-i` on Unix,
-///   omits `-NoProfile` for `PowerShell`)
+/// * `interactive` - Whether to run in interactive mode (uses `-Interactive`
+///   for `PowerShell` and `-i` before `-c` for Unix-like shells)
 /// * `envs` - Environment variables to set for the command
 /// * `shell_override` - Optionally override the shell used to execute the command.
 ///   If `None`, the shell is detected from the environment.
@@ -43,17 +43,27 @@ pub fn shell_command<S>(
         .unwrap_or_else(|| Shell::from_env().unwrap_or_default());
     let mut cmd = Command::new(shell.executable());
 
-    cmd.args(match shell {
-        Shell::Psh if interactive => vec!["-NoLogo", "-Command"],
-        Shell::Psh => vec!["-NoLogo", "-NoProfile", "-Command"],
+    let args = match shell {
+        Shell::Psh if interactive => {
+            vec!["-NoLogo", "-OutputFormat", "Text", "-Interactive", "-Command"]
+        }
+        Shell::Psh => {
+            vec![
+                "-NoLogo",
+                "-OutputFormat",
+                "Text",
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+            ]
+        }
         Shell::Cmd => vec!["/C"],
+        #[cfg(unix)]
+        _ if interactive => vec!["-i", "-c"],
         _ => vec!["-c"],
-    });
+    };
 
-    #[cfg(unix)]
-    if interactive {
-        cmd.arg("-i");
-    }
+    cmd.args(args);
 
     cmd.envs(envs).arg(command);
     cmd
@@ -234,6 +244,7 @@ fn attach_to_tty(cmd: &mut Command) -> Result<()> {
 mod tests {
     use super::*;
     use crate::channels::entry::Entry;
+    use crate::utils::shell::Shell;
 
     #[test]
     fn test_simple_braces_syntactic_sugar() {
@@ -312,5 +323,52 @@ mod tests {
             result == "nvim 'file1\\'s.txt' 'file2.txt'"
                 || result == "nvim 'file2.txt' 'file1\\'s.txt'"
         );
+    }
+
+    #[test]
+    fn test_shell_command_powershell_interactive_args() {
+        let envs = HashMap::new();
+        let cmd = shell_command(
+            "Get-Date",
+            true,
+            &envs,
+            Some(Shell::Psh),
+        );
+
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+
+        assert_eq!(
+            args,
+            vec![
+                "-NoLogo",
+                "-OutputFormat",
+                "Text",
+                "-Interactive",
+                "-Command",
+                "Get-Date",
+            ]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_shell_command_unix_interactive_args_order() {
+        let envs = HashMap::new();
+        let cmd = shell_command(
+            "echo hi",
+            true,
+            &envs,
+            Some(Shell::Bash),
+        );
+
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+
+        assert_eq!(args, vec!["-i", "-c", "echo hi"]);
     }
 }

--- a/television/utils/command.rs
+++ b/television/utils/command.rs
@@ -45,7 +45,13 @@ pub fn shell_command<S>(
 
     let args = match shell {
         Shell::Psh if interactive => {
-            vec!["-NoLogo", "-OutputFormat", "Text", "-Interactive", "-Command"]
+            vec![
+                "-NoLogo",
+                "-OutputFormat",
+                "Text",
+                "-Interactive",
+                "-Command",
+            ]
         }
         Shell::Psh => {
             vec![
@@ -328,12 +334,7 @@ mod tests {
     #[test]
     fn test_shell_command_powershell_interactive_args() {
         let envs = HashMap::new();
-        let cmd = shell_command(
-            "Get-Date",
-            true,
-            &envs,
-            Some(Shell::Psh),
-        );
+        let cmd = shell_command("Get-Date", true, &envs, Some(Shell::Psh));
 
         let args: Vec<String> = cmd
             .get_args()
@@ -357,12 +358,7 @@ mod tests {
     #[test]
     fn test_shell_command_unix_interactive_args_order() {
         let envs = HashMap::new();
-        let cmd = shell_command(
-            "echo hi",
-            true,
-            &envs,
-            Some(Shell::Bash),
-        );
+        let cmd = shell_command("echo hi", true, &envs, Some(Shell::Bash));
 
         let args: Vec<String> = cmd
             .get_args()


### PR DESCRIPTION
## Summary
This PR fixes shell argument construction for PowerShell and interactive Unix shells in [television/utils/command.rs](television/utils/command.rs).

## What changed
- Build shell args as a single ordered list before appending command text.
- For `Shell::Psh` interactive mode, use:
  - `-NoLogo -OutputFormat Text -Interactive -Command <command>`
- For `Shell::Psh` non-interactive mode, use:
  - `-NoLogo -OutputFormat Text -NoProfile -NonInteractive -Command <command>`
- For Unix-like non-PowerShell interactive mode, ensure ordering is:
  - `-i -c <command>`

## Why
`-Command`/`-c` consume the next token as command text. Some flags were previously appended in positions where they could be parsed as part of the command payload rather than shell options.

This aligns behavior with Microsoft docs:
- about_Pwsh (PowerShell 7.6): https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_pwsh?view=powershell-7.6
- about_PowerShell_exe (Windows PowerShell 5.1): https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_powershell_exe?view=powershell-5.1&viewFallbackFrom=powershell-7.6

## Tests
Added regression tests in [television/utils/command.rs](television/utils/command.rs):
- `test_shell_command_powershell_interactive_args`
- `test_shell_command_unix_interactive_args_order`

Local validation:
- `cargo test utils::command::tests --lib`
