### PR TITLE
FEAT: export autocomplete vars 

### DIFF
--- a/television/utils/shell/completion.bash
+++ b/television/utils/shell/completion.bash
@@ -38,6 +38,7 @@ __tv_path_completion() {
             
             # Call tv with proper arguments and process output
             matches=$(
+                LBUF="$lbuf" BASE="$base" LEFTOVER="$leftover" DIR="$dir" \
                 tv "$dir" --autocomplete-prompt "$lbuf" --no-status-bar --inline --input "$leftover" < /dev/tty | while IFS= read -r item; do
                     item="${item%$suffix}$suffix"
                     dirP="$dir/"


### PR DESCRIPTION
## 📺 PR Description

When using different autocomplete engines (e.g., Carapace) it is useful to have these variables available for channel setup.

## Checklist

- [X] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- I'm not sure this applies, happy to if needed. 
- [ ] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [ ] I have added a reasonable amount of documentation to the code where appropriate
