### PR TITLE
feat(render): drop 60 fps cap

### DIFF
--- a/television/render.rs
+++ b/television/render.rs
@@ -40,12 +40,6 @@ impl UiState {
     }
 }
 
-/// The maximum frame rate for the UI rendering loop (in milliseconds).
-///
-/// This is used to limit the frame rate of the UI rendering loop to avoid consuming
-/// unnecessary CPU resources.
-const MAX_FRAME_RATE: u128 = 1000 / 60; // 60 FPS
-
 /// The main UI rendering task loop.
 ///
 /// This function is responsible for rendering the UI based on the rendering tasks it receives from
@@ -66,11 +60,9 @@ pub async fn render<W: Write>(
 ) -> Result<()> {
     let mut buffer = Vec::with_capacity(256);
     let mut num_instructions;
-    let mut frame_start;
 
     // Rendering loop
     'rendering: while render_rx.recv_many(&mut buffer, 256).await > 0 {
-        frame_start = std::time::Instant::now();
         num_instructions = buffer.len();
         // we only keep the last render instruction in the buffer
         if let Some(last_render) = buffer
@@ -145,15 +137,6 @@ pub async fn render<W: Write>(
                     break 'rendering;
                 }
             }
-        }
-        // yield back to the scheduler until the next frame
-        let elapsed = frame_start.elapsed();
-        if elapsed.as_millis() < MAX_FRAME_RATE {
-            let sleep_duration = std::time::Duration::from_millis(
-                u64::try_from(MAX_FRAME_RATE - elapsed.as_millis())
-                    .unwrap_or(0),
-            );
-            tokio::time::sleep(sleep_duration).await;
         }
     }
 


### PR DESCRIPTION
## 📺 PR Description

In my testing, the only source of events that could hit the FPS cap was inputs from the user. With a default cap of 60 fps, on my 240hz monitor, the added typing latency of up to 16ms was surprisingly noticeable.

This has the added benefit of speeding up the `--select-1` path as well since it waits for render before returning the result. Testing with `time tv text --input "Matcher::withnotifywoken" --select-1` on the `frizbee` branch, the time went from 76ms -> 62ms. Combined with the `frizbee` branch, due to faster matching, less startup overhead and immediate update when the matcher finishes, the time went from 62ms -> 25ms. Also, the results from the matcher come in up to 16ms earlier since they always render atleast one frame after the pattern is rendered, making matching feel a bit more responsive.

In my super duper scientific test, I measured overall CPU time via `time tv text` and typed then deleted `license` 4 times. Timings were identical with and without this patch.
