### PR TITLE
fix(flake): add filtered out legacy_config_templates.json

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,8 @@
               (lib.fileset.maybeMissing ./working-dir-test.txt)
               # Pass tests/app.rs tests
               (lib.fileset.maybeMissing ./tests/target_dir)
+              # Pass legacy config file templates
+              (lib.fileset.maybeMissing ./television/config/legacy_config_templates.json)
             ];
           };
 


### PR DESCRIPTION
## 📺 PR Description

Fixed https://github.com/alexpasmantier/television/issues/1114, due to the file embedded in code during compilation was filtered out by nix before the build step

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [X] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [ ] I have added a reasonable amount of documentation to the code where appropriate
