### PR TITLE
test(matcher): cover the never-zero matcher thread count (#1139)

### DIFF
--- a/television/matcher/mod.rs
+++ b/television/matcher/mod.rs
@@ -487,6 +487,17 @@ fn matched_item<I: Sync + Send + Clone + 'static>(
     )
 }
 
+/// Threads left to the rest of the program, so the matcher doesn't saturate
+/// the system.
+const RESERVED_THREADS: usize = 3;
+
+/// Upper bound on matcher threads, to avoid impacting startup time and memory
+/// usage.
+const MAX_MATCHER_THREADS: usize = 32;
+
+/// Fallback when the number of available threads cannot be determined.
+const FALLBACK_MATCHER_THREADS: usize = 4;
+
 /// Get the number of threads to use for the matcher.
 ///
 /// This uses the number of available threads on the system, minus 3, to avoid
@@ -497,8 +508,18 @@ fn matched_item<I: Sync + Send + Clone + 'static>(
 /// Defaults to 4 if the number of available threads cannot be determined.
 pub fn matcher_threads() -> usize {
     available_parallelism()
-        .map(|n| n.get().saturating_sub(3).clamp(1, 32))
-        .unwrap_or(4)
+        .map_or(FALLBACK_MATCHER_THREADS, |n| matcher_threads_for(n.get()))
+}
+
+/// The matcher thread count for a given amount of available parallelism.
+///
+/// Always returns at least one thread: machines with `RESERVED_THREADS` cores
+/// or fewer would otherwise be left with zero, which used to be passed
+/// straight through to the matcher backend and crash it (issue #1139).
+fn matcher_threads_for(available_parallelism: usize) -> usize {
+    available_parallelism
+        .saturating_sub(RESERVED_THREADS)
+        .clamp(1, MAX_MATCHER_THREADS)
 }
 
 #[cfg(test)]
@@ -752,5 +773,77 @@ mod tests {
         let mut expected = vec![5];
         expected.extend((0..11).filter(|i| *i != 5));
         assert_eq!(collect_ids(&mut matcher), expected);
+    }
+
+    /// Small machines must still get a usable thread count.
+    ///
+    /// Regression test for issue #1139: with `RESERVED_THREADS` cores or
+    /// fewer, the subtraction saturated to zero and the matcher was started
+    /// with no threads at all.
+    #[test]
+    fn matcher_threads_on_small_machines() {
+        for available in 1..=RESERVED_THREADS + 1 {
+            assert_eq!(
+                matcher_threads_for(available),
+                1,
+                "{available} available thread(s) should yield a single \
+                 matcher thread",
+            );
+        }
+    }
+
+    /// Whatever the machine, the matcher never gets zero threads.
+    #[test]
+    fn matcher_threads_are_never_zero() {
+        for available in 0..=128 {
+            assert!(
+                matcher_threads_for(available) >= 1,
+                "{available} available thread(s) yielded zero matcher threads",
+            );
+        }
+    }
+
+    /// Bigger machines get `available - RESERVED_THREADS`, capped.
+    #[test]
+    fn matcher_threads_leave_room_and_stay_capped() {
+        assert_eq!(matcher_threads_for(8), 8 - RESERVED_THREADS);
+        assert_eq!(matcher_threads_for(1024), MAX_MATCHER_THREADS);
+    }
+
+    /// The thread count actually used at runtime stays within bounds on
+    /// whichever machine the tests run.
+    #[test]
+    fn matcher_threads_are_within_bounds() {
+        assert!((1..=MAX_MATCHER_THREADS).contains(&matcher_threads()));
+    }
+
+    /// A single-threaded matcher (what small machines get, see #1139) must
+    /// return the same results, in the same order, as a multi-threaded one.
+    #[test]
+    fn single_threaded_matching_equals_multi_threaded() {
+        let items: Vec<(usize, String)> = (0..300)
+            .map(|i| {
+                let haystack = match i % 3 {
+                    0 => format!("abc_{i}"),
+                    1 => format!("xx_abc_{i}"),
+                    _ => format!("a{i}b{i}c{i}"),
+                };
+                (i, haystack)
+            })
+            .collect();
+
+        let mut single: Matcher<usize> = Matcher::new(SortStrategy::Score, 1);
+        single.injector().push_batch(items.clone());
+        single.find("abc");
+        single.wait_for_idle();
+
+        let mut multi: Matcher<usize> = Matcher::new(SortStrategy::Score, 4);
+        multi.injector().push_batch(items);
+        multi.find("abc");
+        multi.wait_for_idle();
+
+        let multi_ids = collect_ids(&mut multi);
+        assert!(!multi_ids.is_empty());
+        assert_eq!(collect_ids(&mut single), multi_ids);
     }
 }


### PR DESCRIPTION
## Context

While investigating #1139 (systematic panic in `television-nucleo`'s
`worker.rs:21` — `index out of bounds: the len is 0 but the index is 0`) I
tracked the crash down to the matcher thread count reaching the backend as
`0`, and confirmed it with a minimal reproducer.

`matcher_threads()` reserves 3 threads for the rest of the program. On the
`0.15.9` release that was:

```rust
available_parallelism().map(|n| n.get().saturating_sub(3).min(32)).unwrap_or(4)
```

There is no lower bound, so **any machine reporting 3 or fewer logical CPUs
gets `0`**. That `0` was passed on as `Some(0)` to nucleo's `Worker::new`,
which sized its per-thread matcher array from it — `(0..0)` → empty — while
`rayon::ThreadPoolBuilder::num_threads(0)` means *"use the default"* and still
spawned real worker threads. The first match pass then indexed an empty array
by its rayon thread index and panicked.

The reproducer below (2-core box, same as the reporter's) panics identically
to the issue on `television-nucleo` 0.5.0:

```
available_parallelism = Ok(2) -> matcher_threads() = 0
thread 'nucleo worker 0' panicked at television-nucleo-0.5.0/src/worker.rs:21:15:
index out of bounds: the len is 0 but the index is 0
Rayon: detected unexpected panic; aborting
```

## What this PR does

`main` is **already safe** here — 5cc1356 (`feat(matcher): replace nucleo with
frizbee`) changed the `.min(32)` to `.clamp(1, 32)`, and frizbee's
`match_list_parallel` treats `0` as "auto" anyway. But that floor arrived
incidentally as part of a rewrite, nothing pins it, and the arithmetic is not
reachable from a test because it reads the host's real CPU count — CI runners
never exercise the `<= 3` core path that broke.

So this is deliberately a **test-coverage + intent PR**, not a behaviour
change:

- extract the pure arithmetic into `matcher_threads_for(available_parallelism)`
  so the small-machine cases are testable without depending on the host,
- name the magic numbers (`RESERVED_THREADS`, `MAX_MATCHER_THREADS`,
  `FALLBACK_MATCHER_THREADS`) and document the "never zero" invariant with a
  pointer to #1139,
- add tests:
  - `matcher_threads_on_small_machines` — 1..=4 cores yield exactly 1 thread
    (the exact regression),
  - `matcher_threads_are_never_zero` — 0..=128 cores never yield 0,
  - `matcher_threads_leave_room_and_stay_capped` — the reserve and the cap,
  - `matcher_threads_are_within_bounds` — the runtime value stays in 1..=32,
  - `single_threaded_matching_equals_multi_threaded` — the low-core path is
    also covered behaviourally; every existing matcher test uses 2+ threads,
    so a single-threaded matcher was previously untested.

Verified locally on the 2-core box that reproduces the crash: `cargo test --lib` 229 passed / 0 failed, `cargo clippy --all-targets --all-features -- -D warnings` clean, `cargo fmt --all --check` clean.

## Note for the released line

`0.15.9` is still the latest release and is affected: fuzzy matching panics on
startup on **any** machine with `<= 3` logical CPUs (small VMs, containers with
a cgroup CPU limit, embedded ARM boxes — the reporter's Freebox Delta, and the
box I reproduced this on). The fix only exists on unreleased `main`, so those
users stay broken until the next release; a one-line `.clamp(1, 32)` backport
would cover them if a `0.15.x` patch is on the table.

Happy to reshape this if you'd rather keep the helper inline and just take the
tests, or drop it entirely if you consider the frizbee rewrite sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
