### PR TITLE
feat(shell): add xonsh integration

### DIFF
--- a/docs/developers/shell-integration-local.md
+++ b/docs/developers/shell-integration-local.md
@@ -8,9 +8,13 @@ In order to develop locally on the shell integration scripts, here are a couple 
    ```sh
    just generate-dev-shell-integration zsh
    ```
-   (or `fish`, `bash`, etc. depending on the shell you are using)
+   (or `fish`, `bash`, `xonsh`, etc. depending on the shell you are using)
 3. Source the generated script in your shell:
    ```sh
    source dev_shell_integration.zsh
+   ```
+   For xonsh, run:
+   ```xonsh
+   source dev_shell_integration.xonsh
    ```
 4. Test the changes by using the shell integration keybindings or commands in your terminal.

--- a/docs/user-guide/04-shell-integration.md
+++ b/docs/user-guide/04-shell-integration.md
@@ -58,6 +58,16 @@ mkdir ($nu.data-dir | path join "vendor/autoload")
 tv init nu | save -f ($nu.data-dir | path join "vendor/autoload/tv.nu")
 ```
 
+### Xonsh
+
+To enable shell integration for xonsh, add this to your `~/.xonshrc` file:
+
+```xonsh
+execx($(tv init xonsh), "exec", __xonsh__.ctx, filename="television")
+```
+
+Then restart your shell.
+
 ### PowerShell
 
 To enable shell integration for PowerShell, run:
@@ -160,6 +170,18 @@ Then add to your PowerShell profile:
 
 ```powershell
 . $HOME/.config/television/shell/integration.ps1
+```
+
+#### Xonsh
+
+```shell
+tv init xonsh > ~/.config/television/shell/integration.xsh
+```
+
+Then add to your `~/.xonshrc` file:
+
+```xonsh
+source ~/.config/television/shell/integration.xsh
 ```
 
 For all shells you'll have to restart it (or similar) to integrate the changes.

--- a/television/cli/args.rs
+++ b/television/cli/args.rs
@@ -696,6 +696,7 @@ pub enum Shell {
     PowerShell,
     Cmd,
     Nu,
+    Xonsh,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, ValueEnum)]

--- a/television/utils/shell.rs
+++ b/television/utils/shell.rs
@@ -426,6 +426,7 @@ mod tests {
         assert!(script.contains("eager=True"));
         assert!(script.contains("responds_to_cpr = False"));
         assert!(script.contains("run_in_terminal"));
+        assert!(script.contains("_tv_unquote_token"));
         assert!(!script.contains("stderr=subprocess.DEVNULL"));
         assert!(!script.contains(r#""--inline""#));
         assert!(script.contains("__xonsh__.history"));

--- a/television/utils/shell.rs
+++ b/television/utils/shell.rs
@@ -19,6 +19,7 @@ pub enum Shell {
     Psh,
     Cmd,
     Nu,
+    Xonsh,
 }
 
 impl Default for Shell {
@@ -54,6 +55,10 @@ impl TryFrom<Shell> for clap_complete::Shell {
             Shell::Nu => Err(ShellError::UnsupportedShell(
                 "Nu shell is not supported for completion scripts".to_string(),
             )),
+            Shell::Xonsh => Err(ShellError::UnsupportedShell(
+                "Xonsh shell is not supported for completion scripts"
+                    .to_string(),
+            )),
         }
     }
 }
@@ -67,6 +72,7 @@ impl Display for Shell {
             Shell::Psh => write!(f, "powershell"),
             Shell::Cmd => write!(f, "cmd"),
             Shell::Nu => write!(f, "nu"),
+            Shell::Xonsh => write!(f, "xonsh"),
         }
     }
 }
@@ -87,6 +93,8 @@ impl TryFrom<&str> for Shell {
             Ok(Shell::Psh)
         } else if value.contains("cmd") {
             Ok(Shell::Cmd)
+        } else if value.contains("xonsh") {
+            Ok(Shell::Xonsh)
         } else if value.contains("nu") {
             Ok(Shell::Nu)
         } else {
@@ -140,6 +148,7 @@ impl Shell {
             Shell::Psh => "powershell",
             Shell::Cmd => "cmd",
             Shell::Nu => "nu",
+            Shell::Xonsh => "xonsh",
         }
     }
 }
@@ -153,6 +162,7 @@ impl From<CliShell> for Shell {
             CliShell::PowerShell => Shell::Psh,
             CliShell::Cmd => Shell::Cmd,
             CliShell::Nu => Shell::Nu,
+            CliShell::Xonsh => Shell::Xonsh,
         }
     }
 }
@@ -166,6 +176,7 @@ impl From<&CliShell> for Shell {
             CliShell::PowerShell => Shell::Psh,
             CliShell::Cmd => Shell::Cmd,
             CliShell::Nu => Shell::Nu,
+            CliShell::Xonsh => Shell::Xonsh,
         }
     }
 }
@@ -175,6 +186,7 @@ const COMPLETION_BASH: &str = include_str!("shell/completion.bash");
 const COMPLETION_FISH: &str = include_str!("shell/completion.fish");
 const COMPLETION_NU: &str = include_str!("shell/completion.nu");
 const COMPLETION_POWERSHELL: &str = include_str!("shell/completion.ps1");
+const COMPLETION_XONSH: &str = include_str!("shell/completion.xsh");
 
 // create the appropriate key binding for each supported shell
 pub fn ctrl_keybinding(shell: Shell, character: char) -> Result<String> {
@@ -190,6 +202,14 @@ pub fn ctrl_keybinding(shell: Shell, character: char) -> Result<String> {
             }
         }
         Shell::Nu => Ok(format!(r"Ctrl-{character}")),
+        Shell::Xonsh => {
+            if character == ' ' {
+                Ok("c-space".to_string())
+            } else {
+                let lower_char = character.to_ascii_lowercase();
+                Ok(format!("c-{lower_char}"))
+            }
+        }
         Shell::Psh => Ok(format!(r"Ctrl+{}", character.to_ascii_lowercase())),
         Shell::Cmd => {
             anyhow::bail!("This shell is not yet supported: {:?}", shell)
@@ -204,6 +224,7 @@ pub fn completion_script(shell: Shell) -> Result<&'static str> {
         Shell::Fish => Ok(COMPLETION_FISH),
         Shell::Nu => Ok(COMPLETION_NU),
         Shell::Psh => Ok(COMPLETION_POWERSHELL),
+        Shell::Xonsh => Ok(COMPLETION_XONSH),
         Shell::Cmd => {
             anyhow::bail!("This shell is not yet supported: {:?}", shell)
         }
@@ -320,6 +341,20 @@ mod tests {
     }
 
     #[test]
+    fn test_xonsh_ctrl_keybinding() {
+        let shell = Shell::Xonsh;
+        assert_eq!(ctrl_keybinding(shell, 'T').unwrap(), "c-t");
+        assert_eq!(ctrl_keybinding(shell, ' ').unwrap(), "c-space");
+    }
+
+    #[test]
+    fn test_xonsh_shell_metadata() {
+        assert_eq!(Shell::try_from("/usr/bin/xonsh").unwrap(), Shell::Xonsh);
+        assert_eq!(Shell::Xonsh.executable(), "xonsh");
+        assert_eq!(Shell::Xonsh.to_string(), "xonsh");
+    }
+
+    #[test]
     fn test_zsh_clap_completion() {
         let shell = Shell::Zsh;
         let result = render_autocomplete_script_template(
@@ -346,6 +381,17 @@ mod tests {
     }
 
     #[test]
+    fn test_xonsh_clap_completion_unsupported() {
+        let result = render_autocomplete_script_template(
+            Shell::Xonsh,
+            "",
+            &ShellIntegrationConfig::default(),
+        );
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_empty());
+    }
+
+    #[test]
     fn test_powershell_clap_completion() {
         let shell = Shell::Psh;
         let result = render_autocomplete_script_template(
@@ -368,5 +414,34 @@ mod tests {
         assert!(script.contains("Invoke-TvSmartAutocomplete"));
         assert!(script.contains("Invoke-TvShellHistory"));
         assert!(script.contains("Set-PSReadLineKeyHandler"));
+    }
+
+    #[test]
+    fn test_xonsh_completion_script() {
+        let script = completion_script(Shell::Xonsh).unwrap();
+        assert!(script.contains("prompt_toolkit"));
+        assert!(script.contains(r#""best""#));
+        assert!(script.contains("from xonsh.events import events"));
+        assert!(script.contains("@events.on_ptk_create"));
+        assert!(script.contains("eager=True"));
+        assert!(script.contains("responds_to_cpr = False"));
+        assert!(script.contains("run_in_terminal"));
+        assert!(!script.contains("stderr=subprocess.DEVNULL"));
+        assert!(!script.contains(r#""--inline""#));
+        assert!(script.contains("__xonsh__.history"));
+        assert!(script.contains("all_items(newest_first=True)"));
+        assert!(script.contains("right = text[cursor:]"));
+        assert!(!script.contains("xonsh-history"));
+        assert!(script.contains("tv_smart_autocomplete"));
+        assert!(script.contains("tv_shell_history"));
+
+        let rendered = render_autocomplete_script_template(
+            Shell::Xonsh,
+            script,
+            &ShellIntegrationConfig::default(),
+        )
+        .unwrap();
+        assert!(!rendered.contains("{tv_smart_autocomplete_keybinding}"));
+        assert!(!rendered.contains("{tv_shell_history_keybinding}"));
     }
 }

--- a/television/utils/shell/completion.xsh
+++ b/television/utils/shell/completion.xsh
@@ -1,6 +1,5 @@
 if $SHELL_TYPE in ("best", "prompt_toolkit", "prompt-toolkit", "ptk"):
     import os
-    import re
     import shlex
     import subprocess
 
@@ -14,16 +13,68 @@ if $SHELL_TYPE in ("best", "prompt_toolkit", "prompt-toolkit", "ptk"):
         buffer.document = Document(text, cursor_position=cursor_position)
 
     def _tv_current_token(text):
-        match = re.search(r"\S*$", text)
-        if match is None:
-            return len(text), ""
-        return match.start(), match.group(0)
+        token_start = 0
+        quote = None
+        escaped = False
+
+        for index, char in enumerate(text):
+            if escaped:
+                escaped = False
+                continue
+            if char == "\\":
+                escaped = True
+                continue
+            if quote is not None:
+                if char == quote:
+                    quote = None
+                continue
+            if char in ("'", '"'):
+                quote = char
+                continue
+            if char.isspace():
+                token_start = index + 1
+
+        return token_start, text[token_start:]
+
+    def _tv_unquote_token(token):
+        chars = []
+        quote = None
+        escaped = False
+
+        for char in token:
+            if escaped:
+                chars.append(char)
+                escaped = False
+                continue
+            if char == "\\":
+                escaped = True
+                continue
+            if quote is not None:
+                if char == quote:
+                    quote = None
+                else:
+                    chars.append(char)
+                continue
+            if char in ("'", '"'):
+                quote = char
+                continue
+            chars.append(char)
+
+        if escaped:
+            chars.append("\\")
+
+        return "".join(chars)
 
     def _tv_path_parts(token):
-        if "/" not in token:
-            return ".", "", token
+        unquoted_token = _tv_unquote_token(token)
+        if "/" not in unquoted_token:
+            return ".", "", unquoted_token
 
-        display_dir = token if token.endswith("/") else token.rsplit("/", 1)[0] + "/"
+        display_dir = (
+            unquoted_token
+            if unquoted_token.endswith("/")
+            else unquoted_token.rsplit("/", 1)[0] + "/"
+        )
         command_dir = os.path.expandvars(os.path.expanduser(display_dir))
 
         while command_dir and not os.path.isdir(command_dir):
@@ -36,7 +87,7 @@ if $SHELL_TYPE in ("best", "prompt_toolkit", "prompt-toolkit", "ptk"):
             stripped = display_dir.rstrip("/")
             display_dir = stripped.rsplit("/", 1)[0] + "/" if "/" in stripped else ""
 
-        query = token[len(display_dir):]
+        query = unquoted_token[len(display_dir):]
         return command_dir or ".", display_dir, query
 
     def _tv_run(args, input_text=None):
@@ -80,7 +131,7 @@ if $SHELL_TYPE in ("best", "prompt_toolkit", "prompt-toolkit", "ptk"):
         matches = []
         for line in output.splitlines():
             if line:
-                matches.append(display_dir + shlex.quote(line))
+                matches.append(shlex.quote(display_dir + line))
 
         if not matches:
             return

--- a/television/utils/shell/completion.xsh
+++ b/television/utils/shell/completion.xsh
@@ -1,0 +1,149 @@
+if $SHELL_TYPE in ("best", "prompt_toolkit", "prompt-toolkit", "ptk"):
+    import os
+    import re
+    import shlex
+    import subprocess
+
+    from prompt_toolkit.application import run_in_terminal
+    from prompt_toolkit.document import Document
+    from xonsh.events import events
+
+    def _tv_replace_buffer(buffer, text, cursor_position=None):
+        if cursor_position is None:
+            cursor_position = len(text)
+        buffer.document = Document(text, cursor_position=cursor_position)
+
+    def _tv_current_token(text):
+        match = re.search(r"\S*$", text)
+        if match is None:
+            return len(text), ""
+        return match.start(), match.group(0)
+
+    def _tv_path_parts(token):
+        if "/" not in token:
+            return ".", "", token
+
+        display_dir = token if token.endswith("/") else token.rsplit("/", 1)[0] + "/"
+        command_dir = os.path.expandvars(os.path.expanduser(display_dir))
+
+        while command_dir and not os.path.isdir(command_dir):
+            parent = os.path.dirname(command_dir.rstrip(os.sep))
+            if parent == command_dir:
+                command_dir = "."
+                display_dir = ""
+                break
+            command_dir = parent
+            stripped = display_dir.rstrip("/")
+            display_dir = stripped.rsplit("/", 1)[0] + "/" if "/" in stripped else ""
+
+        query = token[len(display_dir):]
+        return command_dir or ".", display_dir, query
+
+    def _tv_run(args, input_text=None):
+        try:
+            result = subprocess.run(
+                args,
+                input=input_text,
+                stdout=subprocess.PIPE,
+                text=True,
+                check=False,
+            )
+        except FileNotFoundError:
+            return ""
+
+        if result.returncode != 0:
+            return ""
+        return result.stdout.strip()
+
+    def _tv_smart_autocomplete_for_buffer(buffer):
+        text = buffer.text
+        cursor = buffer.cursor_position
+        left = text[:cursor]
+        right = text[cursor:]
+        token_start, token = _tv_current_token(left)
+        prompt = left[:token_start]
+        directory, display_dir, query = _tv_path_parts(token)
+
+        output = _tv_run([
+            "tv",
+            directory,
+            "--autocomplete-prompt",
+            prompt,
+            "--input",
+            query,
+            "--no-status-bar",
+        ])
+
+        if not output:
+            return
+
+        matches = []
+        for line in output.splitlines():
+            if line:
+                matches.append(display_dir + shlex.quote(line))
+
+        if not matches:
+            return
+
+        new_left = prompt + " ".join(matches) + " "
+        _tv_replace_buffer(buffer, new_left + right, len(new_left))
+
+    def _tv_history_input():
+        history = __xonsh__.history
+        if history is None:
+            return ""
+
+        try:
+            items = history.all_items(newest_first=True)
+        except Exception:
+            items = history.items(newest_first=True)
+
+        seen = set()
+        commands = []
+        for item in items:
+            command = item.get("inp") or item.get("cmd") or ""
+            command = command.strip()
+            if command and command not in seen:
+                seen.add(command)
+                commands.append(command)
+
+        return "\n".join(commands)
+
+    def _tv_shell_history_for_buffer(buffer):
+        current_prompt = buffer.text[:buffer.cursor_position]
+        output = _tv_run(
+            ["tv", "--input", current_prompt, "--no-status-bar"],
+            _tv_history_input(),
+        )
+
+        if output:
+            _tv_replace_buffer(buffer, output)
+
+    def _tv_run_in_terminal(event, callback):
+        try:
+            event.app.output.responds_to_cpr = False
+        except Exception:
+            pass
+        run_in_terminal(callback)
+
+    def tv_smart_autocomplete(event):
+        _tv_run_in_terminal(
+            event,
+            lambda: _tv_smart_autocomplete_for_buffer(event.current_buffer),
+        )
+
+    def tv_shell_history(event):
+        _tv_run_in_terminal(
+            event,
+            lambda: _tv_shell_history_for_buffer(event.current_buffer),
+        )
+
+    @events.on_ptk_create
+    def tv_keybindings(bindings, **kw):
+        @bindings.add("{tv_smart_autocomplete_keybinding}", eager=True)
+        def _tv_smart_autocomplete(event):
+            tv_smart_autocomplete(event)
+
+        @bindings.add("{tv_shell_history_keybinding}", eager=True)
+        def _tv_shell_history(event):
+            tv_shell_history(event)

--- a/tests/cli/special.rs
+++ b/tests/cli/special.rs
@@ -96,6 +96,44 @@ fn test_init_subcommand_generates_completion_script() {
     );
 }
 
+/// Tests that the `init` subcommand generates a shell integration script for xonsh.
+#[test]
+fn test_init_subcommand_generates_xonsh_script() {
+    let pt = phantom();
+
+    let s = tv_local_config_and_cable_with_args(&pt, &["init", "xonsh"])
+        .scrollback(1000)
+        .start()
+        .unwrap();
+
+    s.wait().exit_code(0).until().unwrap();
+
+    let scrollback = s.scrollback(None).unwrap();
+    assert!(
+        scrollback.contains("@events.on_ptk_create")
+            && scrollback.contains("tv_smart_autocomplete")
+            && scrollback.contains("tv_shell_history"),
+        "expected scrollback to contain xonsh integration functions, got:\n{scrollback}"
+    );
+}
+
+/// Tests that standalone clap completions report xonsh as unsupported.
+#[test]
+fn test_completions_subcommand_rejects_xonsh() {
+    let pt = phantom();
+
+    let s =
+        tv_local_config_and_cable_with_args(&pt, &["completions", "xonsh"])
+            .start()
+            .unwrap();
+
+    s.wait()
+        .text("Shell completions are not supported for xonsh")
+        .until()
+        .unwrap();
+    s.wait().exit_code(1).until().unwrap();
+}
+
 /// Tests that the `init` subcommand rejects unsupported shells.
 #[test]
 fn test_init_subcommand_invalid_shell_errors() {


### PR DESCRIPTION
## PR Description

Adds xonsh shell integration for `tv init xonsh`.

This includes:
- xonsh shell detection and CLI enum support
- prompt-toolkit keybindings for smart autocomplete and shell history
- xonsh setup docs for direct init and saved integration files
- tests for init output, unsupported standalone completions, keybindings, metadata, and script rendering

Standalone clap completions remain unsupported for xonsh, matching nu/cmd-style unsupported behavior.

Parts of this PR were generated with AI assistance. I reviewed the changes and checked them locally.

## Checklist

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [x] I have added a reasonable amount of documentation to the code where appropriate