### PR TITLE
refactor(matcher): configure exact matching instead of quoting the pattern

### DIFF
--- a/docs/advanced/02-tips-and-tricks.md
+++ b/docs/advanced/02-tips-and-tricks.md
@@ -247,6 +247,10 @@ Disable fuzzy matching for exact substring search:
 tv files --exact
 ```
 
+Bare patterns then match as substrings, while the
+[search-pattern operators](../user-guide/06-search-patterns.md) (`^foo`,
+`foo$`, `!foo`, ...) keep working.
+
 ### When to Use
 
 - Better performance on very large datasets

--- a/docs/user-guide/06-search-patterns.md
+++ b/docs/user-guide/06-search-patterns.md
@@ -34,5 +34,10 @@ And will produce the following results:
 | _the black motorbike flew past the tourists_ | ✅ | |
 | _the motorbike flew past the tourists_ | ❌ | doesn't contain 'car' |
 
+When running with `--exact`, bare patterns match as substrings instead of
+fuzzily (`foo` behaves like `'foo`); all the operators above keep their
+meaning. Prefix a special character with a backslash to search for it
+literally (e.g. `\^foo`, `foo\$`, `foo\ bar`).
+
 For more information on the matcher behavior, see the
-[nucleo-matcher](https://docs.rs/nucleo-matcher/latest/nucleo_matcher/pattern/enum.AtomKind.html) documentation.
+[frizbee](https://docs.rs/frizbee/latest/frizbee/) documentation.

--- a/television/channels/action_picker.rs
+++ b/television/channels/action_picker.rs
@@ -3,7 +3,7 @@ use crate::{
     channels::entry::into_ranges,
     channels::prototypes::ActionSpec,
     event::Key,
-    matcher::{Matcher, Notify, SortStrategy},
+    matcher::{Matcher, Matching, Notify, SortStrategy},
     screen::result_item::ResultItem,
 };
 use anyhow::Result;
@@ -86,8 +86,12 @@ impl ActionPicker {
         action_keybindings: &FxHashMap<String, Key>,
         notify: Notify,
     ) -> Self {
-        let matcher =
-            Matcher::with_notify(SortStrategy::Score, NUM_THREADS, notify);
+        let matcher = Matcher::with_notify(
+            SortStrategy::Score,
+            Matching::Fuzzy,
+            NUM_THREADS,
+            notify,
+        );
         let injector = matcher.injector();
 
         // Sort actions alphabetically for consistent display

--- a/television/channels/channel.rs
+++ b/television/channels/channel.rs
@@ -8,7 +8,8 @@ use crate::{
     },
     frecency::FrecencyHandle,
     matcher::{
-        Matcher, Notify, SortStrategy, injector::Injector, matcher_threads,
+        Matcher, Matching, Notify, SortStrategy, injector::Injector,
+        matcher_threads,
     },
     utils::command::shell_command,
 };
@@ -54,6 +55,7 @@ impl<P: EntryProcessor> Channel<P> {
         source_output: Option<Template>,
         supports_preview: bool,
         no_sort: bool,
+        matching: Matching,
         processor: P,
         frecency: Option<(FrecencyHandle, String)>,
         is_stdin: bool,
@@ -71,8 +73,12 @@ impl<P: EntryProcessor> Channel<P> {
             SortStrategy::Score
         };
 
-        let matcher =
-            Matcher::with_notify(sort_strategy, matcher_threads(), notify);
+        let matcher = Matcher::with_notify(
+            sort_strategy,
+            matching,
+            matcher_threads(),
+            notify,
+        );
         let current_source_index = 0;
         Self {
             source_command,
@@ -524,6 +530,7 @@ impl ChannelKind {
         source_output: Option<Template>,
         supports_preview: bool,
         no_sort: bool,
+        matching: Matching,
         frecency: Option<(FrecencyHandle, String)>,
         is_stdin: bool,
         notify: Notify,
@@ -535,6 +542,7 @@ impl ChannelKind {
                 source_output,
                 supports_preview,
                 no_sort,
+                matching,
                 PlainProcessor,
                 frecency,
                 is_stdin,
@@ -546,6 +554,7 @@ impl ChannelKind {
                 source_output,
                 supports_preview,
                 no_sort,
+                matching,
                 AnsiProcessor::new(),
                 frecency,
                 is_stdin,
@@ -557,6 +566,7 @@ impl ChannelKind {
                 source_output,
                 supports_preview,
                 no_sort,
+                matching,
                 DisplayProcessor { template },
                 frecency,
                 is_stdin,

--- a/television/channels/remote_control.rs
+++ b/television/channels/remote_control.rs
@@ -5,7 +5,7 @@ use crate::{
         prototypes::{BinaryRequirement, ChannelPrototype},
     },
     event::Key,
-    matcher::{Matcher, Notify, SortStrategy},
+    matcher::{Matcher, Matching, Notify, SortStrategy},
     screen::result_item::ResultItem,
 };
 use anyhow::Result;
@@ -91,6 +91,7 @@ impl RemoteControl {
     ) -> Self {
         let matcher = Matcher::with_notify(
             SortStrategy::Score,
+            Matching::Fuzzy,
             REMOTE_NUM_THREADS,
             notify,
         );

--- a/television/config/layers.rs
+++ b/television/config/layers.rs
@@ -9,6 +9,7 @@ use crate::{
         ui::{BorderType, Padding, ThemeOverrides},
     },
     keymap::InputMap,
+    matcher::Matching,
     screen::layout::{InputPosition, Orientation},
     utils::shell::Shell,
 };
@@ -729,6 +730,17 @@ pub struct MergedConfig {
 }
 
 impl MergedConfig {
+    /// The matching mode bare pattern atoms use: `--exact` makes them match
+    /// as substrings instead of fuzzily; operators (`^`, `$`, `'`, `!`) keep
+    /// their meaning in both modes.
+    pub fn matching(&self) -> Matching {
+        if self.exact_match {
+            Matching::Substring
+        } else {
+            Matching::Fuzzy
+        }
+    }
+
     /// An empty input bar header means "no header line at all".
     pub fn input_bar_header_hidden(&self) -> bool {
         self.input_bar_header.as_deref().is_some_and(str::is_empty)

--- a/television/matcher/mod.rs
+++ b/television/matcher/mod.rs
@@ -19,6 +19,8 @@ mod worker;
 
 use worker::{Snapshot, Store, Worker, WorkerMessage};
 
+pub use frizbee::Matching;
+
 /// Hoist scores: keys of entries to hoist mapped to their score.
 pub type HoistTable = Arc<FxHashMap<String, u64>>;
 
@@ -90,6 +92,8 @@ where
     /// store so the count stays current while batches are still in flight
     /// to the worker.
     count: Arc<AtomicUsize>,
+    /// The matching mode bare pattern atoms use (fuzzy or substring).
+    matching: Matching,
     /// The last pattern passed to `find`, used to avoid notifying the worker
     /// when the pattern hasn't changed.
     last_pattern: String,
@@ -107,18 +111,25 @@ where
     /// Use [`Matcher::with_notify`] to be woken as soon as fresh results are
     /// available.
     pub fn new(sort_strategy: SortStrategy<I>, n_threads: usize) -> Self {
-        Self::with_notify(sort_strategy, n_threads, Arc::new(|| {}))
+        Self::with_notify(
+            sort_strategy,
+            Matching::Fuzzy,
+            n_threads,
+            Arc::new(|| {}),
+        )
     }
 
     /// Create a new fuzzy matcher that calls `notify` every time the background
     /// worker publishes fresh results.
     pub fn with_notify(
         sort_strategy: SortStrategy<I>,
+        matching: Matching,
         n_threads: usize,
         notify: Notify,
     ) -> Self {
         Self::build(
             sort_strategy,
+            matching,
             n_threads,
             notify,
             worker::INITIAL_CHUNK_SIZE,
@@ -133,11 +144,18 @@ where
         n_threads: usize,
         chunk_size: usize,
     ) -> Self {
-        Self::build(sort_strategy, n_threads, Arc::new(|| {}), chunk_size)
+        Self::build(
+            sort_strategy,
+            Matching::Fuzzy,
+            n_threads,
+            Arc::new(|| {}),
+            chunk_size,
+        )
     }
 
     fn build(
         sort_strategy: SortStrategy<I>,
+        matching: Matching,
         n_threads: usize,
         notify: Notify,
         initial_chunk_size: usize,
@@ -154,6 +172,7 @@ where
             notify,
             worker_rx,
             sort_strategy,
+            matching,
             n_threads,
             initial_chunk_size,
         );
@@ -167,17 +186,23 @@ where
             snapshot,
             worker_tx,
             running,
+            matching,
             count: Arc::new(AtomicUsize::new(0)),
             last_pattern: String::new(),
-            indices_matcher: (String::new(), build_indices_matcher("")),
+            indices_matcher: (
+                String::new(),
+                build_indices_matcher("", matching),
+            ),
         }
     }
 
     /// The cached indices matcher, rebuilt only when `pattern` changes.
     fn indices_matcher(&mut self, pattern: &str) -> &mut frizbee::Matcher {
         if self.indices_matcher.0 != pattern {
-            self.indices_matcher =
-                (pattern.to_string(), build_indices_matcher(pattern));
+            self.indices_matcher = (
+                pattern.to_string(),
+                build_indices_matcher(pattern, self.matching),
+            );
         }
         &mut self.indices_matcher.1
     }
@@ -393,10 +418,15 @@ where
 }
 
 /// Build a matcher for computing match indices with the given pattern.
-fn build_indices_matcher(pattern: &str) -> frizbee::Matcher {
+fn build_indices_matcher(
+    pattern: &str,
+    matching: Matching,
+) -> frizbee::Matcher {
     frizbee::Matcher::from_query(
         pattern,
-        &frizbee::Config::default().casing(frizbee::CaseMatching::Smart),
+        &frizbee::Config::default()
+            .matching(matching)
+            .casing(frizbee::CaseMatching::Smart),
     )
 }
 

--- a/television/matcher/worker.rs
+++ b/television/matcher/worker.rs
@@ -1,5 +1,5 @@
 use super::{HoistTable, Notify, SortStrategy};
-use frizbee::Match;
+use frizbee::{Match, Matching};
 use parking_lot::{Mutex, RwLock};
 use std::sync::{
     Arc,
@@ -176,6 +176,8 @@ pub(super) struct Worker<I: Sync + Send + 'static> {
     matcher: frizbee::Matcher,
     pattern: String,
     sort_strategy: SortStrategy<I>,
+    /// The matching mode bare pattern atoms use (fuzzy or substring).
+    matching: Matching,
     /// Last item that was matched
     last_match_index: usize,
     /// Number of threads to use when matching.
@@ -201,6 +203,7 @@ where
         notify: Notify,
         rx: mpsc::Receiver<WorkerMessage<I>>,
         sort_strategy: SortStrategy<I>,
+        matching: Matching,
         n_threads: usize,
         initial_chunk_size: usize,
     ) -> Self {
@@ -210,9 +213,10 @@ where
             running,
             notify,
             rx,
-            matcher: build_matcher("", &sort_strategy),
+            matcher: build_matcher("", matching, &sort_strategy),
             pattern: String::new(),
             sort_strategy,
+            matching,
             last_match_index: 0,
             n_threads,
             initial_chunk_size,
@@ -275,7 +279,11 @@ where
                 if pattern == self.pattern {
                     return false;
                 }
-                self.matcher = build_matcher(&pattern, &self.sort_strategy);
+                self.matcher = build_matcher(
+                    &pattern,
+                    self.matching,
+                    &self.sort_strategy,
+                );
                 self.pattern = pattern;
                 self.last_match_index = 0;
                 true
@@ -554,6 +562,7 @@ fn merge_matches(
 
 fn build_matcher<I: Sync + Send + 'static>(
     pattern: &str,
+    matching: Matching,
     sort_strategy: &SortStrategy<I>,
 ) -> frizbee::Matcher {
     let sort_strategy = match sort_strategy {
@@ -567,6 +576,7 @@ fn build_matcher<I: Sync + Send + 'static>(
         pattern,
         &frizbee::Config::default()
             .sort(sort_strategy)
+            .matching(matching)
             .casing(frizbee::CaseMatching::Smart),
     )
 }

--- a/television/television.rs
+++ b/television/television.rs
@@ -71,12 +71,6 @@ pub struct MissingRequirementsPopup {
     pub missing_requirements: Vec<String>,
 }
 
-#[derive(PartialEq, Copy, Clone, Hash, Eq, Debug, Serialize, Deserialize)]
-pub enum MatchingMode {
-    Substring,
-    Fuzzy,
-}
-
 pub struct Television {
     action_tx: UnboundedSender<Action>,
     pub layered_config: ConfigLayers,
@@ -87,7 +81,6 @@ pub struct Television {
     pub mode: Mode,
     pub currently_selected: Option<Entry>,
     pub current_pattern: String,
-    pub matching_mode: MatchingMode,
     pub results_picker: Picker<Entry>,
     pub rc_picker: Picker<CableEntry>,
     pub ap_picker: Picker<ActionEntry>,
@@ -143,12 +136,6 @@ impl Television {
             results_picker = results_picker.inverted();
         }
 
-        let matching_mode = if merged_config.exact_match {
-            MatchingMode::Substring
-        } else {
-            MatchingMode::Fuzzy
-        };
-
         // previewer
         let preview_handles = merged_config
             .channel_preview_command
@@ -178,6 +165,7 @@ impl Television {
             merged_config.channel_source_output.clone(),
             merged_config.channel_preview_command.is_some(),
             merged_config.no_sort,
+            merged_config.matching(),
             frecency_config,
             merged_config.is_stdin,
             notify.clone(),
@@ -199,15 +187,7 @@ impl Television {
             });
         let colorscheme = (&theme).into();
 
-        let pattern = Television::preprocess_pattern(
-            matching_mode,
-            &merged_config
-                .input
-                .clone()
-                .unwrap_or(EMPTY_STRING.to_string()),
-        );
-
-        channel.find(&pattern);
+        channel.find(merged_config.input.as_deref().unwrap_or(EMPTY_STRING));
 
         let preview_state = PreviewState::new(
             channel.supports_preview(),
@@ -239,7 +219,6 @@ impl Television {
             currently_selected: None,
             current_pattern: EMPTY_STRING.to_string(),
             results_picker,
-            matching_mode,
             rc_picker: Picker::default(),
             ap_picker: Picker::default(),
             preview_state,
@@ -390,6 +369,7 @@ impl Television {
             self.merged_config.channel_source_output.clone(),
             self.merged_config.channel_preview_command.is_some(),
             self.merged_config.no_sort,
+            self.merged_config.matching(),
             frecency_config,
             false, // stdin only applies to the initial channel
             self.notify.clone(),
@@ -401,9 +381,7 @@ impl Television {
     pub fn find(&mut self, pattern: &str) {
         match self.mode {
             Mode::Channel => {
-                let processed_pattern =
-                    Self::preprocess_pattern(self.matching_mode, pattern);
-                self.channel.find(&processed_pattern);
+                self.channel.find(pattern);
             }
             Mode::RemoteControl => {
                 if let Some(rc) = self.remote_control.as_mut() {
@@ -415,31 +393,6 @@ impl Television {
                     ap.find(pattern);
                 }
             }
-        }
-    }
-
-    fn preprocess_pattern(mode: MatchingMode, pattern: &str) -> String {
-        if mode == MatchingMode::Substring {
-            let parts: Vec<&str> = pattern.split_ascii_whitespace().collect();
-            if parts.is_empty() {
-                return pattern.to_string();
-            }
-
-            let capacity = parts.iter().map(|s| s.len() + 2).sum::<usize>()
-                + parts.len()
-                - 1;
-            let mut result = String::with_capacity(capacity);
-
-            for (i, part) in parts.iter().enumerate() {
-                if i > 0 {
-                    result.push(' ');
-                }
-                result.push('\'');
-                result.push_str(part);
-            }
-            result
-        } else {
-            pattern.to_string()
         }
     }
 
@@ -1307,26 +1260,10 @@ mod test {
         config::layers::ConfigLayers,
         event::Key,
         frecency::Frecency,
-        television::{MatchingMode, Mode, Television},
+        television::{Mode, Television},
     };
     use std::sync::Arc;
     use tempfile::tempdir;
-
-    #[test]
-    fn test_prompt_preprocessing() {
-        let one_word = "test";
-        let mult_word = "this is a specific test";
-        let expect_one = "'test";
-        let expect_mult = "'this 'is 'a 'specific 'test";
-        assert_eq!(
-            Television::preprocess_pattern(MatchingMode::Substring, one_word),
-            expect_one
-        );
-        assert_eq!(
-            Television::preprocess_pattern(MatchingMode::Substring, mult_word),
-            expect_mult
-        );
-    }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_cli_overrides() {
@@ -1357,7 +1294,7 @@ mod test {
             frecency,
         );
 
-        assert_eq!(tv.matching_mode, MatchingMode::Substring);
+        assert!(tv.merged_config.exact_match);
         assert!(tv.remote_control.is_none());
     }
 


### PR DESCRIPTION
`--exact` now sets frizbee's `Matching::Substring` on the matcher config instead of quoting every token. This also allows existing operators (`^foo`, `foo$`, `!foo`) to keep their meaning in exact mode.