### PR TITLE
feat(cable): cred cable support

### DIFF
--- a/cable/unix/cred.toml
+++ b/cable/unix/cred.toml
@@ -1,0 +1,50 @@
+[metadata]
+name = "cred"
+description = "A channel to select from cred data"
+
+[source]
+command = 'fd . ~/.cred-store --type file --exclude config | sed "s|.*/\.cred-store/||"'
+
+[keybindings]
+enter = "actions:copy"
+
+[actions.copy]
+description = "Copy value to clipboard"
+command = '''
+sh -c '
+store=$(echo {} | cut -d/ -f1)
+file=$(echo {} | sed "s|$store/||")
+cred "$store" copy "$file"
+'
+'''
+mode = "execute"
+
+[actions.show]
+description = "Show value"
+command = '''
+sh -c '
+store=$(echo {} | cut -d/ -f1)
+file=$(echo {} | sed "s|$store/||")
+cred "$store" show "$file"
+'
+'''
+mode = "execute"
+
+[actions.connect]
+description = "Connect to ssh connection"
+command = '''
+sh -c '
+store=$(echo {} | cut -d/ -f1)
+file=$(echo {} | sed "s|$store/||")
+
+if [ "$store" != "ssh" ]; then
+  echo "This action is only available for ssh connections."
+  exit 1
+else
+  basefile=$(basename "$file")
+  dir=$(echo "$file" | sed "s|/$basefile||")
+  cred "$store" connect "$dir"
+fi
+'
+'''
+mode = "execute"

--- a/docs/community/channels-unix.md
+++ b/docs/community/channels-unix.md
@@ -402,6 +402,45 @@ mode = "execute"
 
 ---
 
+### *cred*
+
+A channel to select from cred data
+
+**Requirements:** *None*
+
+**Code:** *cred.toml*
+
+```toml
+[metadata]
+name = "cred"
+description = "A channel to select from cred data"
+
+[source]
+command = "fd . ~/.cred-store --type file --exclude config | sed \"s|.*/\\.cred-store/||\""
+
+[keybindings]
+enter = "actions:copy"
+
+[actions.copy]
+description = "Copy value to clipboard"
+command = "sh -c '\nstore=$(echo {} | cut -d/ -f1)\nfile=$(echo {} | sed \"s|$store/||\")\ncred \"$store\" copy \"$file\"\n'\n"
+mode = "execute"
+
+[actions.show]
+description = "Show value"
+command = "sh -c '\nstore=$(echo {} | cut -d/ -f1)\nfile=$(echo {} | sed \"s|$store/||\")\ncred \"$store\" show \"$file\"\n'\n"
+mode = "execute"
+
+[actions.connect]
+description = "Connect to ssh connection"
+command = "sh -c '\nstore=$(echo {} | cut -d/ -f1)\nfile=$(echo {} | sed \"s|$store/||\")\n\nif [ \"$store\" != \"ssh\" ]; then\n  echo \"This action is only available for ssh connections.\"\n  exit 1\nelse\n  basefile=$(basename \"$file\")\n  dir=$(echo \"$file\" | sed \"s|/$basefile||\")\n  cred \"$store\" connect \"$dir\"\nfi\n'\n"
+mode = "execute"
+
+```
+
+
+---
+
 ### *crontab*
 
 List and manage crontab entries


### PR DESCRIPTION
- add support for `cred cli` as a cable.
- fixes #1105.

## 📺 PR Description
Added suuport to `cred cli` tool for unix based system, through `cables`.

## Checklist
- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [x] I have added a reasonable amount of documentation to the code where appropriate
