### PR TITLE
feat: allow configuring the path separator used for entries

### DIFF
--- a/.config/config.toml
+++ b/.config/config.toml
@@ -34,6 +34,13 @@ history_size = 200
 # When true: history navigation shows entries from all channels
 # When false: history navigation is scoped to the current channel
 global_history = false
+# Path separator
+# --------------
+# Rewrite path separators in entries to this character, everywhere they show
+# up (results list, preview title and selected output). Handy on Windows to
+# work with forward slashes, e.g. turning `src\main.rs` into `src/main.rs`.
+# When unset, paths are left untouched.
+# path_separator = "/"
 
 [ui]
 # How much space to allocate for the UI (in percentage of the screen)

--- a/benches/main/load_candidates.rs
+++ b/benches/main/load_candidates.rs
@@ -49,6 +49,7 @@ pub fn load_candidates_by_size(c: &mut Criterion) {
                         black_box(0),
                         black_box(PlainProcessor),
                         injector,
+                        black_box(None),
                     )
                     .await;
 
@@ -91,6 +92,7 @@ pub fn load_candidates_with_ansi(c: &mut Criterion) {
                 black_box(0),
                 black_box(PlainProcessor),
                 injector,
+                black_box(None),
             )
             .await;
 
@@ -123,6 +125,7 @@ pub fn load_candidates_with_ansi(c: &mut Criterion) {
                 black_box(0),
                 black_box(AnsiProcessor::new()),
                 injector,
+                black_box(None),
             )
             .await;
 
@@ -161,6 +164,7 @@ pub fn load_candidates_with_display_template(c: &mut Criterion) {
                 black_box(0),
                 black_box(PlainProcessor),
                 injector,
+                black_box(None),
             )
             .await;
 
@@ -192,6 +196,7 @@ pub fn load_candidates_with_display_template(c: &mut Criterion) {
                     template: source_spec.display.unwrap(),
                 }),
                 injector,
+                black_box(None),
             )
             .await;
 

--- a/television/channels/channel.rs
+++ b/television/channels/channel.rs
@@ -10,7 +10,7 @@ use crate::{
     matcher::{
         Matcher, Notify, SortStrategy, injector::Injector, matcher_threads,
     },
-    utils::command::shell_command,
+    utils::{command::shell_command, strings::apply_path_separator},
 };
 use rustc_hash::{FxBuildHasher, FxHashSet};
 use std::collections::HashSet;
@@ -44,6 +44,9 @@ pub struct Channel<P: EntryProcessor> {
     /// source command. When true, `load()` reads `tokio::io::stdin()` and
     /// `reload()` is a no-op (stdin can only be consumed once).
     is_stdin: bool,
+    /// When set, path separators in ingested entries are rewritten to this
+    /// character (see [`apply_path_separator`]).
+    path_separator: Option<char>,
 }
 
 impl<P: EntryProcessor> Channel<P> {
@@ -58,6 +61,7 @@ impl<P: EntryProcessor> Channel<P> {
         frecency: Option<(FrecencyHandle, String)>,
         is_stdin: bool,
         notify: Notify,
+        path_separator: Option<char>,
     ) -> Self {
         let sort_strategy = if no_sort {
             SortStrategy::Index
@@ -86,6 +90,7 @@ impl<P: EntryProcessor> Channel<P> {
             current_source_index,
             reloading: Arc::new(AtomicBool::new(false)),
             is_stdin,
+            path_separator,
         }
     }
 
@@ -97,6 +102,7 @@ impl<P: EntryProcessor> Channel<P> {
                 self.source_entry_delimiter,
                 processor,
                 injector,
+                self.path_separator,
             ))
         } else {
             tokio::spawn(load_candidates(
@@ -105,6 +111,7 @@ impl<P: EntryProcessor> Channel<P> {
                 self.current_source_index,
                 processor,
                 injector,
+                self.path_separator,
             ))
         };
         self.crawl_handle = Some(crawl_handle);
@@ -279,6 +286,7 @@ async fn stream_entries<R, P>(
     delimiter: u8,
     processor: &P,
     injector: &Injector<P::Data>,
+    path_separator: Option<char>,
 ) -> bool
 where
     R: AsyncRead + Unpin,
@@ -310,7 +318,13 @@ where
                 let inj = injector.clone();
                 let mut proc = processor.clone();
                 flush_handles.spawn_blocking(move || {
-                    flush_chunk(&chunk, &inj, &mut proc, delimiter);
+                    flush_chunk(
+                        &chunk,
+                        &inj,
+                        &mut proc,
+                        delimiter,
+                        path_separator,
+                    );
                 });
                 produced_output = true;
                 last_flush = Instant::now();
@@ -323,7 +337,7 @@ where
         let inj = injector.clone();
         let mut proc = processor.clone();
         flush_handles.spawn_blocking(move || {
-            flush_chunk(&acc, &inj, &mut proc, delimiter);
+            flush_chunk(&acc, &inj, &mut proc, delimiter, path_separator);
         });
         produced_output = true;
     }
@@ -341,6 +355,7 @@ pub async fn load_candidates<P: EntryProcessor>(
     command_index: usize,
     mut processor: P,
     injector: Injector<P::Data>,
+    path_separator: Option<char>,
 ) {
     debug!("Loading candidates from command: {:?}", command);
     let mut std_command = shell_command(
@@ -363,8 +378,14 @@ pub async fn load_candidates<P: EntryProcessor>(
             .map(|d| *d as u8)
             .unwrap_or(DEFAULT_DELIMITER);
 
-        let produced_output =
-            stream_entries(out, delimiter, &processor, &injector).await;
+        let produced_output = stream_entries(
+            out,
+            delimiter,
+            &processor,
+            &injector,
+            path_separator,
+        )
+        .await;
 
         debug!("Finished reading command output.");
 
@@ -397,6 +418,7 @@ pub async fn load_stdin_candidates<P: EntryProcessor>(
     entry_delimiter: Option<char>,
     processor: P,
     injector: Injector<P::Data>,
+    path_separator: Option<char>,
 ) {
     debug!("Loading candidates from stdin");
     let stdin = tokio::io::stdin();
@@ -406,7 +428,8 @@ pub async fn load_stdin_candidates<P: EntryProcessor>(
         .map(|d| *d as u8)
         .unwrap_or(DEFAULT_DELIMITER);
 
-    stream_entries(stdin, delimiter, &processor, &injector).await;
+    stream_entries(stdin, delimiter, &processor, &injector, path_separator)
+        .await;
 
     debug!("Finished reading stdin.");
 }
@@ -420,6 +443,7 @@ fn flush_chunk<P: EntryProcessor>(
     injector: &Injector<P::Data>,
     processor: &mut P,
     delimiter: u8,
+    path_separator: Option<char>,
 ) {
     let mut entries = Vec::new();
     let mut start = 0;
@@ -432,7 +456,11 @@ fn flush_chunk<P: EntryProcessor>(
             continue;
         }
         if let Ok(line) = std::str::from_utf8(line) {
-            entries.push(processor.process(line.to_string()));
+            let line = match path_separator {
+                Some(sep) => apply_path_separator(line, sep).into_owned(),
+                None => line.to_string(),
+            };
+            entries.push(processor.process(line));
         }
     }
     injector.push_batch(entries);
@@ -527,6 +555,7 @@ impl ChannelKind {
         frecency: Option<(FrecencyHandle, String)>,
         is_stdin: bool,
         notify: Notify,
+        path_separator: Option<char>,
     ) -> Self {
         match (source_ansi, source_display) {
             (false, None) => ChannelKind::Plain(Channel::new(
@@ -539,6 +568,7 @@ impl ChannelKind {
                 frecency,
                 is_stdin,
                 notify,
+                path_separator,
             )),
             (true, None) => ChannelKind::Ansi(Channel::new(
                 source_command,
@@ -550,6 +580,7 @@ impl ChannelKind {
                 frecency,
                 is_stdin,
                 notify,
+                path_separator,
             )),
             (_, Some(template)) => ChannelKind::Display(Channel::new(
                 source_command,
@@ -561,6 +592,7 @@ impl ChannelKind {
                 frecency,
                 is_stdin,
                 notify,
+                path_separator,
             )),
         }
     }
@@ -623,6 +655,7 @@ mod tests {
             0,
             PlainProcessor,
             injector,
+            None,
         )
         .await;
 
@@ -654,6 +687,7 @@ mod tests {
             0,
             PlainProcessor,
             injector,
+            None,
         )
         .await;
 
@@ -685,6 +719,7 @@ mod tests {
             0,
             PlainProcessor,
             injector,
+            None,
         )
         .await;
 
@@ -717,6 +752,7 @@ mod tests {
             0,
             PlainProcessor,
             injector,
+            None,
         )
         .await;
 
@@ -751,6 +787,7 @@ mod tests {
             0,
             AnsiProcessor::new(),
             injector,
+            None,
         )
         .await;
 
@@ -762,5 +799,36 @@ mod tests {
         assert_eq!(results[0].matched_string, "test1");
         assert_eq!(results[1].matched_string, "test2");
         assert_eq!(results[2].matched_string, "test3");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+    async fn test_load_candidates_rewrites_path_separator() {
+        // Emit a path using the platform separator so the rewrite has
+        // something to act on regardless of the OS running the test.
+        let native = std::path::MAIN_SEPARATOR;
+        let source_spec: SourceSpec = toml::from_str(&format!(
+            "command = \"printf 'src{native}a{native}b'\""
+        ))
+        .unwrap();
+
+        let mut matcher =
+            Matcher::<()>::new(SortStrategy::Score, MATCHER_TEST_THREADS);
+        let injector = matcher.injector();
+
+        load_candidates(
+            source_spec.command,
+            source_spec.entry_delimiter,
+            0,
+            PlainProcessor,
+            injector,
+            Some('|'),
+        )
+        .await;
+
+        matcher.find("src");
+        matcher.wait_for_idle();
+        let results = matcher.results(10, 0);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].matched_string, "src|a|b");
     }
 }

--- a/television/config/layers.rs
+++ b/television/config/layers.rs
@@ -74,6 +74,7 @@ impl ConfigLayers {
         let history_size = self.base_config.application.history_size;
         let frecency_max_entries =
             self.base_config.application.frecency_max_entries;
+        let path_separator = self.base_config.application.path_separator;
         let theme = self.base_config.ui.theme.clone();
         let shell_integration_commands =
             self.base_config.shell_integration.commands.clone();
@@ -531,6 +532,7 @@ impl ConfigLayers {
             history_size,
             global_history,
             frecency_max_entries,
+            path_separator,
             working_directory,
             autocomplete_prompt,
             shell: global_shell,
@@ -634,6 +636,8 @@ pub struct MergedConfig {
     pub history_size: usize,
     pub global_history: bool,
     pub frecency_max_entries: usize,
+    /// Character to rewrite path separators to in ingested entries.
+    pub path_separator: Option<char>,
     pub working_directory: Option<PathBuf>,
     pub autocomplete_prompt: Option<String>,
     /// Global shell for command execution (from base config).

--- a/television/config/mod.rs
+++ b/television/config/mod.rs
@@ -54,6 +54,11 @@ pub struct AppConfig {
     /// Channel-specific shell settings override this.
     #[serde(default)]
     pub shell: Option<Shell>,
+    /// Character to rewrite path separators to in entries (results, preview
+    /// title and output). Useful on Windows to display and copy paths with
+    /// forward slashes. When unset, paths are left untouched.
+    #[serde(default)]
+    pub path_separator: Option<char>,
 }
 
 impl Default for AppConfig {
@@ -67,6 +72,7 @@ impl Default for AppConfig {
             global_history: default_global_history(),
             frecency_max_entries: default_frecency_max_entries(),
             shell: None,
+            path_separator: None,
         }
     }
 }
@@ -97,6 +103,7 @@ impl Hash for AppConfig {
         self.global_history.hash(state);
         self.frecency_max_entries.hash(state);
         self.shell.hash(state);
+        self.path_separator.hash(state);
     }
 }
 

--- a/television/television.rs
+++ b/television/television.rs
@@ -181,6 +181,7 @@ impl Television {
             frecency_config,
             merged_config.is_stdin,
             notify.clone(),
+            merged_config.path_separator,
         );
 
         let app_metadata = AppMetadata::new(
@@ -393,6 +394,7 @@ impl Television {
             frecency_config,
             false, // stdin only applies to the initial channel
             self.notify.clone(),
+            self.merged_config.path_separator,
         );
         self.was_running = true;
         self.channel.load();

--- a/television/utils/strings.rs
+++ b/television/utils/strings.rs
@@ -605,6 +605,34 @@ pub fn to_title_case(s: &str) -> String {
         .join(" ")
 }
 
+/// Rewrites the platform path separator in `line` to `separator`.
+///
+/// This is meant for sources that emit filesystem paths (e.g. the `files`
+/// channel) so the same separator is used everywhere it shows up: the results
+/// list, the preview title and the selected output. On Windows for instance,
+/// setting this to `/` turns `src\main.rs` into `src/main.rs`, which is easier
+/// to paste back into a shell like git bash.
+///
+/// Nothing is allocated when there is nothing to replace (the separator is
+/// already the platform one, or the line doesn't contain it).
+pub fn apply_path_separator(line: &str, separator: char) -> Cow<'_, str> {
+    if separator == std::path::MAIN_SEPARATOR
+        || !line.contains(std::path::MAIN_SEPARATOR)
+    {
+        Cow::Borrowed(line)
+    } else {
+        let mut buf = String::with_capacity(line.len());
+        for c in line.chars() {
+            if c == std::path::MAIN_SEPARATOR {
+                buf.push(separator);
+            } else {
+                buf.push(c);
+            }
+        }
+        Cow::Owned(buf)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -958,5 +986,33 @@ mod tests {
         let (printable, match_indices) = make_result_item_printable(&entry);
         assert_eq!(printable, "ジェ abc");
         assert_eq!(match_indices, vec![(0, 1), (2, 3)]);
+    }
+
+    #[test]
+    fn test_apply_path_separator_replaces_platform_separator() {
+        let native = std::path::MAIN_SEPARATOR;
+        let line = format!("src{native}channels{native}entry.rs");
+        assert_eq!(apply_path_separator(&line, '/'), "src/channels/entry.rs");
+        assert_eq!(apply_path_separator(&line, '|'), "src|channels|entry.rs");
+    }
+
+    #[test]
+    fn test_apply_path_separator_noop_when_same_separator() {
+        let native = std::path::MAIN_SEPARATOR;
+        let line = format!("a{native}b{native}c");
+        // No allocation and identical content when the target is already the
+        // platform separator.
+        assert!(matches!(
+            apply_path_separator(&line, native),
+            Cow::Borrowed(_)
+        ));
+    }
+
+    #[test]
+    fn test_apply_path_separator_noop_without_separator() {
+        assert!(matches!(
+            apply_path_separator("no-separators-here", '/'),
+            Cow::Borrowed(_)
+        ));
     }
 }


### PR DESCRIPTION
## 📺 PR Description

Closes #279.

Adds an opt-in `path_separator` setting under `[application]`. When set, path separators in ingested entries get rewritten to that character everywhere they show up (results list, preview title and selected output). On Windows this lets you turn `src\main.rs` into `src/main.rs`, which is much nicer to paste back into a shell like git bash.

The rewrite happens once at ingestion (in `flush_chunk`), so display, matching and output all stay consistent and match highlighting is unaffected. It's a no-op when the setting is unset, so existing behavior is unchanged, and it doesn't allocate when there's nothing to replace.

## Checklist

<!-- a quick pass through the following items to make sure you haven't forgotten anything -->

- [x] my commits **and PR title** follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] if this is a new feature, I have added tests to consolidate the feature and prevent regressions
- [x] if this is a bug fix, I have added a test that reproduces the bug (if applicable)
- [x] I have added a reasonable amount of documentation to the code where appropriate
