### PR TITLE
fix(shell): bind nushell integration in helix mode too

### DIFF
--- a/television/utils/shell/completion.nu
+++ b/television/utils/shell/completion.nu
@@ -38,7 +38,7 @@ $env.config = (
               name: tv_completion,
               modifier: Control,
               keycode: char_{tv_smart_autocomplete_keybinding},
-              mode: [vi_normal, vi_insert, emacs],
+              mode: [vi_normal, vi_insert, emacs, helix_normal, helix_insert, helix_select],
               event: {
                   send: executehostcommand,
                   cmd: "tv_smart_autocomplete"
@@ -48,7 +48,7 @@ $env.config = (
               name: tv_history,
               modifier: Control,
               keycode: char_{tv_shell_history_keybinding},
-              mode: [vi_normal, vi_insert, emacs],
+              mode: [vi_normal, vi_insert, emacs, helix_normal, helix_insert, helix_select],
               event: {
                   send: executehostcommand,
                   cmd: "tv_shell_history"


### PR DESCRIPTION
## Summary

The nushell shell integration script (`completion.nu`, rendered by `tv init nu`) only binds the Ctrl-T/Ctrl-R keybindings for `emacs`, `vi_normal`, and `vi_insert` modes.

Since nushell 0.115, Helix edit mode keeps its own keybinding tables (`helix_normal`, `helix_insert`, `helix_select`) instead of sharing the vi tables. As a result, `tv_smart_autocomplete` and `tv_shell_history` silently don't trigger when `$env.config.edit_mode = "helix"`.

This adds the three helix mode names to both bindings so the integration works under Helix edit mode too, mirroring the earlier fish fix in #610 (which bound keys for both `default` and `insert` fish modes).

## Tested

Verified in a PTY with nushell 0.115.1 + `edit_mode = "helix"`:
- before: Ctrl-T/Ctrl-R do nothing
- after: Ctrl-T runs `tv_smart_autocomplete`, Ctrl-R runs `tv_shell_history`

## Notes

The `helix_*` mode names require nushell >= 0.115. Older versions that support Helix edit mode (0.113/0.114) share the vi tables, so the existing `vi_normal`/`vi_insert` entries keep them working; the added entries are only recognized from 0.115+.