### PR TITLE
fix: nushell smart autocomplete keybind fix

### DIFF
--- a/television/utils/shell.rs
+++ b/television/utils/shell.rs
@@ -316,7 +316,7 @@ mod tests {
         let shell = Shell::Nu;
         let result = ctrl_keybinding(shell, character);
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), "Ctrl-s");
+        assert_eq!(result.unwrap(), "s");
     }
 
     #[test]

--- a/television/utils/shell.rs
+++ b/television/utils/shell.rs
@@ -189,7 +189,7 @@ pub fn ctrl_keybinding(shell: Shell, character: char) -> Result<String> {
                 Ok(format!(r"ctrl-{lower_char}"))
             }
         }
-        Shell::Nu => Ok(format!(r"Ctrl-{character}")),
+        Shell::Nu => Ok(format!(r"{character}")),
         Shell::Psh => Ok(format!(r"Ctrl+{}", character.to_ascii_lowercase())),
         Shell::Cmd => {
             anyhow::bail!("This shell is not yet supported: {:?}", shell)

--- a/television/utils/shell/completion.nu
+++ b/television/utils/shell/completion.nu
@@ -37,7 +37,7 @@ $env.config = (
           {
               name: tv_completion,
               modifier: Control,
-              keycode: char_t,
+              keycode: char_{tv_smart_autocomplete_keybinding},
               mode: [vi_normal, vi_insert, emacs],
               event: {
                   send: executehostcommand,
@@ -47,7 +47,7 @@ $env.config = (
           {
               name: tv_history,
               modifier: Control,
-              keycode: char_r,
+              keycode: char_{tv_shell_history_keybinding},
               mode: [vi_normal, vi_insert, emacs],
               event: {
                   send: executehostcommand,


### PR DESCRIPTION
## 📺 PR Description

This PR fixes a bug with the completion.nu which had the values for smart autocomplete and shell history hard-coded as `t` and `r` respectively. I changed the hard-coded values for `{tv_smart_autocomplete_keybinding}` and `{tv_shell_history_keybinding}` respectively to match the other completion  

## Checklist

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [x] I have added a reasonable amount of documentation to the code where appropriate

## Notes
I am sorry, if this PR is not up to standards. This is my first ever PR and  it's just that I really like television and nushell but I can't change the key-bind, so I decided to try to fix it myself.

I also don't know how to simulate key-press in nushell in the tests, that is why I didn't check the checkbox.

Hope this is better that just creating an issue. :)