### PR TITLE
fix: sanitize control characters in selected entry output

### DIFF
--- a/television/main.rs
+++ b/television/main.rs
@@ -35,6 +35,18 @@ use television::{
 };
 use tracing::{debug, info};
 
+/// Replaces control characters (which can include terminal escape
+/// sequences) with the Unicode replacement character. A selected entry's
+/// output can originate from an untrusted source (e.g. a file name in
+/// the current directory), which has no character restrictions, and is
+/// printed to the real terminal after the TUI has already exited,
+/// bypassing ratatui's own protective rendering entirely.
+fn sanitize_for_display(s: &str) -> String {
+    s.chars()
+        .map(|c| if c.is_control() { '\u{FFFD}' } else { c })
+        .collect()
+}
+
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<()> {
     television::errors::init()?;
@@ -121,7 +133,7 @@ async fn main() -> Result<()> {
     }
     if let Some(entries) = output.selected_entries {
         for entry in &entries {
-            writeln!(bufwriter, "{}", entry.output()?)?;
+            writeln!(bufwriter, "{}", sanitize_for_display(&entry.output()?))?;
         }
     }
     bufwriter.flush()?;


### PR DESCRIPTION
Fixes #1124.

tv's interactive TUI is built on ratatui, which correctly renders control characters as safe placeholder glyphs on screen. But tv's own primary intended usage, piping the selected entry into another command after exiting (`cd "$(tv)"`, etc.), prints that selection directly to the terminal after the TUI has already stopped, bypassing ratatui's protection entirely. The default files channel searches file names in the current directory, which have no character restrictions, so a crafted file name can inject terminal escape sequences into the printed selection.

Adds `sanitize_for_display` (`television/main.rs`), replacing control characters with the Unicode replacement character, applied at the sole print site for a selected entry's output.

Verified against a file named using a raw OSC title-set escape sequence, selecting it and exiting, output captured via tmux's raw pty pipe and inspected as a hex dump. Confirmed no regression with a normal file name.

One caveat: I wasn't able to run the full `cargo test` suite in my environment, since it pulls in `libghostty-vt-sys` (used elsewhere in the crate for VT-emulation tests, unrelated to this change), which needs a `zig` toolchain version I couldn't get working locally (`build.zig.zon` parse error against the zig version I had available). I verified the actual runtime behavior directly instead, both before and after the fix, rather than relying on the test suite for this one.