### PR TITLE
perf(ui): defer results fetch to render-eligible ticks

### DIFF
--- a/television/channels/channel.rs
+++ b/television/channels/channel.rs
@@ -176,6 +176,13 @@ impl<P: EntryProcessor> Channel<P> {
         self.matcher.tick();
     }
 
+    /// Refresh cached counts without running the full results pipeline.
+    ///
+    /// Keeps `result_count()` accurate on ticks where `results()` is skipped.
+    pub fn update_counts(&mut self) {
+        self.matcher.update_counts();
+    }
+
     pub fn results(&mut self, num_entries: u32, offset: u32) -> Vec<Entry> {
         self.matcher.tick();
 
@@ -581,6 +588,7 @@ impl ChannelKind {
         reload() -> (),
         find(pattern: &str) -> (),
         tick() -> (),
+        update_counts() -> (),
         results(num_entries: u32, offset: u32) -> Vec<Entry>,
         get_result(index: u32) -> Option<Entry>,
         toggle_selection(entry: &Entry) -> (),

--- a/television/matcher/mod.rs
+++ b/television/matcher/mod.rs
@@ -88,6 +88,16 @@ where
         self.status = self.inner.tick(MATCHER_TICK_TIMEOUT).into();
     }
 
+    /// Refresh cached counts from the current snapshot.
+    ///
+    /// Cheap alternative to `results()`: no lock, no per-item work.
+    /// Requires a prior `tick()` to reflect the latest worker progress.
+    pub fn update_counts(&mut self) {
+        let snapshot = self.inner.snapshot();
+        self.total_item_count = snapshot.item_count();
+        self.matched_item_count = snapshot.matched_item_count();
+    }
+
     /// Get an injector that can be used to push items into the fuzzy matcher.
     ///
     /// This can be used at any time to push items into the fuzzy matcher.

--- a/television/television.rs
+++ b/television/television.rs
@@ -1184,7 +1184,11 @@ impl Television {
         }
         self.ticks += 1;
 
-        Ok(if will_render { Some(Action::Render) } else { None })
+        Ok(if will_render {
+            Some(Action::Render)
+        } else {
+            None
+        })
     }
 }
 

--- a/television/television.rs
+++ b/television/television.rs
@@ -100,8 +100,6 @@ pub struct Television {
     frecency: FrecencyHandle,
     /// Tracks whether the channel was running on the previous tick to reset ticks
     was_running: bool,
-    /// Set by actions that could change results; consumed on the next render.
-    results_dirty: bool,
     /// Popup shown when attempting to switch to a channel with missing requirements
     pub missing_requirements_popup: Option<MissingRequirementsPopup>,
 }
@@ -233,7 +231,6 @@ impl Television {
             colorscheme: Arc::new(colorscheme),
             ticks: 0,
             was_running: true,
-            results_dirty: true,
             ui_state: UiState::default(),
             frecency,
             missing_requirements_popup: None,
@@ -1164,17 +1161,12 @@ impl Television {
         }
         self.was_running = running;
 
-        if action.affects_results() {
-            self.results_dirty = true;
-        }
-
         let will_render = self.should_render(action);
 
         // Defer the expensive results pipeline (matcher lock, index
         // computation, per-item to_string) to render-eligible ticks.
-        if will_render && self.results_dirty {
+        if will_render {
             self.update_results_picker_state();
-            self.results_dirty = false;
         }
 
         if self.remote_control.is_some() && self.mode == Mode::RemoteControl {

--- a/television/television.rs
+++ b/television/television.rs
@@ -100,6 +100,8 @@ pub struct Television {
     frecency: FrecencyHandle,
     /// Tracks whether the channel was running on the previous tick to reset ticks
     was_running: bool,
+    /// Set by actions that could change results; consumed on the next render.
+    results_dirty: bool,
     /// Popup shown when attempting to switch to a channel with missing requirements
     pub missing_requirements_popup: Option<MissingRequirementsPopup>,
 }
@@ -231,6 +233,7 @@ impl Television {
             colorscheme: Arc::new(colorscheme),
             ticks: 0,
             was_running: true,
+            results_dirty: true,
             ui_state: UiState::default(),
             frecency,
             missing_requirements_popup: None,
@@ -1149,6 +1152,7 @@ impl Television {
 
         // Always let the background matcher make progress
         self.channel.tick();
+        self.channel.update_counts();
 
         // When the channel transitions from running to stopped, reset ticks
         // to restart the fast-render window. This ensures newly loaded results
@@ -1160,10 +1164,17 @@ impl Television {
         }
         self.was_running = running;
 
-        // Only run the full results pipeline when the action could
-        // have changed the results or the visible viewport
         if action.affects_results() {
+            self.results_dirty = true;
+        }
+
+        let will_render = self.should_render(action);
+
+        // Defer the expensive results pipeline (matcher lock, index
+        // computation, per-item to_string) to render-eligible ticks.
+        if will_render && self.results_dirty {
             self.update_results_picker_state();
+            self.results_dirty = false;
         }
 
         if self.remote_control.is_some() && self.mode == Mode::RemoteControl {
@@ -1181,11 +1192,7 @@ impl Television {
         }
         self.ticks += 1;
 
-        Ok(if self.should_render(action) {
-            Some(Action::Render)
-        } else {
-            None
-        })
+        Ok(if will_render { Some(Action::Render) } else { None })
     }
 }
 


### PR DESCRIPTION
## Summary
- `Television::update()` was running the full results pipeline (matcher lock, index computation, per-item `to_string` + clone) on every tick (~50 Hz), while the renderer only consumes new state at ~17 Hz under load and ~2 Hz idle. Under heavy load (large source streams, big corpora) the redundant work starves keystrokes and renders.
- Now the results pipeline only runs on render-eligible ticks. Counts are refreshed every tick via a new cheap `Matcher::update_counts()` so `select_1` / `take_1` / status bar stay accurate.

## Test plan
- [ ] `tv files` or `find ~ -type f | tv` on a large tree — UI stays responsive while loading; typing feels snappier
- [ ] `select_1` / `take_1` / `take_1_fast` flows still trigger correctly